### PR TITLE
Improve item names again

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -786,14 +786,14 @@
             },
             {
                 "type": "collect",
-                "target": "USEC dogtags",
+                "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
                 "id": 37
             },
             {
                 "type": "collect",
-                "target": "BEAR dogtags",
+                "target": "Dogtag BEAR",
                 "number": 7,
                 "location": "Any",
                 "id": 38
@@ -1849,7 +1849,7 @@
             },
             {
                 "type": "find",
-                "target": "USEC dogtags",
+                "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
                 "id": 85

--- a/quests.json
+++ b/quests.json
@@ -4797,14 +4797,16 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "BNTI Gzhel-K armor 0-50% condition",
+                "target": "BNTI Gzhel-K armor",
+                "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
                 "id": 225
             },
             {
                 "type": "collect",
-                "target": "BNTI Gzhel-K armor 50-100% condition",
+                "target": "BNTI Gzhel-K armor",
+                "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
                 "id": 226
@@ -4834,14 +4836,16 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "6B43 Zabralo-Sh 6A Armor 0-50% condition",
+                "target": "6B43 Zabralo-Sh 6A Armor",
+                "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
                 "id": 227
             },
             {
                 "type": "collect",
-                "target": "6B43 Zabralo-Sh 6A Armor 50-100% condition",
+                "target": "6B43 Zabralo-Sh 6A Armor",
+                "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
                 "id": 228


### PR DESCRIPTION
Two changes merged into 1:
Fixed the dogtag names
Moved the armor percentage to a hint instead of the item name