### PR TITLE
Item localisation

### DIFF
--- a/items.en.json
+++ b/items.en.json
@@ -1,0 +1,11710 @@
+{
+    "54009119af1c881c07000029": {
+        "id": "54009119af1c881c07000029",
+        "name": "Item",
+        "shortName": "Item"
+    },
+    "5af0561e86f7745f5f3ad6ac": {
+        "id": "5af0561e86f7745f5f3ad6ac",
+        "name": "Powerbank",
+        "shortName": "Powerbank"
+    },
+    "5733279d245977289b77ec24": {
+        "id": "5733279d245977289b77ec24",
+        "name": "Car battery",
+        "shortName": "Battery"
+    },
+    "5672cb304bdc2dc2088b456a": {
+        "id": "5672cb304bdc2dc2088b456a",
+        "name": "D Size Battery",
+        "shortName": "D Bat."
+    },
+    "5e2aedd986f7746d404f3aa4": {
+        "id": "5e2aedd986f7746d404f3aa4",
+        "name": "GreenBat lithium battery",
+        "shortName": "GreenBat "
+    },
+    "590a358486f77429692b2790": {
+        "id": "590a358486f77429692b2790",
+        "name": "Rechargeable battery",
+        "shortName": "RecBatt"
+    },
+    "5672cb124bdc2d1a0f8b4568": {
+        "id": "5672cb124bdc2d1a0f8b4568",
+        "name": "AA Battery",
+        "shortName": "AA Bat."
+    },
+    "5d03794386f77420415576f5": {
+        "id": "5d03794386f77420415576f5",
+        "name": "6-STEN-140-M military battery",
+        "shortName": "Tank battery"
+    },
+    "5e2aee0a86f774755a234b62": {
+        "id": "5e2aee0a86f774755a234b62",
+        "name": "Cyclon accumulator battery",
+        "shortName": "Cyclon "
+    },
+    "590c346786f77423e50ed342": {
+        "id": "590c346786f77423e50ed342",
+        "name": "Xenomorph sealing foam",
+        "shortName": "Xeno"
+    },
+    "57347c1124597737fb1379e3": {
+        "id": "57347c1124597737fb1379e3",
+        "name": "Duct tape",
+        "shortName": "Duct tape"
+    },
+    "59e366c186f7741778269d85": {
+        "id": "59e366c186f7741778269d85",
+        "name": "Piece of plexiglas",
+        "shortName": "Plex"
+    },
+    "5d1b32c186f774252167a530": {
+        "id": "5d1b32c186f774252167a530",
+        "name": "Analog thermometer",
+        "shortName": "Therm."
+    },
+    "59e35cbb86f7741778269d83": {
+        "id": "59e35cbb86f7741778269d83",
+        "name": "Corrugated hose",
+        "shortName": "Hose"
+    },
+    "5734795124597738002c6176": {
+        "id": "5734795124597738002c6176",
+        "name": "Insulating tape",
+        "shortName": "Tape"
+    },
+    "590c35a486f774273531c822": {
+        "id": "590c35a486f774273531c822",
+        "name": "Shustrilo sealing foam",
+        "shortName": "Shus"
+    },
+    "57347c77245977448d35f6e2": {
+        "id": "57347c77245977448d35f6e2",
+        "name": "Screw nut",
+        "shortName": "Screw nut"
+    },
+    "5d1b327086f7742525194449": {
+        "id": "5d1b327086f7742525194449",
+        "name": "Pressure gauge",
+        "shortName": "Gauge"
+    },
+    "59e35ef086f7741777737012": {
+        "id": "59e35ef086f7741777737012",
+        "name": "A pack of screws",
+        "shortName": "Screws"
+    },
+    "5e2af29386f7746d4159f077": {
+        "id": "5e2af29386f7746d4159f077",
+        "name": "KEKTAPE duct tape",
+        "shortName": "KEK"
+    },
+    "57347c5b245977448d35f6e1": {
+        "id": "57347c5b245977448d35f6e1",
+        "name": "Bolts",
+        "shortName": "Bolts"
+    },
+    "590c31c586f774245e3141b2": {
+        "id": "590c31c586f774245e3141b2",
+        "name": "A pack of nails",
+        "shortName": "Nails"
+    },
+    "5d1b39a386f774252339976f": {
+        "id": "5d1b39a386f774252339976f",
+        "name": "Silicone tube",
+        "shortName": "Tube"
+    },
+    "5e2af22086f7746d3f3c33fa": {
+        "id": "5e2af22086f7746d3f3c33fa",
+        "name": "Tube of Poxeram Cold Welding",
+        "shortName": "Poxeram"
+    },
+    "573477e124597737dd42e191": {
+        "id": "573477e124597737dd42e191",
+        "name": "PC CPU",
+        "shortName": "CPU"
+    },
+    "5c052fb986f7746b2101e909": {
+        "id": "5c052fb986f7746b2101e909",
+        "name": "UHF RFID Reader ",
+        "shortName": "RFIDR"
+    },
+    "5734779624597737e04bf329": {
+        "id": "5734779624597737e04bf329",
+        "name": "CPU Fan",
+        "shortName": "CPU Fan"
+    },
+    "5c06782b86f77426df5407d2": {
+        "id": "5c06782b86f77426df5407d2",
+        "name": "Capacitors",
+        "shortName": "Cap."
+    },
+    "5b4c72c686f77462ac37e907": {
+        "id": "5b4c72c686f77462ac37e907",
+        "name": "Motor Controller",
+        "shortName": "Controller"
+    },
+    "5af04c0b86f774138708f78e": {
+        "id": "5af04c0b86f774138708f78e",
+        "name": "Motor Controller",
+        "shortName": "Controller"
+    },
+    "59e35de086f7741778269d84": {
+        "id": "59e35de086f7741778269d84",
+        "name": "Electric drill",
+        "shortName": "Drill"
+    },
+    "5b4c72b386f7745b453af9c0": {
+        "id": "5b4c72b386f7745b453af9c0",
+        "name": "Motor Controller",
+        "shortName": "Controller"
+    },
+    "590a3b0486f7743954552bdb": {
+        "id": "590a3b0486f7743954552bdb",
+        "name": "Printed circuit board",
+        "shortName": "Сircuit board"
+    },
+    "5c1265fc86f7743f896a21c2": {
+        "id": "5c1265fc86f7743f896a21c2",
+        "name": "Broken GPhone X",
+        "shortName": "GPX"
+    },
+    "5b4c72fb86f7745cef1cffc5": {
+        "id": "5b4c72fb86f7745cef1cffc5",
+        "name": "Single-axis Fiber Optic Gyroscope",
+        "shortName": "Gyroscope"
+    },
+    "590a391c86f774385a33c404": {
+        "id": "590a391c86f774385a33c404",
+        "name": "Magnet",
+        "shortName": "Magnet"
+    },
+    "57347c2e24597744902c94a1": {
+        "id": "57347c2e24597744902c94a1",
+        "name": "Power supply unit",
+        "shortName": "PSU"
+    },
+    "590a3c0a86f774385a33c450": {
+        "id": "590a3c0a86f774385a33c450",
+        "name": "Spark plug",
+        "shortName": "Plug"
+    },
+    "5a29284f86f77463ef3db363": {
+        "id": "5a29284f86f77463ef3db363",
+        "name": "Toughbook reinforced laptop",
+        "shortName": "Toughbook"
+    },
+    "5af04e0a86f7743a532b79e2": {
+        "id": "5af04e0a86f7743a532b79e2",
+        "name": "Single-axis Fiber Optic Gyroscope",
+        "shortName": "Gyroscope"
+    },
+    "59e36c6f86f774176c10a2a7": {
+        "id": "59e36c6f86f774176c10a2a7",
+        "name": "Powercord",
+        "shortName": "Cord"
+    },
+    "56742c324bdc2d150f8b456d": {
+        "id": "56742c324bdc2d150f8b456d",
+        "name": "Broken GPhone",
+        "shortName": "GPhone"
+    },
+    "5c06779c86f77426e00dd782": {
+        "id": "5c06779c86f77426e00dd782",
+        "name": "Wires",
+        "shortName": "Wires"
+    },
+    "590a3d9c86f774385926e510": {
+        "id": "590a3d9c86f774385926e510",
+        "name": "Ultraviolet lamp",
+        "shortName": "UV Lamp"
+    },
+    "5672cb724bdc2dc2088b456b": {
+        "id": "5672cb724bdc2dc2088b456b",
+        "name": "Geiger-Muller counter",
+        "shortName": "GMcount"
+    },
+    "590a3efd86f77437d351a25b": {
+        "id": "590a3efd86f77437d351a25b",
+        "name": "Gas analyzer",
+        "shortName": "GasAn"
+    },
+    "57347baf24597738002c6178": {
+        "id": "57347baf24597738002c6178",
+        "name": "RAM",
+        "shortName": "RAM"
+    },
+    "5bc9b720d4351e450201234b": {
+        "id": "5bc9b720d4351e450201234b",
+        "name": "Golden 1GPhone",
+        "shortName": "1GPhone"
+    },
+    "5909e99886f7740c983b9984": {
+        "id": "5909e99886f7740c983b9984",
+        "name": "USB Adapter",
+        "shortName": "USB-A"
+    },
+    "57347cd0245977445a2d6ff1": {
+        "id": "57347cd0245977445a2d6ff1",
+        "name": "T-Shaped Plug",
+        "shortName": "T-Plug"
+    },
+    "5c052f6886f7746b1e3db148": {
+        "id": "5c052f6886f7746b1e3db148",
+        "name": "Military COFDM wireless Signal Transmitter",
+        "shortName": "SG-C10"
+    },
+    "5734781f24597737e04bf32a": {
+        "id": "5734781f24597737e04bf32a",
+        "name": "DVD drive",
+        "shortName": "DVD"
+    },
+    "5d1b392c86f77425243e98fe": {
+        "id": "5d1b392c86f77425243e98fe",
+        "name": "Light bulb",
+        "shortName": "Bulb"
+    },
+    "5d1b2ffd86f77425243e8d17": {
+        "id": "5d1b2ffd86f77425243e8d17",
+        "name": "NIXXOR lens",
+        "shortName": "NIXXOR"
+    },
+    "5d1b304286f774253763a528": {
+        "id": "5d1b304286f774253763a528",
+        "name": "Working LCD",
+        "shortName": "LCD"
+    },
+    "5d1b2fa286f77425227d1674": {
+        "id": "5d1b2fa286f77425227d1674",
+        "name": "Electric motor",
+        "shortName": "Motor"
+    },
+    "5d1b309586f77425227d1676": {
+        "id": "5d1b309586f77425227d1676",
+        "name": "Broken LCD",
+        "shortName": "BrokenLCD"
+    },
+    "5d03784a86f774203e7e0c4d": {
+        "id": "5d03784a86f774203e7e0c4d",
+        "name": "Military gyrotachometer",
+        "shortName": "MGT"
+    },
+    "5d03775b86f774203e7e0c4b": {
+        "id": "5d03775b86f774203e7e0c4b",
+        "name": "Phased array element",
+        "shortName": "AESA"
+    },
+    "5d1c774f86f7746d6620f8db": {
+        "id": "5d1c774f86f7746d6620f8db",
+        "name": "Radiator helix",
+        "shortName": "Helix"
+    },
+    "5d1b313086f77425227d1678": {
+        "id": "5d1b313086f77425227d1678",
+        "name": "Phase control relay",
+        "shortName": "Relay"
+    },
+    "5c05300686f7746dce784e5d": {
+        "id": "5c05300686f7746dce784e5d",
+        "name": "VPX Flash Storage Module",
+        "shortName": "VPX"
+    },
+    "590a3cd386f77436f20848cb": {
+        "id": "590a3cd386f77436f20848cb",
+        "name": "Energy-saving lamp",
+        "shortName": "ES Lamp"
+    },
+    "5c12620d86f7743f8b198b72": {
+        "id": "5c12620d86f7743f8b198b72",
+        "name": "Tetriz portable game",
+        "shortName": "Tetriz"
+    },
+    "5c05308086f7746b2101e90b": {
+        "id": "5c05308086f7746b2101e90b",
+        "name": "Virtex programmable processor",
+        "shortName": "Virtex"
+    },
+    "5d0377ce86f774186372f689": {
+        "id": "5d0377ce86f774186372f689",
+        "name": "Military thermal vision module Iridium",
+        "shortName": "Iridium"
+    },
+    "5d0375ff86f774186372f685": {
+        "id": "5d0375ff86f774186372f685",
+        "name": "Military cable",
+        "shortName": "M.Cable"
+    },
+    "5d0376a486f7747d8050965c": {
+        "id": "5d0376a486f7747d8050965c",
+        "name": "Military circuit board",
+        "shortName": "MCB"
+    },
+    "5d0378d486f77420421a5ff4": {
+        "id": "5d0378d486f77420421a5ff4",
+        "name": "Military power filter",
+        "shortName": "Filter"
+    },
+    "590a386e86f77429692b27ab": {
+        "id": "590a386e86f77429692b27ab",
+        "name": "Damaged hard drive",
+        "shortName": "HDD"
+    },
+    "5a29276886f77435ed1b117c": {
+        "id": "5a29276886f77435ed1b117c",
+        "name": "Working hard drive",
+        "shortName": "HDD"
+    },
+    "57347ca924597744596b4e71": {
+        "id": "57347ca924597744596b4e71",
+        "name": "Graphics card",
+        "shortName": "Graphics card"
+    },
+    "577e1c9d2459773cd707c525": {
+        "id": "577e1c9d2459773cd707c525",
+        "name": "Printer paper",
+        "shortName": "Paper"
+    },
+    "59e3596386f774176c10a2a2": {
+        "id": "59e3596386f774176c10a2a2",
+        "name": "Paid AntiRoach",
+        "shortName": "Paid"
+    },
+    "59e3556c86f7741776641ac2": {
+        "id": "59e3556c86f7741776641ac2",
+        "name": "Ox bleach",
+        "shortName": "Bleach"
+    },
+    "59e35abd86f7741778269d82": {
+        "id": "59e35abd86f7741778269d82",
+        "name": "Sodium bicarbonate",
+        "shortName": "Sodium"
+    },
+    "59e358a886f7741776641ac3": {
+        "id": "59e358a886f7741776641ac3",
+        "name": "Clin wiper",
+        "shortName": "Wiper"
+    },
+    "5c13cef886f774072e618e82": {
+        "id": "5c13cef886f774072e618e82",
+        "name": "Toilet paper",
+        "shortName": "TP"
+    },
+    "59faf98186f774067b6be103": {
+        "id": "59faf98186f774067b6be103",
+        "name": "Heat-exchange alkali surface washer",
+        "shortName": "Alkali"
+    },
+    "5d4041f086f7743cac3f22a7": {
+        "id": "5d4041f086f7743cac3f22a7",
+        "name": "Ortodontox toothpaste",
+        "shortName": "Ortodontox"
+    },
+    "57347c93245977448d35f6e3": {
+        "id": "57347c93245977448d35f6e3",
+        "name": "Toothpaste",
+        "shortName": "Toothpaste"
+    },
+    "5d40412b86f7743cb332ac3a": {
+        "id": "5d40412b86f7743cb332ac3a",
+        "name": "Schaman shampoo",
+        "shortName": "Shampoo"
+    },
+    "5c13cd2486f774072c757944": {
+        "id": "5c13cd2486f774072c757944",
+        "name": "Soap",
+        "shortName": "Soap"
+    },
+    "5e2af02c86f7746d420957d4": {
+        "id": "5e2af02c86f7746d420957d4",
+        "name": "Pack of chlorine",
+        "shortName": "Chlorine"
+    },
+    "5e2af00086f7746d3f3c33f7": {
+        "id": "5e2af00086f7746d3f3c33f7",
+        "name": "Smoked Chimney drain cleaner",
+        "shortName": "Cleaner"
+    },
+    "5e2aef7986f7746d3f3c33f5": {
+        "id": "5e2aef7986f7746d3f3c33f5",
+        "name": "Repellent",
+        "shortName": "Repellent"
+    },
+    "5bc9b9ecd4351e3bac122519": {
+        "id": "5bc9b9ecd4351e3bac122519",
+        "name": "Deadlyslob's beard oil",
+        "shortName": "Beardoil"
+    },
+    "573478bc24597738002c6175": {
+        "id": "573478bc24597738002c6175",
+        "name": "Horse figurine",
+        "shortName": "Horse"
+    },
+    "5c1267ee86f77416ec610f72": {
+        "id": "5c1267ee86f77416ec610f72",
+        "name": "Chain with Prokill medallion",
+        "shortName": "Prokill"
+    },
+    "59e3647686f774176a362507": {
+        "id": "59e3647686f774176a362507",
+        "name": "Wooden clock",
+        "shortName": "Clock"
+    },
+    "5734758f24597738025ee253": {
+        "id": "5734758f24597738025ee253",
+        "name": "Golden neck chain",
+        "shortName": "GoldChain"
+    },
+    "59faff1d86f7746c51718c9c": {
+        "id": "59faff1d86f7746c51718c9c",
+        "name": "Physical bitcoin",
+        "shortName": "0.2BTC"
+    },
+    "5bc9bdb8d4351e003562b8a1": {
+        "id": "5bc9bdb8d4351e003562b8a1",
+        "name": "Silver Badge",
+        "shortName": "Badge"
+    },
+    "59faf7ca86f7740dbe19f6c2": {
+        "id": "59faf7ca86f7740dbe19f6c2",
+        "name": "Roler submariner gold wrist watch",
+        "shortName": "Roler"
+    },
+    "573474f924597738002c6174": {
+        "id": "573474f924597738002c6174",
+        "name": "Chainlet",
+        "shortName": "Chainlet"
+    },
+    "5937fd0086f7742bf33fc198": {
+        "id": "5937fd0086f7742bf33fc198",
+        "name": "Bronze pocket watch on a chain",
+        "shortName": "Watch"
+    },
+    "590de7e986f7741b096e5f32": {
+        "id": "590de7e986f7741b096e5f32",
+        "name": "Antique vase",
+        "shortName": "Vase"
+    },
+    "590de71386f774347051a052": {
+        "id": "590de71386f774347051a052",
+        "name": "Antique teapot",
+        "shortName": "Teapot"
+    },
+    "5d235b4d86f7742e017bc88a": {
+        "id": "5d235b4d86f7742e017bc88a",
+        "name": "GP coin",
+        "shortName": "GP"
+    },
+    "59e3658a86f7741776641ac4": {
+        "id": "59e3658a86f7741776641ac4",
+        "name": "Cat figurine",
+        "shortName": "Cat"
+    },
+    "5d235a5986f77443f6329bc6": {
+        "id": "5d235a5986f77443f6329bc6",
+        "name": "Gold skull ring",
+        "shortName": "Skull"
+    },
+    "59e3639286f7741777737013": {
+        "id": "59e3639286f7741777737013",
+        "name": "Bronze lion",
+        "shortName": "Lion"
+    },
+    "5bc9bc53d4351e00367fbcee": {
+        "id": "5bc9bc53d4351e00367fbcee",
+        "name": "Golden rooster",
+        "shortName": "Rooster"
+    },
+    "5e54f62086f774219b0f1937": {
+        "id": "5e54f62086f774219b0f1937",
+        "name": "Raven figurine",
+        "shortName": "Raven"
+    },
+    "5f745ee30acaeb0d490d8c5b": {
+        "id": "5f745ee30acaeb0d490d8c5b",
+        "name": "Veritas guitar pick",
+        "shortName": "Veritas"
+    },
+    "5df8a6a186f77412640e2e80": {
+        "id": "5df8a6a186f77412640e2e80",
+        "name": "Christmas tree decoration ball (red)",
+        "shortName": "R.Ball"
+    },
+    "5df8a72c86f77412640e2e83": {
+        "id": "5df8a72c86f77412640e2e83",
+        "name": "Christmas tree decoration ball (silver)",
+        "shortName": "S.Ball"
+    },
+    "5df8a77486f77412672a1e3f": {
+        "id": "5df8a77486f77412672a1e3f",
+        "name": "Christmas tree decoration ball (violet)",
+        "shortName": "V.Ball"
+    },
+    "5d1b36a186f7742523398433": {
+        "id": "5d1b36a186f7742523398433",
+        "name": "Metal fuel tank",
+        "shortName": "Fuel"
+    },
+    "5d1b371186f774253763a656": {
+        "id": "5d1b371186f774253763a656",
+        "name": "Expeditionary fuel tank",
+        "shortName": "Fuel"
+    },
+    "56742c284bdc2d98058b456d": {
+        "id": "56742c284bdc2d98058b456d",
+        "name": "Crickent lighter",
+        "shortName": "Crickent"
+    },
+    "5bc9b355d4351e6d1509862a": {
+        "id": "5bc9b355d4351e6d1509862a",
+        "name": "#FireKlean gun lube",
+        "shortName": "#FireKlean"
+    },
+    "57347b8b24597737dd42e192": {
+        "id": "57347b8b24597737dd42e192",
+        "name": "Classic matches",
+        "shortName": "Matches"
+    },
+    "5939a00786f7742fe8132936": {
+        "id": "5939a00786f7742fe8132936",
+        "name": "Zibbo lighter",
+        "shortName": "Zibbo"
+    },
+    "590c5c9f86f77477c91c36e7": {
+        "id": "590c5c9f86f77477c91c36e7",
+        "name": "WD-40 400ml",
+        "shortName": "WD-40"
+    },
+    "590c5bbd86f774785762df04": {
+        "id": "590c5bbd86f774785762df04",
+        "name": "WD-40 100ml.",
+        "shortName": "WD-40"
+    },
+    "56742c2e4bdc2d95058b456d": {
+        "id": "56742c2e4bdc2d95058b456d",
+        "name": "Zibbo lighter",
+        "shortName": "Zibbo"
+    },
+    "59fafb5d86f774067a6f2084": {
+        "id": "59fafb5d86f774067a6f2084",
+        "name": "5L propane tank",
+        "shortName": "Propane"
+    },
+    "5d650c3e815116009f6201d2": {
+        "id": "5d650c3e815116009f6201d2"
+    },
+    "590a373286f774287540368b": {
+        "id": "590a373286f774287540368b",
+        "name": "Dry fuel",
+        "shortName": "Dfuel"
+    },
+    "5e2af37686f774755a234b65": {
+        "id": "5e2af37686f774755a234b65",
+        "name": "SurvL Survivor Lighter",
+        "shortName": "SurvL "
+    },
+    "5e2af2bc86f7746d3f3c33fc": {
+        "id": "5e2af2bc86f7746d3f3c33fc",
+        "name": "Hunter matches",
+        "shortName": "Matches"
+    },
+    "5b43575a86f77424f443fe62": {
+        "id": "5b43575a86f77424f443fe62",
+        "name": "Fuel conditioner",
+        "shortName": "Fcond"
+    },
+    "59e3606886f77417674759a5": {
+        "id": "59e3606886f77417674759a5",
+        "name": "Saline solution",
+        "shortName": "NaCl"
+    },
+    "5d1b3a5d86f774252167ba22": {
+        "id": "5d1b3a5d86f774252167ba22",
+        "name": "Pile of meds",
+        "shortName": "Meds"
+    },
+    "5a687e7886f7740c4a5133fb": {
+        "id": "5a687e7886f7740c4a5133fb",
+        "name": "Blood sample",
+        "shortName": "Blood sample"
+    },
+    "5b4335ba86f7744d2837a264": {
+        "id": "5b4335ba86f7744d2837a264",
+        "name": "Medical bloodset",
+        "shortName": "Bloodset"
+    },
+    "5af0534a86f7743b6f354284": {
+        "id": "5af0534a86f7743b6f354284",
+        "name": "Ophthalmoscope",
+        "shortName": "Ophthalmoscope"
+    },
+    "59e361e886f774176c10a2a5": {
+        "id": "59e361e886f774176c10a2a5",
+        "name": "Hydrogen peroxide",
+        "shortName": "H2O2"
+    },
+    "5c052e6986f7746b207bc3c9": {
+        "id": "5c052e6986f7746b207bc3c9",
+        "name": "Portable defibrillator",
+        "shortName": "Defibrillator"
+    },
+    "5d1b3f2d86f774253763b735": {
+        "id": "5d1b3f2d86f774253763b735",
+        "name": "Disposable syringe",
+        "shortName": "Syringe"
+    },
+    "5c0530ee86f774697952d952": {
+        "id": "5c0530ee86f774697952d952",
+        "name": "LEDX Skin Transilluminator",
+        "shortName": "LEDX"
+    },
+    "5b4c81a086f77417d26be63f": {
+        "id": "5b4c81a086f77417d26be63f",
+        "name": "Сhemical container",
+        "shortName": "Сhemcont"
+    },
+    "5b43237186f7742f3a4ab252": {
+        "id": "5b43237186f7742f3a4ab252",
+        "name": "Сhemical container",
+        "shortName": "Сhemcont"
+    },
+    "593a87af86f774122f54a951": {
+        "id": "593a87af86f774122f54a951",
+        "name": "Syringe with a chemical",
+        "shortName": "Reagent"
+    },
+    "5b4c81bd86f77418a75ae159": {
+        "id": "5b4c81bd86f77418a75ae159",
+        "name": "Сhemical container",
+        "shortName": "Сhemcont"
+    },
+    "59f32bb586f774757e1e8442": {
+        "id": "59f32bb586f774757e1e8442",
+        "name": "Dogtag BEAR",
+        "shortName": "Dogtag"
+    },
+    "5d1b2f3f86f774252167a52c": {
+        "id": "5d1b2f3f86f774252167a52c",
+        "name": "FP-100 filter absorber",
+        "shortName": "FP-100"
+    },
+    "59f32c3b86f77472a31742f0": {
+        "id": "59f32c3b86f77472a31742f0",
+        "name": "Dogtag USEC",
+        "shortName": "Dogtag"
+    },
+    "5d1c819a86f774771b0acd6c": {
+        "id": "5d1c819a86f774771b0acd6c",
+        "name": "Weapon parts",
+        "shortName": "W.parts"
+    },
+    "5af0484c86f7740f02001f7f": {
+        "id": "5af0484c86f7740f02001f7f",
+        "name": "Coffee Majaica",
+        "shortName": "Coffee"
+    },
+    "5d6fc78386f77449d825f9dc": {
+        "id": "5d6fc78386f77449d825f9dc",
+        "name": "Gunpowder \"Eagle\"",
+        "shortName": "Gpowder"
+    },
+    "590c5a7286f7747884343aea": {
+        "id": "590c5a7286f7747884343aea",
+        "name": "Gunpowder \"Kite\"",
+        "shortName": "Gpowder"
+    },
+    "5c12688486f77426843c7d32": {
+        "id": "5c12688486f77426843c7d32",
+        "name": "Paracord",
+        "shortName": "Paracord"
+    },
+    "5bc9c049d4351e44f824d360": {
+        "id": "5bc9c049d4351e44f824d360",
+        "name": "Battered antique Book",
+        "shortName": "Book"
+    },
+    "5d0379a886f77420407aa271": {
+        "id": "5d0379a886f77420407aa271",
+        "name": "OFZ 30x160mm shell ",
+        "shortName": "OFZ "
+    },
+    "5e2af41e86f774755a234b67": {
+        "id": "5e2af41e86f774755a234b67",
+        "name": "Polyamide fabric Cordura",
+        "shortName": "Cordura"
+    },
+    "5e2af4d286f7746d4159f07a": {
+        "id": "5e2af4d286f7746d4159f07a",
+        "name": "Aramid fiber cloth",
+        "shortName": "Aramid"
+    },
+    "5d6fc87386f77449db3db94e": {
+        "id": "5d6fc87386f77449db3db94e",
+        "name": "Gunpowder \"Hawk\"",
+        "shortName": "Gpowder"
+    },
+    "5e2af47786f7746d404f3aaa": {
+        "id": "5e2af47786f7746d404f3aaa",
+        "name": "Fleece cloth",
+        "shortName": "Fleece "
+    },
+    "5e2af4a786f7746d3f3c3400": {
+        "id": "5e2af4a786f7746d3f3c3400",
+        "name": "Ripstop cloth",
+        "shortName": "Ripstop"
+    },
+    "573476d324597737da2adc13": {
+        "id": "573476d324597737da2adc13",
+        "name": "Malboro Cigarettes",
+        "shortName": "Cigarettes"
+    },
+    "5e2af51086f7746d3f3c3402": {
+        "id": "5e2af51086f7746d3f3c3402",
+        "name": "UZRGM grenade fuze",
+        "shortName": "Fuze"
+    },
+    "573475fb24597737fb1379e1": {
+        "id": "573475fb24597737fb1379e1",
+        "name": "Apollon Soyuz cigarettes ",
+        "shortName": "Cigarettes"
+    },
+    "573476f124597737e04bf328": {
+        "id": "573476f124597737e04bf328",
+        "name": "Wilston cigarettes",
+        "shortName": "Cigarettes"
+    },
+    "5e54f6af86f7742199090bf3": {
+        "id": "5e54f6af86f7742199090bf3",
+        "name": "Can of Dr. Lupo's coffee beans",
+        "shortName": "Lupo's"
+    },
+    "5734770f24597738025ee254": {
+        "id": "5734770f24597738025ee254",
+        "name": "Strike Cigarettes",
+        "shortName": "Cigarettes"
+    },
+    "5bc9be8fd4351e00334cae6e": {
+        "id": "5bc9be8fd4351e00334cae6e",
+        "name": "42nd Signature Blend English Tea",
+        "shortName": "Tea"
+    },
+    "5d1b385e86f774252167b98a": {
+        "id": "5d1b385e86f774252167b98a",
+        "name": "Water filter",
+        "shortName": "Filter"
+    },
+    "590c595c86f7747884343ad7": {
+        "id": "590c595c86f7747884343ad7",
+        "name": "Air filter for gas mask",
+        "shortName": "Filter"
+    },
+    "5bc9c377d4351e3bac12251b": {
+        "id": "5bc9c377d4351e3bac12251b",
+        "name": "Old firesteel",
+        "shortName": "Firesteel"
+    },
+    "5d40419286f774318526545f": {
+        "id": "5d40419286f774318526545f",
+        "name": "Metal cutting scissors",
+        "shortName": "M. Scissors"
+    },
+    "590c2b4386f77425357b6123": {
+        "id": "590c2b4386f77425357b6123",
+        "name": "Pliers",
+        "shortName": "Pliers"
+    },
+    "5d1b317c86f7742523398392": {
+        "id": "5d1b317c86f7742523398392",
+        "name": "Hand drill",
+        "shortName": "Hand drill"
+    },
+    "590c311186f77424d1667482": {
+        "id": "590c311186f77424d1667482",
+        "name": "Wrench",
+        "shortName": "Wrench"
+    },
+    "5d1b31ce86f7742523398394": {
+        "id": "5d1b31ce86f7742523398394",
+        "name": "Round pliers",
+        "shortName": "R-pliers"
+    },
+    "5d40425986f7743185265461": {
+        "id": "5d40425986f7743185265461",
+        "name": "Nippers",
+        "shortName": "Nippers"
+    },
+    "5af04b6486f774195a3ebb49": {
+        "id": "5af04b6486f774195a3ebb49",
+        "name": "Pliers Elite",
+        "shortName": "Elite"
+    },
+    "5d63d33b86f7746ea9275524": {
+        "id": "5d63d33b86f7746ea9275524",
+        "name": "Flat screwdriver",
+        "shortName": "F Scr."
+    },
+    "590c2c9c86f774245b1f03f2": {
+        "id": "590c2c9c86f774245b1f03f2",
+        "name": "Construction measuring tape",
+        "shortName": "MTape"
+    },
+    "5d4042a986f7743185265463": {
+        "id": "5d4042a986f7743185265463",
+        "name": "Long flat screwdriver",
+        "shortName": "L&F Scr."
+    },
+    "590c2d8786f774245b1f03f3": {
+        "id": "590c2d8786f774245b1f03f3",
+        "name": "Screwdriver",
+        "shortName": "Screwdriver"
+    },
+    "590c2e1186f77425357b6124": {
+        "id": "590c2e1186f77425357b6124",
+        "name": "A set of tools",
+        "shortName": "Set"
+    },
+    "57864c322459775490116fbf": {
+        "id": "57864c322459775490116fbf",
+        "name": "Household goods",
+        "shortName": "Item"
+    },
+    "57864a3d24597754843f8721": {
+        "id": "57864a3d24597754843f8721",
+        "name": "Jewelry",
+        "shortName": "Item"
+    },
+    "57864ee62459775490116fc1": {
+        "id": "57864ee62459775490116fc1",
+        "name": "Battery",
+        "shortName": "Item"
+    },
+    "57864a66245977548f04a81f": {
+        "id": "57864a66245977548f04a81f",
+        "name": "Electronics",
+        "shortName": "Item"
+    },
+    "57864bb7245977548b3b66c2": {
+        "id": "57864bb7245977548b3b66c2",
+        "name": "Tool",
+        "shortName": "Item"
+    },
+    "57864c8c245977548867e7f1": {
+        "id": "57864c8c245977548867e7f1",
+        "name": "Medical supplies",
+        "shortName": "Item"
+    },
+    "57864e4c24597754843f8723": {
+        "id": "57864e4c24597754843f8723",
+        "name": "Lubricant",
+        "shortName": "Item"
+    },
+    "57864ada245977548638de91": {
+        "id": "57864ada245977548638de91",
+        "name": "Building material",
+        "shortName": "Item"
+    },
+    "590c745b86f7743cc433c5f2": {
+        "id": "590c745b86f7743cc433c5f2"
+    },
+    "55d7217a4bdc2d86028b456d": {
+        "id": "55d7217a4bdc2d86028b456d",
+        "name": "Default Inventory",
+        "shortName": "Default Inventory"
+    },
+    "567143bf4bdc2d1a0f8b4567": {
+        "id": "567143bf4bdc2d1a0f8b4567",
+        "name": "Pistol case",
+        "shortName": "Сase"
+    },
+    "590dde5786f77405e71908b2": {
+        "id": "590dde5786f77405e71908b2",
+        "name": "Bank case",
+        "shortName": "Сase"
+    },
+    "5910922b86f7747d96753483": {
+        "id": "5910922b86f7747d96753483",
+        "name": "Carbon case",
+        "shortName": "Сase"
+    },
+    "56ea8222d2720b69698b4567": {
+        "id": "56ea8222d2720b69698b4567",
+        "name": "Izhmash SV-98 bipod",
+        "shortName": "SV-98 Bipod"
+    },
+    "5888961624597754281f93f3": {
+        "id": "5888961624597754281f93f3",
+        "name": "Harris HBR Bipod",
+        "shortName": "Harris HBR"
+    },
+    "59d790f486f77403cb06aec6": {
+        "id": "59d790f486f77403cb06aec6",
+        "name": "Armytek Predator Pro v3 XHP35 HI Flashlight",
+        "shortName": "Predator Pro v3 XHP35"
+    },
+    "57d17c5e2459775a5c57d17d": {
+        "id": "57d17c5e2459775a5c57d17d",
+        "name": "Ultrafire WF-501B Flashlight",
+        "shortName": "WF501B"
+    },
+    "5de8fbad2fbe23140d3ee9c4": {
+        "id": "5de8fbad2fbe23140d3ee9c4",
+        "name": "B&T MP9-N Vertical grip",
+        "shortName": "MP9 VFG"
+    },
+    "5df36948bb49d91fb446d5ad": {
+        "id": "5df36948bb49d91fb446d5ad",
+        "name": "T-5000 Pad",
+        "shortName": "T-5000 pad"
+    },
+    "57cffcdd24597763f5110006": {
+        "id": "57cffcdd24597763f5110006",
+        "name": "Magpul M-LOK AFG (Olive Drab) Tactical grip",
+        "shortName": "AFG M-LOK"
+    },
+    "5c7fc87d2e221644f31c0298": {
+        "id": "5c7fc87d2e221644f31c0298",
+        "name": "BCM MOD.3 Tactical grip",
+        "shortName": "MOD3"
+    },
+    "5cda9bcfd7f00c0c0b53e900": {
+        "id": "5cda9bcfd7f00c0c0b53e900",
+        "name": "ASh-12 Vertical pistol grip",
+        "shortName": "ASh-12"
+    },
+    "59f8a37386f7747af3328f06": {
+        "id": "59f8a37386f7747af3328f06",
+        "name": "Fortis Shift tactical grip",
+        "shortName": "Shift"
+    },
+    "5a7dbfc1159bd40016548fde": {
+        "id": "5a7dbfc1159bd40016548fde",
+        "name": "Hera Arms CQR tactical grip",
+        "shortName": "CQR"
+    },
+    "5c87ca002e221600114cb150": {
+        "id": "5c87ca002e221600114cb150",
+        "name": "KAC Vertical pistol grip",
+        "shortName": "VPG"
+    },
+    "588226d124597767ad33f787": {
+        "id": "588226d124597767ad33f787",
+        "name": "Magpul AFG grip black",
+        "shortName": "AFG blk."
+    },
+    "588226dd24597767ad33f789": {
+        "id": "588226dd24597767ad33f789",
+        "name": "Magpul AFG grip FDE",
+        "shortName": "AFG FDE"
+    },
+    "588226e62459776e3e094af7": {
+        "id": "588226e62459776e3e094af7",
+        "name": "Magpul AFG grip FG",
+        "shortName": "AFG FG"
+    },
+    "588226ef24597767af46e39c": {
+        "id": "588226ef24597767af46e39c",
+        "name": "Magpul AFG grip OD",
+        "shortName": "AFG OD"
+    },
+    "59fc48e086f77463b1118392": {
+        "id": "59fc48e086f77463b1118392",
+        "name": "Magpul RVG grip black",
+        "shortName": "RVG blk."
+    },
+    "5fce0cf655375d18a253eff0": {
+        "id": "5fce0cf655375d18a253eff0",
+        "name": "Magpul RVG grip FDE",
+        "shortName": "RVG FDE"
+    },
+    "5cf4fb76d7f00c065703d3ac": {
+        "id": "5cf4fb76d7f00c065703d3ac",
+        "name": "RTM Pillau Tactical grip",
+        "shortName": "Pillau"
+    },
+    "5b057b4f5acfc4771e1bd3e9": {
+        "id": "5b057b4f5acfc4771e1bd3e9",
+        "name": "SE-5 Express Grip",
+        "shortName": "SE-5"
+    },
+    "5c791e872e2216001219c40a": {
+        "id": "5c791e872e2216001219c40a",
+        "name": "SI \"Cobra tactical\" tactical grip",
+        "shortName": "Cobra"
+    },
+    "558032614bdc2de7118b4585": {
+        "id": "558032614bdc2de7118b4585",
+        "name": "Tango Down Stubby BGV-MK46K tactical grip Black",
+        "shortName": "BGV-MK46K Black"
+    },
+    "58c157be86f77403c74b2bb6": {
+        "id": "58c157be86f77403c74b2bb6",
+        "name": "Tango Down Stubby BGV-MK46K tactical grip FDE",
+        "shortName": "BGV-MK46K FDE"
+    },
+    "58c157c886f774032749fb06": {
+        "id": "58c157c886f774032749fb06",
+        "name": "Tango Down Stubby BGV-MK46K tactical grip FG",
+        "shortName": "BGV-MK46K FG"
+    },
+    "5f6340d3ca442212f4047eb2": {
+        "id": "5f6340d3ca442212f4047eb2",
+        "name": "TD Aluminium skeletonized vertical grip",
+        "shortName": "TD"
+    },
+    "591af28e86f77414a27a9e1d": {
+        "id": "591af28e86f77414a27a9e1d",
+        "name": "Viking Tactical UVG Tactical grip",
+        "shortName": "UVG Tactical"
+    },
+    "5c1cd46f2e22164bef5cfedb": {
+        "id": "5c1cd46f2e22164bef5cfedb",
+        "name": "Zenit RK-1 Foregrip on B-25U mount",
+        "shortName": "B-25U RK-1"
+    },
+    "5c1bc4812e22164bef5cfde7": {
+        "id": "5c1bc4812e22164bef5cfde7",
+        "name": "Zenit RK-0 Foregrip",
+        "shortName": "RK-0"
+    },
+    "5c1bc5612e221602b5429350": {
+        "id": "5c1bc5612e221602b5429350",
+        "name": "Zenit RK-1 Foregrip",
+        "shortName": "RK-1"
+    },
+    "5c1bc5af2e221602b412949b": {
+        "id": "5c1bc5af2e221602b412949b",
+        "name": "Zenit RK-2 Foregrip",
+        "shortName": "RK-2"
+    },
+    "5c1bc5fb2e221602b1779b32": {
+        "id": "5c1bc5fb2e221602b1779b32",
+        "name": "Zenit RK-4 Foregrip",
+        "shortName": "RK-4"
+    },
+    "5c1bc7432e221602b412949d": {
+        "id": "5c1bc7432e221602b412949d",
+        "name": "Zenit RK-5 Foregrip",
+        "shortName": "RK-5"
+    },
+    "5c1bc7752e221602b1779b34": {
+        "id": "5c1bc7752e221602b1779b34",
+        "name": "Zenit RK-6 Foregrip",
+        "shortName": "RK-6"
+    },
+    "5fc0f9b5d724d907e2077d82": {
+        "id": "5fc0f9b5d724d907e2077d82",
+        "name": "MVF001 A3 Vertical Grip KeyMod black",
+        "shortName": "MVF001 A3"
+    },
+    "5fc0f9cbd6fa9c00c571bb90": {
+        "id": "5fc0f9cbd6fa9c00c571bb90",
+        "name": "Sig Sauer Vertical Foregrip Keymod Black",
+        "shortName": "SSVFK blk."
+    },
+    "57cffb66245977632f391a99": {
+        "id": "57cffb66245977632f391a99",
+        "name": "Magpul M-LOK AFG Tactical grip",
+        "shortName": "AFG M-LOK"
+    },
+    "57cffcd624597763133760c5": {
+        "id": "57cffcd624597763133760c5",
+        "name": "Magpul M-LOK AFG (Flat Dark Earth) Tactical grip",
+        "shortName": "AFG M-LOK"
+    },
+    "57cffce524597763b31685d8": {
+        "id": "57cffce524597763b31685d8",
+        "name": "Magpul M-LOK AFG (Stealth Gray) Tactical grip",
+        "shortName": "AFG M-LOK"
+    },
+    "5a34fbadc4a28200741e230a": {
+        "id": "5a34fbadc4a28200741e230a",
+        "name": "JP Enterprises Gas System-6",
+        "shortName": "JPGS6"
+    },
+    "59d36a0086f7747e673f3946": {
+        "id": "59d36a0086f7747e673f3946",
+        "name": "AKS-74U Gas tube",
+        "shortName": "AKS74U G.tube"
+    },
+    "5fbc210bf24b94483f726481": {
+        "id": "5fbc210bf24b94483f726481",
+        "name": "SIG MCX Gas Block",
+        "shortName": "MCX Gas.Bl."
+    },
+    "5a01ad4786f77450561fda02": {
+        "id": "5a01ad4786f77450561fda02",
+        "name": "Kiba Arms VDM CS gas tube",
+        "shortName": "VDM CS"
+    },
+    "5d00ec68d7ad1a04a067e5be": {
+        "id": "5d00ec68d7ad1a04a067e5be",
+        "name": "JP Enterprises Gas System-5b",
+        "shortName": "JPGS5b"
+    },
+    "59ccfdba86f7747f2109a587": {
+        "id": "59ccfdba86f7747f2109a587",
+        "name": "UltiMAK M1-B gas tube for АК",
+        "shortName": "M1-B"
+    },
+    "59c6633186f7740cf0493bb9": {
+        "id": "59c6633186f7740cf0493bb9",
+        "name": "AK-74 Gas tube",
+        "shortName": "AK 74 G.Tube"
+    },
+    "5ae30e795acfc408fb139a0b": {
+        "id": "5ae30e795acfc408fb139a0b",
+        "name": "Colt M4 Front sight",
+        "shortName": "M4 FS"
+    },
+    "59d64ec286f774171d1e0a42": {
+        "id": "59d64ec286f774171d1e0a42",
+        "name": "AKM (6P1 Sb.1-2) gas tube",
+        "shortName": "6P1 Sb.1-2"
+    },
+    "56ea8d2fd2720b7c698b4570": {
+        "id": "56ea8d2fd2720b7c698b4570",
+        "name": "Windham Weaponry Rail Gas Block",
+        "shortName": "PICBLOCK"
+    },
+    "5b237e425acfc4771e1be0b6": {
+        "id": "5b237e425acfc4771e1be0b6",
+        "name": "Handguard with a gas block combo by TROY Industries for AK",
+        "shortName": "TROY Combo"
+    },
+    "59ccd11386f77428f24a488f": {
+        "id": "59ccd11386f77428f24a488f",
+        "name": "PP-19-01 gas tube",
+        "shortName": "PP-19-01 g.tube"
+    },
+    "5fc2360f900b1d5091531e19": {
+        "id": "5fc2360f900b1d5091531e19",
+        "name": "Mk-18 Gas Block",
+        "shortName": "Mk-18 Gas.Bl."
+    },
+    "59e649f986f77411d949b246": {
+        "id": "59e649f986f77411d949b246",
+        "name": "Molot AKM type gas tube\n",
+        "shortName": "AKM Type"
+    },
+    "5dfa3d45dfc58d14537c20b0": {
+        "id": "5dfa3d45dfc58d14537c20b0",
+        "name": "KAC Low Profile Gas Block",
+        "shortName": "KAC Gas.Bl."
+    },
+    "5d4aab30a4b9365435358c55": {
+        "id": "5d4aab30a4b9365435358c55",
+        "name": "VS-24 white handguard with a VS-33c gas block combo for AK",
+        "shortName": "VS Combo wht"
+    },
+    "5cf656f2d7f00c06585fb6eb": {
+        "id": "5cf656f2d7f00c06585fb6eb",
+        "name": "VS-24 Handguard with a VS-33c gas block combo for AK",
+        "shortName": "VS Combo"
+    },
+    "5bb20dcad4351e3bac1212da": {
+        "id": "5bb20dcad4351e3bac1212da",
+        "name": "HK 416A5 Regular Low Profile Gas Block",
+        "shortName": "416A5"
+    },
+    "5c471c842e221615214259b5": {
+        "id": "5c471c842e221615214259b5",
+        "name": "SVDS Gas tube",
+        "shortName": "SVDS G.Tube"
+    },
+    "5c5039be2e221602b177c9ff": {
+        "id": "5c5039be2e221602b177c9ff",
+        "name": "VPO-101 Gas tube",
+        "shortName": "VPO-101 G.Tube"
+    },
+    "56eabcd4d2720b66698b4574": {
+        "id": "56eabcd4d2720b66698b4574",
+        "name": "MK12 Low Profile Gas Block",
+        "shortName": "MK12"
+    },
+    "5f6339d53ada5942720e2dc3": {
+        "id": "5f6339d53ada5942720e2dc3",
+        "name": "Ferfrans \"CRD\" 5.56x45",
+        "shortName": "CRD"
+    },
+    "5649aa744bdc2ded0b8b457e": {
+        "id": "5649aa744bdc2ded0b8b457e",
+        "name": "Izhmash 5.45x39 АК-74 muzzle brake & compensator (6P20 0-20)",
+        "shortName": "6P20 0-20"
+    },
+    "57dc324a24597759501edc20": {
+        "id": "57dc324a24597759501edc20",
+        "name": "IzhMash 5.45x39 muzzle brake for AKS-74U (6P26 0-20)",
+        "shortName": "6P26 0-20"
+    },
+    "5888996c24597754281f9419": {
+        "id": "5888996c24597754281f9419",
+        "name": "DVL-10 М2 muzzle brake",
+        "shortName": "DVL-10 М2 MBr"
+    },
+    "5a70366c8dc32e001207fb06": {
+        "id": "5a70366c8dc32e001207fb06",
+        "name": "Double Diamond flash hider",
+        "shortName": "Glock DD"
+    },
+    "5c48a2a42e221602b66d1e07": {
+        "id": "5c48a2a42e221602b66d1e07",
+        "name": "Desert Tech 5.56x45 Flash hider",
+        "shortName": "MDR reg."
+    },
+    "5fbcbcf593164a5b6278efb2": {
+        "id": "5fbcbcf593164a5b6278efb2",
+        "name": "3-prong SIG Flash hider 7.62x51",
+        "shortName": "3-pr.FH"
+    },
+    "5c78f2882e22165df16b832e": {
+        "id": "5c78f2882e22165df16b832e",
+        "name": "SAI Jail Break 5.56x45 for AR-15",
+        "shortName": "Jail Break"
+    },
+    "5ac72e945acfc43f3b691116": {
+        "id": "5ac72e945acfc43f3b691116",
+        "name": "Izhmash 5.45x39 АК-105 muzzlebrake & compensator (6P44 0-20)",
+        "shortName": "6P44 0-20"
+    },
+    "544a38634bdc2d58388b4568": {
+        "id": "544a38634bdc2d58388b4568",
+        "name": "Colt USGI A2 5.56x45 Flash hider for AR-15",
+        "shortName": "USGI A2"
+    },
+    "5ac72e615acfc43f67248aa0": {
+        "id": "5ac72e615acfc43f67248aa0",
+        "name": "Izhmash 5.56x45 АК-101 muzzlebrake & compensator",
+        "shortName": "AK-101 MB"
+    },
+    "5c0fafb6d174af02a96260ba": {
+        "id": "5c0fafb6d174af02a96260ba",
+        "name": "ADAR 2-15.56x45 Flashhider",
+        "shortName": "ADAR FH"
+    },
+    "5ba26acdd4351e003562908e": {
+        "id": "5ba26acdd4351e003562908e",
+        "name": "HK A1 4.6x30 Flash hider for MP7",
+        "shortName": "MP7"
+    },
+    "5caf17c9ae92150b30006be1": {
+        "id": "5caf17c9ae92150b30006be1",
+        "name": "ASh-12 regular muzzle brake 12.7x55",
+        "shortName": "ASh MB"
+    },
+    "5a7ad0c451dfba0013379712": {
+        "id": "5a7ad0c451dfba0013379712",
+        "name": "Carver Custom 4 Port 9x19 muzzle brake",
+        "shortName": "4Port"
+    },
+    "5c6beec32e221601da3578f2": {
+        "id": "5c6beec32e221601da3578f2",
+        "name": "TJ Custom 9x19 Compensator",
+        "shortName": "TJ"
+    },
+    "5998598e86f7740b3f498a86": {
+        "id": "5998598e86f7740b3f498a86",
+        "name": "Izhmash 9x19 Saiga-9 muzzle brake/compensator",
+        "shortName": "Saiga-9 Br"
+    },
+    "5cc9ad73d7f00c000e2579d4": {
+        "id": "5cc9ad73d7f00c000e2579d4",
+        "name": "SRVV 7.62x39 АК muzzle brake & compensator",
+        "shortName": "SRVV"
+    },
+    "5cc9a96cd7f00c011c04e04a": {
+        "id": "5cc9a96cd7f00c011c04e04a",
+        "name": "SRVV 5.45x39 АК-74 muzzle brake",
+        "shortName": "SRVV"
+    },
+    "58949dea86f77409483e16a8": {
+        "id": "58949dea86f77409483e16a8",
+        "name": "A2 9x19 Flash hider for MPX",
+        "shortName": "MPX A2"
+    },
+    "5a9ea27ca2750c00137fa672": {
+        "id": "5a9ea27ca2750c00137fa672",
+        "name": "Spike tactical dynacomp 7.62x39 muzzle brake & compensator for AK ",
+        "shortName": "Dynacomp"
+    },
+    "5a705e128dc32e000d46d258": {
+        "id": "5a705e128dc32e000d46d258",
+        "name": "Alpha Wolf Bullnose 9x19 Compensator",
+        "shortName": "G AW"
+    },
+    "5bbdb83fd4351e44f824c44b": {
+        "id": "5bbdb83fd4351e44f824c44b",
+        "name": "Tacfire Tanker style muzzle brake for Mosin rifle",
+        "shortName": "Tanker"
+    },
+    "5ac72e895acfc43b321d4bd5": {
+        "id": "5ac72e895acfc43b321d4bd5",
+        "name": "Izhmash 7.62x39 АК-104 muzzlebrake & compensator (6P46 0-20)",
+        "shortName": "6P46 0-20"
+    },
+    "58889c7324597754281f9439": {
+        "id": "58889c7324597754281f9439",
+        "name": "DVL-10 muzzle device",
+        "shortName": "DVL-10 MD"
+    },
+    "5d1f819086f7744b355c219b": {
+        "id": "5d1f819086f7744b355c219b",
+        "name": "Daniel Defense Wave Muzzle Brake 7.62x51",
+        "shortName": "Wave MB"
+    },
+    "5943eeeb86f77412d6384f6b": {
+        "id": "5943eeeb86f77412d6384f6b",
+        "name": "PWS CQB 74 5.45x39 Muzzle brake",
+        "shortName": "PWS CQB 74"
+    },
+    "5df35e7f2a78646d96665dd4": {
+        "id": "5df35e7f2a78646d96665dd4",
+        "name": "Orsis T-5000M muzzle brake",
+        "shortName": "T-5000M MBr"
+    },
+    "5a0d716f1526d8000d26b1e2": {
+        "id": "5a0d716f1526d8000d26b1e2",
+        "name": "Izhmash 7.62x39 flash hider for AKML system",
+        "shortName": "AKML"
+    },
+    "560e620e4bdc2d724b8b456b": {
+        "id": "560e620e4bdc2d724b8b456b",
+        "name": "SV-98 muzzle device",
+        "shortName": "SV-98 STD"
+    },
+    "59e8a00d86f7742ad93b569c": {
+        "id": "59e8a00d86f7742ad93b569c",
+        "name": "Thread protection for AKM/VPO-209",
+        "shortName": "VPO-209"
+    },
+    "5f633f68f5750b524b45f112": {
+        "id": "5f633f68f5750b524b45f112",
+        "name": "JMAC RRD-4C 7.62x39 muzzle brake for AKM type thread",
+        "shortName": "RRD 4C"
+    },
+    "5c4ee3d62e2216152006f302": {
+        "id": "5c4ee3d62e2216152006f302",
+        "name": "SRVV \"Mk.2.0\" compensator 7.62x54 for SV-98",
+        "shortName": "Mk.2.0"
+    },
+    "5cc82796e24e8d000f5859a8": {
+        "id": "5cc82796e24e8d000f5859a8",
+        "name": "FN P90 5.7x28 flash hider",
+        "shortName": "P90 FH"
+    },
+    "5bffd7ed0db834001d23ebf9": {
+        "id": "5bffd7ed0db834001d23ebf9",
+        "name": "PM-Laser DTK-TT muzzle brake for TT pistol",
+        "shortName": "DTK-TT"
+    },
+    "5a7ad1fb51dfba0013379715": {
+        "id": "5a7ad1fb51dfba0013379715",
+        "name": "Lone Wolf Compensator 9 9x19",
+        "shortName": "LW 9"
+    },
+    "5cf6935bd7f00c06585fb791": {
+        "id": "5cf6935bd7f00c06585fb791",
+        "name": "Carbine brake for SIG MPX by TACCOM",
+        "shortName": "TACCOM"
+    },
+    "5ac72e725acfc400180ae701": {
+        "id": "5ac72e725acfc400180ae701",
+        "name": "Izhmash 5.56x45 АК-102 muzzlebrake & compensator (6P44 0-20)",
+        "shortName": "6P44 0-20"
+    },
+    "59e61eb386f77440d64f5daf": {
+        "id": "59e61eb386f77440d64f5daf",
+        "name": "Molot 7.62x39 Vepr KM / VPO-136 muzzle brake & compensator",
+        "shortName": "VPO-136"
+    },
+    "5998597786f77414ea6da093": {
+        "id": "5998597786f77414ea6da093",
+        "name": "Izhmash 9x19 PP-19-01 muzzle brake/compensator",
+        "shortName": "PP-19-01 Br"
+    },
+    "56ea8180d2720bf2698b456a": {
+        "id": "56ea8180d2720bf2698b456a",
+        "name": "KAC QD Compensator 5.56x45",
+        "shortName": "KAC QDC"
+    },
+    "5beec3420db834001b095429": {
+        "id": "5beec3420db834001b095429",
+        "name": "Izhmash 5.45x39 RPK-16 muzzle brake & compensator",
+        "shortName": "RPK-16 MB"
+    },
+    "5c471bfc2e221602b21d4e17": {
+        "id": "5c471bfc2e221602b21d4e17",
+        "name": "Izhmash 7.62x54 SVDS muzzlebrake & compensator",
+        "shortName": "SVDS MB"
+    },
+    "56ea6fafd2720b844b8b4593": {
+        "id": "56ea6fafd2720b844b8b4593",
+        "name": "Noveske KX3 5.56x45 flash hider",
+        "shortName": "KX3"
+    },
+    "5cff9e5ed7ad1a09407397d4": {
+        "id": "5cff9e5ed7ad1a09407397d4",
+        "name": "Daniel Defense Wave Muzzle Brake 5.56x45",
+        "shortName": "Wave MB"
+    },
+    "5aafa1c2e5b5b00015042a56": {
+        "id": "5aafa1c2e5b5b00015042a56",
+        "name": "Socom 16 7.62x51 muzzle brake & compensator for M1A",
+        "shortName": "Socom 16 MB"
+    },
+    "5f633f791b231926f2329f13": {
+        "id": "5f633f791b231926f2329f13",
+        "name": "JMAC RRD-4C muzzle brake for AK-74 type thread",
+        "shortName": "RRD 4C"
+    },
+    "5c6d710d2e22165df16b81e7": {
+        "id": "5c6d710d2e22165df16b81e7",
+        "name": "Surefire WarComp 5.56x45 Flash hider for AR-15",
+        "shortName": "WarComp"
+    },
+    "5ac7655e5acfc40016339a19": {
+        "id": "5ac7655e5acfc40016339a19",
+        "name": "Izhmash 5.45x39 АК-74M muzzle brake & compensator (6P20 0-20)",
+        "shortName": "6P20 0-20"
+    },
+    "5d026791d7ad1a04a067ea63": {
+        "id": "5d026791d7ad1a04a067ea63",
+        "name": "Fortis Red Brake 7.62x51 muzzle brake for AR-10",
+        "shortName": "Red Brake"
+    },
+    "5ac72e7d5acfc40016339a02": {
+        "id": "5ac72e7d5acfc40016339a02",
+        "name": "Izhmash 7.62x39 АК-103 muzzlebrake & compensator",
+        "shortName": "AK-103 MB"
+    },
+    "59d64fc686f774171b243fe2": {
+        "id": "59d64fc686f774171b243fe2",
+        "name": "Izhmash 7.62x39 АКM muzzle brake & compensator (6P1 0-14)",
+        "shortName": "6P1 0-14"
+    },
+    "5649ab884bdc2ded0b8b457f": {
+        "id": "5649ab884bdc2ded0b8b457f",
+        "name": "Zenit DTK-1 7.62x39 & 5.45x39 muzzle brake & compensator for AK ",
+        "shortName": "DTK-1"
+    },
+    "5dcbe965e4ed22586443a79d": {
+        "id": "5dcbe965e4ed22586443a79d",
+        "name": "Desert Tech .308 Flash hider",
+        "shortName": "MDR reg."
+    },
+    "5c07c5ed0db834001b73571c": {
+        "id": "5c07c5ed0db834001b73571c",
+        "name": "HK Noveske style muzzle brake & compensator for MP-5",
+        "shortName": "Noveske Style"
+    },
+    "5943ee5a86f77413872d25ec": {
+        "id": "5943ee5a86f77413872d25ec",
+        "name": "PWS CQB 5.56 x 45 Muzzle brake",
+        "shortName": "PWS CQB"
+    },
+    "5addbbb25acfc40015621bd9": {
+        "id": "5addbbb25acfc40015621bd9",
+        "name": "Phantom 7.62x51 muzzle brake & compensator for M14",
+        "shortName": "Phantom"
+    },
+    "5addbba15acfc400185c2854": {
+        "id": "5addbba15acfc400185c2854",
+        "name": "Vortex DC 7.62x51 muzzle brake & compensator for M14",
+        "shortName": "Vortex DC"
+    },
+    "5fbcbd02900b1d5091531dd3": {
+        "id": "5fbcbd02900b1d5091531dd3",
+        "name": "SIG micro brake muzzle brake 7.62x51",
+        "shortName": "Micr.Br."
+    },
+    "5cf78720d7f00c06595bc93e": {
+        "id": "5cf78720d7f00c06595bc93e",
+        "name": "Lantac \"Blast mitigation device\" 7.62x51",
+        "shortName": "BMD"
+    },
+    "5addbb945acfc4001a5fc44e": {
+        "id": "5addbb945acfc4001a5fc44e",
+        "name": "Good Iron 7.62x51 muzzle brake & compensator for M14",
+        "shortName": "Good Iron"
+    },
+    "5ea172e498dacb342978818e": {
+        "id": "5ea172e498dacb342978818e",
+        "name": "Surefire FH556RC 5.56x45 Flash hider for AR-15",
+        "shortName": "FH556RC"
+    },
+    "5c878ebb2e2216001219d48a": {
+        "id": "5c878ebb2e2216001219d48a",
+        "name": "Lantac Dragon 7.62x39 muzzle brake & compensator for AK ",
+        "shortName": "DGNAK47B"
+    },
+    "5f6372e2865db925d54f3869": {
+        "id": "5f6372e2865db925d54f3869",
+        "name": "Ferfrans Muzzle Brake 5.56x45",
+        "shortName": "Ferfrans MB"
+    },
+    "5d440625a4b9361eec4ae6c5": {
+        "id": "5d440625a4b9361eec4ae6c5",
+        "name": "Thunder Beast 223CB Muzzle brake 5.56x45",
+        "shortName": "223CB"
+    },
+    "5d443f8fa4b93678dd4a01aa": {
+        "id": "5d443f8fa4b93678dd4a01aa",
+        "name": "Thunder Beast 30CB Muzzle Brake 7.62x51",
+        "shortName": "30CB"
+    },
+    "5bc5a35cd4351e450201232f": {
+        "id": "5bc5a35cd4351e450201232f",
+        "name": "Witt Machine muzzle brake for Mosin rifle",
+        "shortName": "Witt"
+    },
+    "5a7b32a2e899ef00135e345a": {
+        "id": "5a7b32a2e899ef00135e345a",
+        "name": "Strike Industries G4 slide compensator 9x19",
+        "shortName": "G4"
+    },
+    "5b099b7d5acfc400186331e4": {
+        "id": "5b099b7d5acfc400186331e4",
+        "name": " DS Arms \"3 prong trident\" 7.62x51 Flash hider for SA-58",
+        "shortName": "3 prong trident"
+    },
+    "5cc9b815d7f00c000e2579d6": {
+        "id": "5cc9b815d7f00c000e2579d6",
+        "name": "TROY Claymore 5.56x45 muzzle brake for AR-15",
+        "shortName": "Claymore"
+    },
+    "5d02677ad7ad1a04a15c0f95": {
+        "id": "5d02677ad7ad1a04a15c0f95",
+        "name": "Nordic Corvette 7.62x51 muzzle brake for AR-10",
+        "shortName": "Corvette"
+    },
+    "5c7e5f112e221600106f4ede": {
+        "id": "5c7e5f112e221600106f4ede",
+        "name": "AAC Blackout 51T 5.56x45 flash-hider",
+        "shortName": "Blackout 51T"
+    },
+    "5dfa3cd1b33c0951220c079b": {
+        "id": "5dfa3cd1b33c0951220c079b",
+        "name": "KAC QDC Flash suppressor kit 7.62x51 flash hider",
+        "shortName": "KAC QDC"
+    },
+    "5c878e9d2e2216000f201903": {
+        "id": "5c878e9d2e2216000f201903",
+        "name": "Lantac Dragon 7.62x51 muzzle brake",
+        "shortName": "DGN762B"
+    },
+    "5fb65424956329274326f316": {
+        "id": "5fb65424956329274326f316",
+        "name": "Kriss Vector .45 ACP Flash hider",
+        "shortName": "Vector 45"
+    },
+    "5c7fb51d2e2216001219ce11": {
+        "id": "5c7fb51d2e2216001219ce11",
+        "name": "Surefire SF3P 5.56x45 Flash hider for AR-15",
+        "shortName": "SF3P"
+    },
+    "5bc5a351d4351e003477a414": {
+        "id": "5bc5a351d4351e003477a414",
+        "name": "Texas Precision Products muzzle brake for Mosin rifle",
+        "shortName": "TPP"
+    },
+    "5a34fd2bc4a282329a73b4c5": {
+        "id": "5a34fd2bc4a282329a73b4c5",
+        "name": "AAC Blackout 51T flash hider (7.62x51)",
+        "shortName": "Blackout 51T"
+    },
+    "5b7d68af5acfc400170e30c3": {
+        "id": "5b7d68af5acfc400170e30c3",
+        "name": " DS Arms \"Austrian Style\" 7.62x51 muzzle brake for SA-58",
+        "shortName": "Austrian Style"
+    },
+    "5c7951452e221644f31bfd5c": {
+        "id": "5c7951452e221644f31bfd5c",
+        "name": "Venom Antidote muzzle brake & compensator for АК ",
+        "shortName": "Antidote"
+    },
+    "5b3a16655acfc40016387a2a": {
+        "id": "5b3a16655acfc40016387a2a",
+        "name": "Annihilator 7.62x39, 5.56x45 and 9mm flash hider for AR-15",
+        "shortName": "Annihilator"
+    },
+    "5d02676dd7ad1a049e54f6dc": {
+        "id": "5d02676dd7ad1a049e54f6dc",
+        "name": "Nordic Corvette 5.56x45 compensator for AR-15",
+        "shortName": "Corvette"
+    },
+    "5f2aa4559b44de6b1b4e68d1": {
+        "id": "5f2aa4559b44de6b1b4e68d1",
+        "name": "Regular RFB 7.62x51 Flash hider",
+        "shortName": "RFB FH"
+    },
+    "5fc23636016cce60e8341b05": {
+        "id": "5fc23636016cce60e8341b05",
+        "name": "SilencerCo AC-858 ASR .338 LM Muzzle brake",
+        "shortName": "AC-858"
+    },
+    "5cf6937cd7f00c056c53fb39": {
+        "id": "5cf6937cd7f00c056c53fb39",
+        "name": "Bulletec ST-6012 5.56x45 Flash hider for AR-15",
+        "shortName": "ST-6012"
+    },
+    "5fbbc3324e8a554c40648348": {
+        "id": "5fbbc3324e8a554c40648348",
+        "name": "KRISS Vector 9x19 Flash hider",
+        "shortName": "Vector 9x19"
+    },
+    "5c4eec9b2e2216398b5aaba2": {
+        "id": "5c4eec9b2e2216398b5aaba2",
+        "name": "Thread adapter 7.62x54 for SV-98",
+        "shortName": "Thread adapter"
+    },
+    "5addbb6e5acfc408fb1393fd": {
+        "id": "5addbb6e5acfc408fb1393fd",
+        "name": "National Match 7.62x51 muzzle brake & compensator for M1A",
+        "shortName": "National Match MB"
+    },
+    "5ef61964ec7f42238c31e0c1": {
+        "id": "5ef61964ec7f42238c31e0c1",
+        "name": "Anarchy Outdoors Muzzle Brake .45 ACP",
+        "shortName": "AO MB"
+    },
+    "5cdd7685d7f00c000f260ed2": {
+        "id": "5cdd7685d7f00c000f260ed2",
+        "name": "Muzzle brake Keeno Arms SHREWD 7.62x51 for AR-10",
+        "shortName": "SHREWD"
+    },
+    "5b7d693d5acfc43bca706a3d": {
+        "id": "5b7d693d5acfc43bca706a3d",
+        "name": "Compensator 2A \"X3\" 7.62x51 for AR-10",
+        "shortName": "2A X3"
+    },
+    "5cdd7693d7f00c0010373aa5": {
+        "id": "5cdd7693d7f00c0010373aa5",
+        "name": "Muzzle brake Precision Armament M-11 7.62x51 for AR-10",
+        "shortName": "M-11"
+    },
+    "5bbdb8bdd4351e4502011460": {
+        "id": "5bbdb8bdd4351e4502011460",
+        "name": "Muzzle brake Odin Works Atlas-7 7.62x51 for AR-10",
+        "shortName": "Atlas-7"
+    },
+    "5a7037338dc32e000d46d257": {
+        "id": "5a7037338dc32e000d46d257",
+        "name": "Decelerator 3 Port 9x19 Compensator",
+        "shortName": "G 3 Port"
+    },
+    "5addbb825acfc408fb139400": {
+        "id": "5addbb825acfc408fb139400",
+        "name": "JP Enterprises tactical compensator 7.62x51 muzzle brake & compensator for M14",
+        "shortName": "JP MB M14"
+    },
+    "5fbcbd10ab884124df0cd563": {
+        "id": "5fbcbd10ab884124df0cd563",
+        "name": "SIG Two Port brake muzzle brake 7.62x51",
+        "shortName": "TPB 7.62x51"
+    },
+    "5a7c147ce899ef00150bd8b8": {
+        "id": "5a7c147ce899ef00150bd8b8",
+        "name": "Muzzle brake Vendetta precision VP-09 5.56x45",
+        "shortName": "VP-09"
+    },
+    "5ab3afb2d8ce87001660304d": {
+        "id": "5ab3afb2d8ce87001660304d",
+        "name": "Socom 16 7.62x51 muzzle brake & compensator for M1A",
+        "shortName": "Socom 16 Th"
+    },
+    "5fbc22ccf24b94483f726483": {
+        "id": "5fbc22ccf24b94483f726483",
+        "name": "SIG Taper-LOK Muzzle Adapter",
+        "shortName": "T-LOK"
+    },
+    "5d270ca28abbc31ee25ee821": {
+        "id": "5d270ca28abbc31ee25ee821",
+        "name": "M700 thread protection cap",
+        "shortName": "M700 protection cap"
+    },
+    "5de8f237bbaf010b10528a70": {
+        "id": "5de8f237bbaf010b10528a70",
+        "name": "B&T adapter for MP9 regular suppressor.",
+        "shortName": "B&T Mount"
+    },
+    "59bffc1f86f77435b128b872": {
+        "id": "59bffc1f86f77435b128b872",
+        "name": "Direct Thread Mount adapter for Silencerco Hybrid 46.",
+        "shortName": "DT Mount"
+    },
+    "5fbbc34106bde7524f03cbe9": {
+        "id": "5fbbc34106bde7524f03cbe9",
+        "name": "Vector 9x19 thread protection cap",
+        "shortName": "Vector protection cap"
+    },
+    "57f3c7e024597738ea4ba286": {
+        "id": "57f3c7e024597738ea4ba286",
+        "name": "PP-91-01 Kedr-B muzzle thread piece",
+        "shortName": "PP-91-01 muzzlethread"
+    },
+    "5a0abb6e1526d8000a025282": {
+        "id": "5a0abb6e1526d8000a025282",
+        "name": "Taktika Tula AK and AKM adapter",
+        "shortName": "TT AKM"
+    },
+    "5c0111ab0db834001966914d": {
+        "id": "5c0111ab0db834001966914d",
+        "name": "ME Cylinder muzzle adapter 12 ga",
+        "shortName": "Cylinder "
+    },
+    "5d270b3c8abbc3105335cfb8": {
+        "id": "5d270b3c8abbc3105335cfb8",
+        "name": "M700 thread protection cap",
+        "shortName": "M700 protection cap"
+    },
+    "59fb137a86f7740adb646af1": {
+        "id": "59fb137a86f7740adb646af1",
+        "name": "Tromix Monster Claw 12ga muzzle brake",
+        "shortName": "Monster Claw"
+    },
+    "587de5ba2459771c0f1e8a58": {
+        "id": "587de5ba2459771c0f1e8a58",
+        "name": "P226 thread protection cap",
+        "shortName": "P226 protection cap"
+    },
+    "576167ab2459773cad038c43": {
+        "id": "576167ab2459773cad038c43",
+        "name": "SOK-12 Protection tube",
+        "shortName": "SOK-12 P.T."
+    },
+    "5a6b59a08dc32e000b452fb7": {
+        "id": "5a6b59a08dc32e000b452fb7",
+        "name": "Glock thread protector produced by Salient Arms",
+        "shortName": "SAI TP"
+    },
+    "58272d7f2459774f6311ddfd": {
+        "id": "58272d7f2459774f6311ddfd",
+        "name": "GK-02 Muzzle Brake",
+        "shortName": "GK-02"
+    },
+    "5e21ca18e4d47f0da15e77dd": {
+        "id": "5e21ca18e4d47f0da15e77dd",
+        "name": "CNC Warrior AK 5.56x45 mm muzzle device adapter",
+        "shortName": "CNC War."
+    },
+    "5cadc390ae921500126a77f1": {
+        "id": "5cadc390ae921500126a77f1",
+        "name": "M9A3 thread protection cap",
+        "shortName": "M9A3 protection cap"
+    },
+    "5c0000c00db834001a6697fc": {
+        "id": "5c0000c00db834001a6697fc",
+        "name": "3 Lug threaded protector",
+        "shortName": "3 Lug thr."
+    },
+    "5e01e9e273d8eb11426f5bc3": {
+        "id": "5e01e9e273d8eb11426f5bc3",
+        "name": "Rotor 43 thread adapter for SVD-S",
+        "shortName": "SVD-S thr."
+    },
+    "5cf79599d7f00c10875d9212": {
+        "id": "5cf79599d7f00c10875d9212",
+        "name": "Tiger Rock Mosin rifle tread adapter",
+        "shortName": "TR"
+    },
+    "560838c94bdc2d77798b4569": {
+        "id": "560838c94bdc2d77798b4569",
+        "name": "Remington Tactical Choke 12ga",
+        "shortName": "RTC 12ga"
+    },
+    "5926e16e86f7742f5a0f7ecb": {
+        "id": "5926e16e86f7742f5a0f7ecb",
+        "name": "3 Lug thread protector",
+        "shortName": "3 Lug"
+    },
+    "5cf79389d7f00c10941a0c4d": {
+        "id": "5cf79389d7f00c10941a0c4d",
+        "name": "Custom Mosin rifle thread adapter",
+        "shortName": "Mosin thr."
+    },
+    "5cf67a1bd7f00c06585fb6f3": {
+        "id": "5cf67a1bd7f00c06585fb6f3",
+        "name": "Weapon Tuning Mosin rifle tread adapter",
+        "shortName": "WT1052"
+    },
+    "5b363dea5acfc4771e1c5e7e": {
+        "id": "5b363dea5acfc4771e1c5e7e",
+        "name": "SilencerCo choke adapter for 12ga shotguns",
+        "shortName": "12g adapter"
+    },
+    "5a6b592c8dc32e00094b97bf": {
+        "id": "5a6b592c8dc32e00094b97bf",
+        "name": "Glock thread protector produced by Double Diamond",
+        "shortName": "DD TP"
+    },
+    "5f2aa4464b50c14bcf07acdb": {
+        "id": "5f2aa4464b50c14bcf07acdb",
+        "name": "RFB thread protection cap",
+        "shortName": "RFB protection cap"
+    },
+    "5de6556a205ddc616a6bc4f7": {
+        "id": "5de6556a205ddc616a6bc4f7",
+        "name": "VPO-215 thread protection cap",
+        "shortName": "215 Pr."
+    },
+    "5b363e1b5acfc4771e1c5e80": {
+        "id": "5b363e1b5acfc4771e1c5e80",
+        "name": "SilencerCo Salvo 12 thread adapter",
+        "shortName": "Thread adapter"
+    },
+    "5c7954d52e221600106f4cc7": {
+        "id": "5c7954d52e221600106f4cc7",
+        "name": "Direct Thread Mount adapter for Gemtech ONE.",
+        "shortName": "ONE Mount"
+    },
+    "5cf67cadd7f00c065a5abab7": {
+        "id": "5cf67cadd7f00c065a5abab7",
+        "name": "Weapon Tuning SKS tread adapter",
+        "shortName": "WT0032-1"
+    },
+    "5f2aa43ba9b91d26f20ae6d2": {
+        "id": "5f2aa43ba9b91d26f20ae6d2",
+        "name": "RFB Thread spacer",
+        "shortName": "RFB sp."
+    },
+    "5fc4b992187fea44d52edaa9": {
+        "id": "5fc4b992187fea44d52edaa9",
+        "name": "Direct Thread Mount adapter for Silencerco Omega 45k",
+        "shortName": "DT Omega"
+    },
+    "5fc4b97bab884124df0cd5e3": {
+        "id": "5fc4b97bab884124df0cd5e3",
+        "name": "Piston Mount adapter for Silencerco Omega 45k",
+        "shortName": "Pist.Omega"
+    },
+    "5cf78496d7f00c065703d6ca": {
+        "id": "5cf78496d7f00c065703d6ca",
+        "name": "Direct Thread adapter for the Lantac Blast mitigation device.",
+        "shortName": "A3 Adapter"
+    },
+    "5a6b585a8dc32e5a9c28b4f1": {
+        "id": "5a6b585a8dc32e5a9c28b4f1",
+        "name": "Thread protector for Alpha Wolf Glock barrels",
+        "shortName": "AW TP"
+    },
+    "5fb6548dd1409e5ca04b54f9": {
+        "id": "5fb6548dd1409e5ca04b54f9",
+        "name": "Kriss Vector .45 ACP  thread protection cap",
+        "shortName": "Vector protection cap"
+    },
+    "57ffb0e42459777d047111c5": {
+        "id": "57ffb0e42459777d047111c5",
+        "name": "PBS-4 5.45x39 Silencer",
+        "shortName": "PBS-4"
+    },
+    "5de8f2d5b74cd90030650c72": {
+        "id": "5de8f2d5b74cd90030650c72",
+        "name": "B&T MP9 9x19mm sound suppressor",
+        "shortName": "MP9 Supp."
+    },
+    "5c4eecc32e221602b412b440": {
+        "id": "5c4eecc32e221602b412b440",
+        "name": "Regular SV-98 7.62x54 silencer",
+        "shortName": "SV-98 sil."
+    },
+    "59fb257e86f7742981561852": {
+        "id": "59fb257e86f7742981561852",
+        "name": "Zenit DTK-4М muzzle brake",
+        "shortName": "DTK-4M"
+    },
+    "5fc4b9b17283c4046c5814d7": {
+        "id": "5fc4b9b17283c4046c5814d7",
+        "name": "SilencerCo Omega 45k .45 ACP sound suppressor",
+        "shortName": "Omega 45k"
+    },
+    "5b86a0e586f7745b600ccb23": {
+        "id": "5b86a0e586f7745b600ccb23",
+        "name": "Bramit silencer for a Mosin rifle",
+        "shortName": "Bramit"
+    },
+    "5fbe7618d6fa9c00c571bb6c": {
+        "id": "5fbe7618d6fa9c00c571bb6c",
+        "name": "Sig-Sauer \"SRD\" 7.62x51 Sound Suppressor ",
+        "shortName": "\"SRD\" 7.62x51"
+    },
+    "5c6165902e22160010261b28": {
+        "id": "5c6165902e22160010261b28",
+        "name": "Sig SRD 9 9x19mm sound suppressor",
+        "shortName": "SRD 9"
+    },
+    "5d44064fa4b9361e4f6eb8b5": {
+        "id": "5d44064fa4b9361e4f6eb8b5",
+        "name": "Thunder Beast Ultra 5 Sound Suppressor ",
+        "shortName": "Ultra 5"
+    },
+    "593d493f86f7745e6b2ceb22": {
+        "id": "593d493f86f7745e6b2ceb22",
+        "name": "Hexagon AK-74 5.45x39 sound suppressor",
+        "shortName": "Hexagon AK-74"
+    },
+    "5c7955c22e221644f31bfd5e": {
+        "id": "5c7955c22e221644f31bfd5e",
+        "name": "Gemtech ONE 7.62x51 Sound Suppressor ",
+        "shortName": "Gemtech ONE"
+    },
+    "5e01ea19e9dc277128008c0b": {
+        "id": "5e01ea19e9dc277128008c0b",
+        "name": "Rotor 43 7.62x54 muzzle brake",
+        "shortName": "Rotor43 7.62x54"
+    },
+    "564caa3d4bdc2d17108b458e": {
+        "id": "564caa3d4bdc2d17108b458e",
+        "name": "TGP-A 5.45x39 muzzle device/suppressor",
+        "shortName": "TGP-A"
+    },
+    "5a27b6bec4a282000e496f78": {
+        "id": "5a27b6bec4a282000e496f78",
+        "name": "SR1MP silencer 9x21",
+        "shortName": "SR1MP"
+    },
+    "57f3c8cc2459773ec4480328": {
+        "id": "57f3c8cc2459773ec4480328",
+        "name": "PP-91-01 Kedr-B 9x18PM suppressor",
+        "shortName": "PP-91-01 suppressor"
+    },
+    "57c44dd02459772d2e0ae249": {
+        "id": "57c44dd02459772d2e0ae249",
+        "name": "AS VAL 9x39 integral barrel-suppressor",
+        "shortName": "VAL suppressor"
+    },
+    "57838c962459774a1651ec63": {
+        "id": "57838c962459774a1651ec63",
+        "name": "VSS 9x39 integral barrel-suppressor",
+        "shortName": "VSS suppressor"
+    },
+    "59bfc5c886f7743bf6794e62": {
+        "id": "59bfc5c886f7743bf6794e62",
+        "name": "Vityaz 9x19 sound suppressing device",
+        "shortName": "Vityaz sil."
+    },
+    "5926d33d86f77410de68ebc0": {
+        "id": "5926d33d86f77410de68ebc0",
+        "name": "MP5SD 9x19 silencer",
+        "shortName": "MP5SD suppressor"
+    },
+    "55d614004bdc2d86028b4568": {
+        "id": "55d614004bdc2d86028b4568",
+        "name": "Surefire SOCOM556-MONSTER 5.56x45 silencer",
+        "shortName": "MONSTER"
+    },
+    "56e05b06d2720bb2668b4586": {
+        "id": "56e05b06d2720bb2668b4586",
+        "name": "Stock silencer for PB 9x18 PM",
+        "shortName": "PB-S"
+    },
+    "5a9fb739a2750c003215717f": {
+        "id": "5a9fb739a2750c003215717f",
+        "name": "Rotor 43 9x19 muzzle brake",
+        "shortName": "Rotor43 9x19"
+    },
+    "5cebec00d7f00c065c53522a": {
+        "id": "5cebec00d7f00c065c53522a",
+        "name": "FN Attenuator 5.7x28 silencer",
+        "shortName": "Attenuator"
+    },
+    "59bffbb386f77435b379b9c2": {
+        "id": "59bffbb386f77435b379b9c2",
+        "name": "Silencerco Hybrid 46 multi-caliber silencer",
+        "shortName": "Hybrid 46"
+    },
+    "5a7ad74e51dfba0015068f45": {
+        "id": "5a7ad74e51dfba0015068f45",
+        "name": "Fischer Development FD917 suppressor",
+        "shortName": "FD917"
+    },
+    "5a33a8ebc4a282000c5a950d": {
+        "id": "5a33a8ebc4a282000c5a950d",
+        "name": "Alpha Dog Alpha 9 9x19 sound suppressor",
+        "shortName": "Alpha 9"
+    },
+    "5dfa3d2b0dee1b22f862eade": {
+        "id": "5dfa3d2b0dee1b22f862eade",
+        "name": "KAC PRS QDC 7.62x51 Sound Suppressor ",
+        "shortName": "PRS QDC"
+    },
+    "571a28e524597720b4066567": {
+        "id": "571a28e524597720b4066567",
+        "name": "Makeshift 7.62x25 ТТ silencer",
+        "shortName": "TT silencer"
+    },
+    "5abcc328d8ce8700194394f3": {
+        "id": "5abcc328d8ce8700194394f3",
+        "name": "Silencer APB 9x18PM",
+        "shortName": "APB 9x18PM"
+    },
+    "5c7e8fab2e22165df16b889b": {
+        "id": "5c7e8fab2e22165df16b889b",
+        "name": "AAC Illusion 9 9x19mm silencer",
+        "shortName": "AAC Illusion 9"
+    },
+    "593d489686f7745c6255d58a": {
+        "id": "593d489686f7745c6255d58a",
+        "name": "Hexagon AKM 7.62x39 sound suppressor",
+        "shortName": "Hexagon AKM"
+    },
+    "5ba26ae8d4351e00367f9bdb": {
+        "id": "5ba26ae8d4351e00367f9bdb",
+        "name": "B&T Rotex 2 4.6x30 silencer",
+        "shortName": "Rotex 2"
+    },
+    "5d3ef698a4b9361182109872": {
+        "id": "5d3ef698a4b9361182109872",
+        "name": "Gemtech SFN-57 5.7x28mm silencer",
+        "shortName": "SFN-57"
+    },
+    "5caf187cae92157c28402e43": {
+        "id": "5caf187cae92157c28402e43",
+        "name": "ASh-12 12.7x55 tactical suppressor",
+        "shortName": "ASh supp"
+    },
+    "5cff9e84d7ad1a049e54ed55": {
+        "id": "5cff9e84d7ad1a049e54ed55",
+        "name": "Daniel Defence Wave QD Sound Suppressor ",
+        "shortName": "Wave QD"
+    },
+    "5b363dd25acfc4001a598fd2": {
+        "id": "5b363dd25acfc4001a598fd2",
+        "name": "SilencerCo Salvo 12 sound suppressor",
+        "shortName": " Salvo 12"
+    },
+    "57dbb57e2459774673234890": {
+        "id": "57dbb57e2459774673234890",
+        "name": "KAC QDSS NT-4 FDE 5.56x45 silencer",
+        "shortName": "NT-4 FDE"
+    },
+    "5fbe760793164a5b6278efc8": {
+        "id": "5fbe760793164a5b6278efc8",
+        "name": "Sig-Sauer SRD QD 7.62x51 Sound Suppressor ",
+        "shortName": "SRD QD 7.62x51"
+    },
+    "57da93632459771cb65bf83f": {
+        "id": "57da93632459771cb65bf83f",
+        "name": "KAC QDSS NT-4 Black 5.56x45 silencer",
+        "shortName": "NT-4 blk."
+    },
+    "58aeac1b86f77457c419f475": {
+        "id": "58aeac1b86f77457c419f475",
+        "name": "MPX-SD 9x19 Integrated silencer",
+        "shortName": "MPX-SD"
+    },
+    "55d6190f4bdc2d87028b4567": {
+        "id": "55d6190f4bdc2d87028b4567",
+        "name": "Surefire SOCOM556-MINI MONSTER 5.56x45 Silencer",
+        "shortName": "M MONSTER"
+    },
+    "5e208b9842457a4a7a33d074": {
+        "id": "5e208b9842457a4a7a33d074",
+        "name": "Hexagon \"DTKP MK.2\" 7.62x39 sound suppressor",
+        "shortName": "DTKP "
+    },
+    "5f63407e1b231926f2329f15": {
+        "id": "5f63407e1b231926f2329f15",
+        "name": "Rotor 43 7.62x51 muzzle brake for VPO-101",
+        "shortName": "Rotor43 7.62x51"
+    },
+    "59c0ec5b86f77435b128bfca": {
+        "id": "59c0ec5b86f77435b128bfca",
+        "name": "Hexagon 12K sound suppressor",
+        "shortName": "Hexagon 12K"
+    },
+    "5a9fbb84a2750c00137fa685": {
+        "id": "5a9fbb84a2750c00137fa685",
+        "name": "Rotor 43 5.56x45 muzzle brake",
+        "shortName": "Rotor43 5.56x45"
+    },
+    "5a9fbacda2750c00141e080f": {
+        "id": "5a9fbacda2750c00141e080f",
+        "name": "Rotor 43 7.62x39 muzzle brake",
+        "shortName": "Rotor43 7.62x39"
+    },
+    "5a32a064c4a28200741e22de": {
+        "id": "5a32a064c4a28200741e22de",
+        "name": "SilencerCo Osprey 9 9x19mm sound suppressor",
+        "shortName": "Osprey 9"
+    },
+    "5a34fe59c4a282000b1521a2": {
+        "id": "5a34fe59c4a282000b1521a2",
+        "name": "AAC 762 SDN-6 7.62x51 Sound Suppressor ",
+        "shortName": "SDN-6"
+    },
+    "5ea17bbc09aa976f2e7a51cd": {
+        "id": "5ea17bbc09aa976f2e7a51cd",
+        "name": "Surefire SOCOM556-RC2 5.56x45 silencer",
+        "shortName": "RC2"
+    },
+    "5a0d63621526d8dba31fe3bf": {
+        "id": "5a0d63621526d8dba31fe3bf",
+        "name": "PBS-1 7.62x39 silencer",
+        "shortName": "PBS-1"
+    },
+    "5a9fbb74a2750c0032157181": {
+        "id": "5a9fbb74a2750c0032157181",
+        "name": "Rotor 43 .366TKM muzzle brake",
+        "shortName": "Rotor43 .366TKM"
+    },
+    "593d490386f7745ee97a1555": {
+        "id": "593d490386f7745ee97a1555",
+        "name": "Hexagon SKS 7.62x39 sound suppressor",
+        "shortName": "Hexagon SKS"
+    },
+    "550aa4bf4bdc2dd6348b456b": {
+        "id": "550aa4bf4bdc2dd6348b456b",
+        "name": "Flashhider",
+        "shortName": "Item"
+    },
+    "550aa4cd4bdc2dd8348b456c": {
+        "id": "550aa4cd4bdc2dd8348b456c",
+        "name": "Silencer",
+        "shortName": "Item"
+    },
+    "550ad14d4bdc2dd5348b456c": {
+        "id": "550ad14d4bdc2dd5348b456c",
+        "name": "PMS",
+        "shortName": "Item"
+    },
+    "550aa4af4bdc2dd4348b456e": {
+        "id": "550aa4af4bdc2dd4348b456e",
+        "name": "Сompensator",
+        "shortName": "Item"
+    },
+    "550aa4dd4bdc2dc9348b4569": {
+        "id": "550aa4dd4bdc2dc9348b4569",
+        "name": "Comb. muzzle device",
+        "shortName": "Item"
+    },
+    "57aca93d2459771f2c7e26db": {
+        "id": "57aca93d2459771f2c7e26db",
+        "name": "ELCAN SpecterDR 1x/4x Scope FDE",
+        "shortName": "DR1/4xFDE"
+    },
+    "544a3a774bdc2d3a388b4567": {
+        "id": "544a3a774bdc2d3a388b4567",
+        "name": "Leupold Mark 4 HAMR 4x24mm DeltaPoint hybrid assault scope",
+        "shortName": "HAMR"
+    },
+    "57adff4f24597737f373b6e6": {
+        "id": "57adff4f24597737f373b6e6",
+        "name": "Sig BRAVO4 4X30 Scope",
+        "shortName": "BRAVO4"
+    },
+    "5c1cdd512e22161b267d91ae": {
+        "id": "5c1cdd512e22161b267d91ae",
+        "name": "Primary Arms Compact prism scope 2.5x",
+        "shortName": "Prism 2.5x"
+    },
+    "59db7e1086f77448be30ddf3": {
+        "id": "59db7e1086f77448be30ddf3",
+        "name": "Trijicon ACOG 3.5x35 scope",
+        "shortName": "TA11D"
+    },
+    "57ac965c24597706be5f975c": {
+        "id": "57ac965c24597706be5f975c",
+        "name": "ELCAN SpecterDR 1x/4x Scope",
+        "shortName": "DR1/4x"
+    },
+    "5d2dc3e548f035404a1a4798": {
+        "id": "5d2dc3e548f035404a1a4798",
+        "name": "Monstrum Compact prism scope 2x32",
+        "shortName": "Monstr. 2x32"
+    },
+    "5c0517910db83400232ffee5": {
+        "id": "5c0517910db83400232ffee5",
+        "name": "Valday PS-320 1x/6x Scope",
+        "shortName": "PS320 1/6x"
+    },
+    "5c05293e0db83400232fff80": {
+        "id": "5c05293e0db83400232fff80",
+        "name": "Trijicon ACOG TA01NSN 4x32 scope",
+        "shortName": "TA01NSN"
+    },
+    "5c052a900db834001a66acbd": {
+        "id": "5c052a900db834001a66acbd",
+        "name": "Trijicon ACOG TA01NSN 4x32 scope TAN",
+        "shortName": "TA01NSN"
+    },
+    "570fd6c2d2720bc6458b457f": {
+        "id": "570fd6c2d2720bc6458b457f",
+        "name": "Eotech 553 holographic sight",
+        "shortName": "553"
+    },
+    "58491f3324597764bc48fa02": {
+        "id": "58491f3324597764bc48fa02",
+        "name": "Eotech XPS3-0 holographic sight",
+        "shortName": "XPS3-0"
+    },
+    "584924ec24597768f12ae244": {
+        "id": "584924ec24597768f12ae244",
+        "name": "Eotech XPS3-2 holographic sight",
+        "shortName": "XPS3-2"
+    },
+    "5b30b0dc5acfc400153b7124": {
+        "id": "5b30b0dc5acfc400153b7124",
+        "name": "Holosun HS401G5 reflex sight",
+        "shortName": "HS401G5"
+    },
+    "5d2da1e948f035477b1ce2ba": {
+        "id": "5d2da1e948f035477b1ce2ba",
+        "name": "Trijicon SRS-02 reflex sight",
+        "shortName": "SRS-02"
+    },
+    "584984812459776a704a82a6": {
+        "id": "584984812459776a704a82a6",
+        "name": "VOMZ Pilad P1X42 \"WEAVER\" reflex sight",
+        "shortName": "P1X42"
+    },
+    "59f9d81586f7744c7506ee62": {
+        "id": "59f9d81586f7744c7506ee62",
+        "name": "Vortex Razor AMG UH-1 holographic sight",
+        "shortName": "UH-1"
+    },
+    "570fd721d2720bc5458b4596": {
+        "id": "570fd721d2720bc5458b4596",
+        "name": "Walther MRS reflex sight",
+        "shortName": "MRS"
+    },
+    "5c7d55de2e221644f31bff68": {
+        "id": "5c7d55de2e221644f31bff68",
+        "name": "Aimpoint COMP M4 reflex sight",
+        "shortName": "COMP M4"
+    },
+    "5cebec38d7f00c00110a652a": {
+        "id": "5cebec38d7f00c00110a652a",
+        "name": "FN Ring sight reflex sight",
+        "shortName": "Ring"
+    },
+    "591c4efa86f7741030027726": {
+        "id": "591c4efa86f7741030027726",
+        "name": "Cobra EKP-8-18 reflex sight",
+        "shortName": "EKP-8-18"
+    },
+    "570fd79bd2720bc7458b4583": {
+        "id": "570fd79bd2720bc7458b4583",
+        "name": "OKP-7 reflex sight",
+        "shortName": "OKP-7"
+    },
+    "558022b54bdc2dac148b458d": {
+        "id": "558022b54bdc2dac148b458d",
+        "name": "Eotech EXPS3 holographic sight",
+        "shortName": "EXPS3"
+    },
+    "5c07dd120db834001c39092d": {
+        "id": "5c07dd120db834001c39092d",
+        "name": "Eotech HHS-1 sight",
+        "shortName": "HHS-1"
+    },
+    "5c0a2cec0db834001b7ce47d": {
+        "id": "5c0a2cec0db834001b7ce47d",
+        "name": "Eotech HHS-1 sight Tan",
+        "shortName": "HHS-1"
+    },
+    "5c0505e00db834001b735073": {
+        "id": "5c0505e00db834001b735073",
+        "name": "Valday 1P87 holographic sight",
+        "shortName": "1P87"
+    },
+    "5947db3f86f77447880cf76f": {
+        "id": "5947db3f86f77447880cf76f",
+        "name": "Cobra EKP-8-02 reflex sight",
+        "shortName": "EKP-8-02"
+    },
+    "57486e672459770abd687134": {
+        "id": "57486e672459770abd687134",
+        "name": "OKP-7 reflex sight",
+        "shortName": "OKP-7 Dove"
+    },
+    "58d399e486f77442e0016fe7": {
+        "id": "58d399e486f77442e0016fe7",
+        "name": "Aimpoint Micro T-1 reflex sight",
+        "shortName": "T-1"
+    },
+    "577d141e24597739c5255e01": {
+        "id": "577d141e24597739c5255e01",
+        "name": "Burris FastFire 3 Reflex Sight",
+        "shortName": "FF3"
+    },
+    "58d268fc86f774111273f8c2": {
+        "id": "58d268fc86f774111273f8c2",
+        "name": "Leupold DeltaPoint Reflex Sight",
+        "shortName": "DP"
+    },
+    "5a32aa8bc4a2826c6e06d737": {
+        "id": "5a32aa8bc4a2826c6e06d737",
+        "name": "Trijicon RMR",
+        "shortName": "RMR"
+    },
+    "57ae0171245977343c27bfcf": {
+        "id": "57ae0171245977343c27bfcf",
+        "name": "Belomo PK-06 reflex sight",
+        "shortName": "PK-06"
+    },
+    "5b3116595acfc40019476364": {
+        "id": "5b3116595acfc40019476364",
+        "name": "Sig Sauer Romeo 4 reflex sight",
+        "shortName": "Romeo 4"
+    },
+    "5c503b1c2e221602b21d6e9d": {
+        "id": "5c503b1c2e221602b21d6e9d",
+        "name": "VPO-101 Standard Rearsight",
+        "shortName": "Vepr Rear"
+    },
+    "59d650cf86f7741b846413a4": {
+        "id": "59d650cf86f7741b846413a4",
+        "name": "AKM Standard Rearsight (6P1 Sb.2-1)",
+        "shortName": "6P1 Sb.2-1"
+    },
+    "5ac733a45acfc400192630e2": {
+        "id": "5ac733a45acfc400192630e2",
+        "name": "AK-105 Standard Rearsight (6P44 Sb.1-30)",
+        "shortName": "6P44 Sb.1-30"
+    },
+    "5beec9450db83400970084fd": {
+        "id": "5beec9450db83400970084fd",
+        "name": "Izhmash Rearsight base for RPK-16",
+        "shortName": "RPK-16 rear"
+    },
+    "5ba26b17d4351e00367f9bdd": {
+        "id": "5ba26b17d4351e00367f9bdd",
+        "name": "MP7 Flip Up Rearsight",
+        "shortName": "MP7  Rearsight Flip Up"
+    },
+    "5649d9a14bdc2d79388b4580": {
+        "id": "5649d9a14bdc2d79388b4580",
+        "name": "Tactica Tula TT01 Rearsight Weaver Adapter",
+        "shortName": "ТТ01"
+    },
+    "5c471ba12e221602b3137d76": {
+        "id": "5c471ba12e221602b3137d76",
+        "name": "SVDS frontsight",
+        "shortName": "SVDS fs"
+    },
+    "5c18b90d2e2216152142466b": {
+        "id": "5c18b90d2e2216152142466b",
+        "name": " Magpul MBUS Gen.2 Frontsight FDE",
+        "shortName": "MBUS Front"
+    },
+    "5ba26b01d4351e0085325a51": {
+        "id": "5ba26b01d4351e0085325a51",
+        "name": "MP7 Flip Up Frontsight",
+        "shortName": "MP7 Front Flip Up"
+    },
+    "5dfa3d7ac41b2312ea33362a": {
+        "id": "5dfa3d7ac41b2312ea33362a",
+        "name": "KAC Folding micro sight Rear",
+        "shortName": "KAC Rear"
+    },
+    "5ae099925acfc4001a5fc7b3": {
+        "id": "5ae099925acfc4001a5fc7b3",
+        "name": "Mosin Rearsight",
+        "shortName": "Mosin rs."
+    },
+    "5ae30bad5acfc400185c2dc4": {
+        "id": "5ae30bad5acfc400185c2dc4",
+        "name": " Rearsight AR-15 Carry Handle",
+        "shortName": "CarryHandle"
+    },
+    "5ac72e475acfc400180ae6fe": {
+        "id": "5ac72e475acfc400180ae6fe",
+        "name": "AK-74M Standard Rearsight (6P20 Sb.2)",
+        "shortName": "6P20 Sb.2"
+    },
+    "5bc09a30d4351e00367fb7c8": {
+        "id": "5bc09a30d4351e00367fb7c8",
+        "name": " Magpul MBUS Gen.2 Frontsight",
+        "shortName": "MBUS Front"
+    },
+    "5c07b36c0db834002a1259e9": {
+        "id": "5c07b36c0db834002a1259e9",
+        "name": "Meprolight \"Tru Dot Night Sight\" Frontsight for P226",
+        "shortName": "TD NS Fr."
+    },
+    "5894a81786f77427140b8347": {
+        "id": "5894a81786f77427140b8347",
+        "name": "SIG MPX Flip Up Rearsight",
+        "shortName": "SIG Rearsight Flip Up"
+    },
+    "5a6f5d528dc32e00094b97d9": {
+        "id": "5a6f5d528dc32e00094b97d9",
+        "name": "Glock Rear Sight",
+        "shortName": "Glock RS"
+    },
+    "5c17804b2e2216152006c02f": {
+        "id": "5c17804b2e2216152006c02f",
+        "name": "KAC Folding sight Frontsight",
+        "shortName": "KAC Front"
+    },
+    "5fc0fa957283c4046c58147e": {
+        "id": "5fc0fa957283c4046c58147e",
+        "name": "SIG MCX Flip Up sight Rearsight",
+        "shortName": "SIG Rear Flip"
+    },
+    "5bfd4c980db834001b73449d": {
+        "id": "5bfd4c980db834001b73449d",
+        "name": "Mosin carbine Rearsight",
+        "shortName": "Mosin rs."
+    },
+    "5a0f096dfcdbcb0176308b15": {
+        "id": "5a0f096dfcdbcb0176308b15",
+        "name": "AKMP system front sight device",
+        "shortName": "AKMP"
+    },
+    "5d3eb4aba4b93650d64e497d": {
+        "id": "5d3eb4aba4b93650d64e497d",
+        "name": "Five-seveN Standard Rear-sight",
+        "shortName": "57 RS"
+    },
+    "59e8977386f77415a553c453": {
+        "id": "59e8977386f77415a553c453",
+        "name": "AKM / VPO-209 Standard Rearsight",
+        "shortName": "VPO-209"
+    },
+    "57838e1b2459774a256959b1": {
+        "id": "57838e1b2459774a256959b1",
+        "name": "VSS Vintorez Standard Rearsight",
+        "shortName": "VSS Rear"
+    },
+    "57a9b9ce2459770ee926038d": {
+        "id": "57a9b9ce2459770ee926038d",
+        "name": "IzhMash SOK-12 rear sight",
+        "shortName": "SOK12 RS"
+    },
+    "55d4af3a4bdc2d972f8b456f": {
+        "id": "55d4af3a4bdc2d972f8b456f",
+        "name": " UTG Low Profile A2 Frontsight AR-15",
+        "shortName": "LPA2F"
+    },
+    "5fc0fa362770a0045c59c677": {
+        "id": "5fc0fa362770a0045c59c677",
+        "name": "SIG MCX Folding sight Frontsight",
+        "shortName": "SIG Front"
+    },
+    "5cadd919ae921500126a77f3": {
+        "id": "5cadd919ae921500126a77f3",
+        "name": "M9A3 Standard Frontsight",
+        "shortName": "M9A3 FR"
+    },
+    "58272b842459774abc128d50": {
+        "id": "58272b842459774abc128d50",
+        "name": "SOK-12 CSS SIGHT RAIL MOUNT rear sight",
+        "shortName": "CSS-SRM-L"
+    },
+    "55d5f46a4bdc2d1b198b4567": {
+        "id": "55d5f46a4bdc2d1b198b4567",
+        "name": "Colt A2 Rearsight AR-15",
+        "shortName": "CA2R"
+    },
+    "599860e986f7743bb57573a6": {
+        "id": "599860e986f7743bb57573a6",
+        "name": "Izhmash rear sight fro PP-19-01",
+        "shortName": "Rear sight PP-19-01"
+    },
+    "5de8fb539f98ac2bc659513a": {
+        "id": "5de8fb539f98ac2bc659513a",
+        "name": "B&T MP9 Standard Rear-sight",
+        "shortName": "MP9 RS"
+    },
+    "5a0eb980fcdbcb001a3b00a6": {
+        "id": "5a0eb980fcdbcb001a3b00a6",
+        "name": "AKMB system rear sight",
+        "shortName": "AKMB"
+    },
+    "5ae099875acfc4001714e593": {
+        "id": "5ae099875acfc4001714e593",
+        "name": "Mosin frontsight",
+        "shortName": "Mosin fs"
+    },
+    "5a71e0048dc32e000c52ecc8": {
+        "id": "5a71e0048dc32e000c52ecc8",
+        "name": "Glock ZEV Tech front sight",
+        "shortName": "G FS ZT"
+    },
+    "5cadd954ae921500103bb3c2": {
+        "id": "5cadd954ae921500103bb3c2",
+        "name": "Sight Mount M9 rear sight bearing",
+        "shortName": "SM M9"
+    },
+    "5d3eb536a4b9363b1f22f8e2": {
+        "id": "5d3eb536a4b9363b1f22f8e2",
+        "name": "Five-seveN MK2 Standard Frontsight",
+        "shortName": "57 FS"
+    },
+    "5a6f58f68dc32e000a311390": {
+        "id": "5a6f58f68dc32e000a311390",
+        "name": "Glock Front Sight",
+        "shortName": "Glock FS"
+    },
+    "5dfa3d950dee1b22f862eae0": {
+        "id": "5dfa3d950dee1b22f862eae0",
+        "name": "KAC Folding micro sight Frontsight",
+        "shortName": "KAC Front"
+    },
+    "5aba62f8d8ce87001943946b": {
+        "id": "5aba62f8d8ce87001943946b",
+        "name": "APS Frontsight",
+        "shortName": "APS FS"
+    },
+    "56ea7293d2720b8d4b8b45ba": {
+        "id": "56ea7293d2720b8d4b8b45ba",
+        "name": "Sight Mount Sig 220-239 rear sight bearing",
+        "shortName": "SM220-239"
+    },
+    "5894a73486f77426d259076c": {
+        "id": "5894a73486f77426d259076c",
+        "name": "SIG MPX Flip Up Frontsight",
+        "shortName": "SIG Front Flip Up"
+    },
+    "5c05295e0db834001a66acbb": {
+        "id": "5c05295e0db834001a66acbb",
+        "name": "Trijicon ACOG backup rear sight",
+        "shortName": "Trij.Bck-up"
+    },
+    "56d5a77ed2720b90418b4568": {
+        "id": "56d5a77ed2720b90418b4568",
+        "name": "Sig Sauer P226 Standard Rearsight",
+        "shortName": "Sig #8R"
+    },
+    "5c18b9192e2216398b5a8104": {
+        "id": "5c18b9192e2216398b5a8104",
+        "name": " Magpul MBUS Gen.2 Rearsight FDE",
+        "shortName": "MBUS Rearsight"
+    },
+    "5bb20e49d4351e3bac1212de": {
+        "id": "5bb20e49d4351e3bac1212de",
+        "name": "HK 416A5 Flip Up Rearsight",
+        "shortName": " 416A5 Rearsight Flip Up"
+    },
+    "574db213245977459a2f3f5d": {
+        "id": "574db213245977459a2f3f5d",
+        "name": "SKS Standard Rearsight",
+        "shortName": "SKS Rear"
+    },
+    "56083e1b4bdc2dc8488b4572": {
+        "id": "56083e1b4bdc2dc8488b4572",
+        "name": "Izhmash SV-98 Rearsight",
+        "shortName": "SV-98 Rear"
+    },
+    "5649b0544bdc2d1b2b8b458a": {
+        "id": "5649b0544bdc2d1b2b8b458a",
+        "name": "AK-74 Standard Rearsight (6P1 Sb.2)",
+        "shortName": "6P1 Sb.2"
+    },
+    "5c471b7e2e2216152006e46c": {
+        "id": "5c471b7e2e2216152006e46c",
+        "name": "SVDS Rearsight",
+        "shortName": "SVDS rs."
+    },
+    "5aba637ad8ce87001773e17f": {
+        "id": "5aba637ad8ce87001773e17f",
+        "name": "APS Rearsight",
+        "shortName": "APS RS"
+    },
+    "57c44e7b2459772d28133248": {
+        "id": "57c44e7b2459772d28133248",
+        "name": "AS VAL Standard rear sight",
+        "shortName": "AS VAL rear sight"
+    },
+    "5caf1691ae92152ac412efb9": {
+        "id": "5caf1691ae92152ac412efb9",
+        "name": " Rearsight ASh-12 Carry Handle",
+        "shortName": "ASh-12 Carry"
+    },
+    "5a0ed824fcdbcb0176308b0d": {
+        "id": "5a0ed824fcdbcb0176308b0d",
+        "name": "AKMP system rear sight device",
+        "shortName": "AKMP"
+    },
+    "56d5a661d2720bd8418b456b": {
+        "id": "56d5a661d2720bd8418b456b",
+        "name": "Sig Sauer Standard Frontsight",
+        "shortName": "Sig #8FR"
+    },
+    "5cadd940ae9215051e1c2316": {
+        "id": "5cadd940ae9215051e1c2316",
+        "name": "Beretta M9A3 Standard Rearsight",
+        "shortName": "M9A3 RS"
+    },
+    "5a7d912f159bd400165484f3": {
+        "id": "5a7d912f159bd400165484f3",
+        "name": "Truglo TFX Glock rear sight",
+        "shortName": "TFX"
+    },
+    "5caf16a2ae92152ac412efbc": {
+        "id": "5caf16a2ae92152ac412efbc",
+        "name": "ASh-12 Folding sight Frontsight",
+        "shortName": "ASh-12 Front"
+    },
+    "5a71e0fb8dc32e00094b97f2": {
+        "id": "5a71e0fb8dc32e00094b97f2",
+        "name": "Glock ZEV Tech Rear sight",
+        "shortName": "G RS ZT"
+    },
+    "5aba639ed8ce8700182ece67": {
+        "id": "5aba639ed8ce8700182ece67",
+        "name": "APB Rearsight",
+        "shortName": "APB RS"
+    },
+    "5bc09a18d4351e003562b68e": {
+        "id": "5bc09a18d4351e003562b68e",
+        "name": " Magpul MBUS Gen.2 Rearsight",
+        "shortName": "MBUS Rearsight"
+    },
+    "5926d2be86f774134d668e4e": {
+        "id": "5926d2be86f774134d668e4e",
+        "name": "HK MP5 Drum Rearsight",
+        "shortName": "MP5 Drum Rearsight"
+    },
+    "5b0bc22d5acfc47a8607f085": {
+        "id": "5b0bc22d5acfc47a8607f085",
+        "name": "DS Arms Holland Type Rearsight for SA-58",
+        "shortName": "Holland Type"
+    },
+    "5e8708d4ae379e67d22e0102": {
+        "id": "5e8708d4ae379e67d22e0102",
+        "name": "Ghost ring kit M590 Frontsight",
+        "shortName": "GR FS"
+    },
+    "5a7d90eb159bd400165484f1": {
+        "id": "5a7d90eb159bd400165484f1",
+        "name": "Dead Ringer Snake Eye Glock front sight",
+        "shortName": "Glock SE"
+    },
+    "5a7d9104159bd400134c8c21": {
+        "id": "5a7d9104159bd400134c8c21",
+        "name": "Truglo TFX Glock front sight",
+        "shortName": "Glock TFX"
+    },
+    "5addba3e5acfc4001669f0ab": {
+        "id": "5addba3e5acfc4001669f0ab",
+        "name": " SA National Match .062 blade Frontsight M1A",
+        "shortName": ".062 blade"
+    },
+    "5aafa49ae5b5b00015042a58": {
+        "id": "5aafa49ae5b5b00015042a58",
+        "name": " SA XS Post .125 blade Frontsight M1A",
+        "shortName": " .125 blade"
+    },
+    "5e87114fe2db31558c75a120": {
+        "id": "5e87114fe2db31558c75a120",
+        "name": "Ghost ring Rear sight for M590",
+        "shortName": "GR RS"
+    },
+    "5bf3f59f0db834001a6fa060": {
+        "id": "5bf3f59f0db834001a6fa060",
+        "name": "Izhmash Rearsight for RPK-16",
+        "shortName": "RPK-16 rear"
+    },
+    "5c1780312e221602b66cc189": {
+        "id": "5c1780312e221602b66cc189",
+        "name": "KAC Folding sight Rear",
+        "shortName": "KAC Rear"
+    },
+    "5a7d9122159bd4001438dbf4": {
+        "id": "5a7d9122159bd4001438dbf4",
+        "name": "Dead Ringer Snake Eye Glock rear sight",
+        "shortName": "Glock SE"
+    },
+    "5abcbb20d8ce87001773e258": {
+        "id": "5abcbb20d8ce87001773e258",
+        "name": "M14 Enlarged Military Aperture Rearsight ",
+        "shortName": "M14 135"
+    },
+    "5e81ee4dcb2b95385c177582": {
+        "id": "5e81ee4dcb2b95385c177582",
+        "name": "M1911A1 Rear Sight",
+        "shortName": "M1911A1 RS"
+    },
+    "5c07b3850db834002330045b": {
+        "id": "5c07b3850db834002330045b",
+        "name": "Meprolight Tru Dot Night Sight rear sight for P226",
+        "shortName": "TD NS Re."
+    },
+    "5e81ee213397a21db957f6a6": {
+        "id": "5e81ee213397a21db957f6a6",
+        "name": "M1911A1 Front Sight",
+        "shortName": "M1911A1 FS"
+    },
+    "5f3e78a7fbf956000b716b8e": {
+        "id": "5f3e78a7fbf956000b716b8e",
+        "name": "Novak Lomount Front Sight",
+        "shortName": "Lomount FS"
+    },
+    "5f3e7897ddc4f03b010e204a": {
+        "id": "5f3e7897ddc4f03b010e204a",
+        "name": "Novak Lomount Rear Sight",
+        "shortName": "Lomount RS"
+    },
+    "5fb6567747ce63734e3fa1dc": {
+        "id": "5fb6567747ce63734e3fa1dc",
+        "name": "Kriss \"Defiance Low Profile Flip Up\" Frontsight",
+        "shortName": "Defiance Front"
+    },
+    "5fb6564947ce63734e3fa1da": {
+        "id": "5fb6564947ce63734e3fa1da",
+        "name": "KRISS Defiance Low Profile Flip-Up rear sight",
+        "shortName": "Defiance Rearsight"
+    },
+    "5dfe6104585a0c3e995c7b82": {
+        "id": "5dfe6104585a0c3e995c7b82",
+        "name": "NcSTAR ADO P4 Sniper 3-9x42 riflescope",
+        "shortName": "ADO P4"
+    },
+    "5b3f7c1c5acfc40dc5296b1d": {
+        "id": "5b3f7c1c5acfc40dc5296b1d",
+        "name": "PU 3.5x riflescope",
+        "shortName": "PU 3.5x"
+    },
+    "576fd4ec2459777f0b518431": {
+        "id": "576fd4ec2459777f0b518431",
+        "name": "Zenit-Belomo PSO 1M2-1 4x24 scope",
+        "shortName": "PSO 1M2-1"
+    },
+    "5c82343a2e221644f31c0611": {
+        "id": "5c82343a2e221644f31c0611",
+        "name": "Zenit-Belomo PSO 1M2 4x24 scope",
+        "shortName": "PSO 1M2"
+    },
+    "5dff772da3651922b360bf91": {
+        "id": "5dff772da3651922b360bf91",
+        "name": "VOMZ Pilad 4x32 riflescope",
+        "shortName": "Pilad 4x32"
+    },
+    "5b2388675acfc4771e1be0be": {
+        "id": "5b2388675acfc4771e1be0be",
+        "name": "Burris FullField TAC 30 1-4x24 riflescope",
+        "shortName": "TAC 30"
+    },
+    "5b3b99475acfc432ff4dcbee": {
+        "id": "5b3b99475acfc432ff4dcbee",
+        "name": "EOtech Vudu 1-6 riflescope",
+        "shortName": "1-6x24"
+    },
+    "5a37cb10c4a282329a73b4e7": {
+        "id": "5a37cb10c4a282329a73b4e7",
+        "name": "Leupold Mark 4 LR 6.5-20x50 riflescope",
+        "shortName": "6.5-20x50"
+    },
+    "57c5ac0824597754771e88a9": {
+        "id": "57c5ac0824597754771e88a9",
+        "name": "Optical scope March Tactical 3-24x42 FFP",
+        "shortName": "3-24x42"
+    },
+    "5d53f4b7a4b936793d58c780": {
+        "id": "5d53f4b7a4b936793d58c780",
+        "name": "PAG-17 scope",
+        "shortName": "PAG-17"
+    },
+    "5c82342f2e221644f31c060e": {
+        "id": "5c82342f2e221644f31c060e",
+        "name": "Zenit-Belomo PSO 1 4x24 scope",
+        "shortName": "PSO 1"
+    },
+    "56ea70acd2720b844b8b4594": {
+        "id": "56ea70acd2720b844b8b4594",
+        "name": "Hensoldt FF 4-16x56 scope",
+        "shortName": "FF 4-16"
+    },
+    "5aa66be6e5b5b0214e506e97": {
+        "id": "5aa66be6e5b5b0214e506e97",
+        "name": "Nightforce ATACR 7-35x56 riflescope",
+        "shortName": "NF 7-35x56"
+    },
+    "5d0a3a58d7ad1a669c15ca14": {
+        "id": "5d0a3a58d7ad1a669c15ca14",
+        "name": "KMZ 1P59 3-10x riflescope",
+        "shortName": "1P59"
+    },
+    "5d0a3e8cd7ad1a6f6a3d35bd": {
+        "id": "5d0a3e8cd7ad1a6f6a3d35bd",
+        "name": "KMZ 1P69 3-10x riflescope",
+        "shortName": "1P69"
+    },
+    "5cf638cbd7f00c06595bc936": {
+        "id": "5cf638cbd7f00c06595bc936",
+        "name": "NPZ USP-1 4x scope",
+        "shortName": "USP-1"
+    },
+    "5c0696830db834001d23f5da": {
+        "id": "5c0696830db834001d23f5da",
+        "name": "PNV-10T Night Vision",
+        "shortName": "PNV-10T"
+    },
+    "5c066e3a0db834001b7353f0": {
+        "id": "5c066e3a0db834001b7353f0",
+        "name": "Armasight N-15 Night Vision",
+        "shortName": "N-15"
+    },
+    "5c0558060db834001b735271": {
+        "id": "5c0558060db834001b735271",
+        "name": "GPNVG-18 Night Vision",
+        "shortName": "GPNVG-18"
+    },
+    "57235b6f24597759bf5a30f1": {
+        "id": "57235b6f24597759bf5a30f1",
+        "name": "AN/PVS-14 Night Vision Monocular",
+        "shortName": "PVS-14"
+    },
+    "5c110624d174af029e69734c": {
+        "id": "5c110624d174af029e69734c",
+        "name": "T-7 Thermal Goggles with Night Vision Mounts",
+        "shortName": "T-7"
+    },
+    "5a2c3a9486f774688b05e574": {
+        "id": "5a2c3a9486f774688b05e574"
+    },
+    "5d21f59b6dbe99052b54ef83": {
+        "id": "5d21f59b6dbe99052b54ef83"
+    },
+    "5d1b5e94d7ad1a2b865a96b0": {
+        "id": "5d1b5e94d7ad1a2b865a96b0",
+        "name": "FLIR RS-32 2.25-9x 35mm 60Hz thermal riflescope",
+        "shortName": "RS-32"
+    },
+    "5b3b6e495acfc4330140bd88": {
+        "id": "5b3b6e495acfc4330140bd88",
+        "name": "Vulcan MG night scope 3.5x",
+        "shortName": "Vulcan MG 3.5x"
+    },
+    "5a1eaa87fcdbcb001865f75e": {
+        "id": "5a1eaa87fcdbcb001865f75e",
+        "name": "Trijicon REAP-IR thermal riflescope",
+        "shortName": "REAP-IR"
+    },
+    "5a7c74b3e899ef0014332c29": {
+        "id": "5a7c74b3e899ef0014332c29",
+        "name": "NSPU-M night Scope",
+        "shortName": "NSPU-M"
+    },
+    "55818aeb4bdc2ddc698b456a": {
+        "id": "55818aeb4bdc2ddc698b456a",
+        "name": "Special scope",
+        "shortName": "Item"
+    },
+    "55818acf4bdc2dde698b456b": {
+        "id": "55818acf4bdc2dde698b456b",
+        "name": "Compact reflex sight",
+        "shortName": "Item"
+    },
+    "55818ac54bdc2d5b648b456e": {
+        "id": "55818ac54bdc2d5b648b456e",
+        "name": "Ironsight",
+        "shortName": "Item"
+    },
+    "55818add4bdc2d5b648b456f": {
+        "id": "55818add4bdc2d5b648b456f",
+        "name": "Assault scope",
+        "shortName": "Item"
+    },
+    "55818ad54bdc2ddc698b4569": {
+        "id": "55818ad54bdc2ddc698b4569",
+        "name": "Reflex sight",
+        "shortName": "Item"
+    },
+    "55818ae44bdc2dde698b456c": {
+        "id": "55818ae44bdc2dde698b456c",
+        "name": "Scope",
+        "shortName": "Item"
+    },
+    "57fd23e32459772d0805bcf1": {
+        "id": "57fd23e32459772d0805bcf1",
+        "name": "Holosun LS321 Tactical device",
+        "shortName": "LS321"
+    },
+    "5b07dd285acfc4001754240d": {
+        "id": "5b07dd285acfc4001754240d",
+        "name": "LAS/TAC 2 tactical flashlight",
+        "shortName": "LAS/TAC 2"
+    },
+    "560d657b4bdc2da74d8b4572": {
+        "id": "560d657b4bdc2da74d8b4572",
+        "name": "Zenit 2P Klesch flashlight + laser designator",
+        "shortName": "Klesch"
+    },
+    "5a5f1ce64f39f90b401987bc": {
+        "id": "5a5f1ce64f39f90b401987bc",
+        "name": "Zenit 2IRS Klesch flashlight + laser designator",
+        "shortName": "2IRS"
+    },
+    "5cc9c20cd7f00c001336c65d": {
+        "id": "5cc9c20cd7f00c001336c65d",
+        "name": "NcSTAR Tactical blue laser LAM-Module",
+        "shortName": "TBL"
+    },
+    "5a800961159bd4315e3a1657": {
+        "id": "5a800961159bd4315e3a1657",
+        "name": "Glock Tactical GL21 flashlight with laser",
+        "shortName": "GL21"
+    },
+    "5c06595c0db834001a66af6c": {
+        "id": "5c06595c0db834001a66af6c",
+        "name": "LA-5 tactical device",
+        "shortName": "LA-5"
+    },
+    "5d2369418abbc306c62e0c80": {
+        "id": "5d2369418abbc306c62e0c80",
+        "name": "Steiner Dbal PL tactical flashlight",
+        "shortName": "Dbal PL"
+    },
+    "56def37dd2720bec348b456a": {
+        "id": "56def37dd2720bec348b456a",
+        "name": "X400 tactical flashlight",
+        "shortName": "X400"
+    },
+    "5a7b483fe899ef0016170d15": {
+        "id": "5a7b483fe899ef0016170d15",
+        "name": "Surefire XC1 tactical flashlight",
+        "shortName": "XC1"
+    },
+    "5c5952732e2216398b5abda2": {
+        "id": "5c5952732e2216398b5abda2",
+        "name": "Zenit Perst-3 tactical device",
+        "shortName": "Perst-3"
+    },
+    "5c079ed60db834001a66b372": {
+        "id": "5c079ed60db834001a66b372",
+        "name": "DLP \"Tactical Precision\" LAM Module for TT Pistol",
+        "shortName": "Precision"
+    },
+    "544909bb4bdc2d6f028b4577": {
+        "id": "544909bb4bdc2d6f028b4577",
+        "name": "AN/PEQ-15 tactical device",
+        "shortName": "AN/PEQ-15"
+    },
+    "5d10b49bd7ad1a1a560708b0": {
+        "id": "5d10b49bd7ad1a1a560708b0",
+        "name": "AN/PEQ-2 tactical device",
+        "shortName": "AN/PEQ-2"
+    },
+    "5b3a337e5acfc4704b4a19a0": {
+        "id": "5b3a337e5acfc4704b4a19a0",
+        "name": "Zenit 2U Klesch tactical flashlight",
+        "shortName": "2U"
+    },
+    "5e81c6a2ac2bb513793cdc7f": {
+        "id": "5e81c6a2ac2bb513793cdc7f",
+        "name": "Trigger for M1911A1",
+        "shortName": "M1911A1 Trig."
+    },
+    "5e81c550763d9f754677befd": {
+        "id": "5e81c550763d9f754677befd",
+        "name": "Hammer for M1911A1",
+        "shortName": "M1911A1 Ham."
+    },
+    "5ef32e4d1c1fd62aea6a150d": {
+        "id": "5ef32e4d1c1fd62aea6a150d",
+        "name": "Caspian Trik Trigger for M1911A1",
+        "shortName": "Trik"
+    },
+    "5e81c539cb2b95385c177553": {
+        "id": "5e81c539cb2b95385c177553",
+        "name": "Slide lock for M1911A1",
+        "shortName": "M1911A1 Catch"
+    },
+    "5f3e777688ca2d00ad199d25": {
+        "id": "5f3e777688ca2d00ad199d25",
+        "name": "Slide lock for M45A1",
+        "shortName": "M45A1 Catch"
+    },
+    "5ef3553c43cb350a955a7ccb": {
+        "id": "5ef3553c43cb350a955a7ccb",
+        "name": "Wilson Extended slide stop for M1911A1",
+        "shortName": "Wilson Ext."
+    },
+    "5f3e76d86cda304dcc634054": {
+        "id": "5f3e76d86cda304dcc634054",
+        "name": "Hammer for M45A1",
+        "shortName": "M45A1 Ham."
+    },
+    "5ef35f46382a846010715a96": {
+        "id": "5ef35f46382a846010715a96",
+        "name": "STI HEX Hammer for M1911A1",
+        "shortName": "HEX Ham."
+    },
+    "5ef35d2ac64c5d0dfc0571b0": {
+        "id": "5ef35d2ac64c5d0dfc0571b0",
+        "name": "Hammer for M1911A1",
+        "shortName": "M1911A1 Ham."
+    },
+    "5ef35bc243cb350a955a7ccd": {
+        "id": "5ef35bc243cb350a955a7ccd",
+        "name": "Wilson Ultralight skeletonized hammer for M1911A1",
+        "shortName": "US Ham."
+    },
+    "5cf639aad7f00c065703d455": {
+        "id": "5cf639aad7f00c065703d455",
+        "name": "USP-1 scope eyecup",
+        "shortName": "USP-1 eyecup"
+    },
+    "5d0b5cd3d7ad1a3fe32ad263": {
+        "id": "5d0b5cd3d7ad1a3fe32ad263",
+        "name": "1P59 scope eyecup",
+        "shortName": "1P59 eyecup"
+    },
+    "5bfe86bd0db83400232fe959": {
+        "id": "5bfe86bd0db83400232fe959",
+        "name": "AGR-870 protection cap",
+        "shortName": "AGR-870 cap"
+    },
+    "591c4e1186f77410354b316e": {
+        "id": "591c4e1186f77410354b316e",
+        "name": "Cobra family sights shade",
+        "shortName": "Cobra shade"
+    },
+    "5a71e1868dc32e00094b97f3": {
+        "id": "5a71e1868dc32e00094b97f3",
+        "name": "Zev Tech sight mount cap",
+        "shortName": "ZT AP"
+    },
+    "5ba36f85d4351e0085325c81": {
+        "id": "5ba36f85d4351e0085325c81",
+        "name": "NSPU-M scope eyecup",
+        "shortName": "NSPU-M eyecup"
+    },
+    "57f3a5ae2459772b0e0bf19e": {
+        "id": "57f3a5ae2459772b0e0bf19e",
+        "name": "PSO scope eyecup",
+        "shortName": "PSO eyecup"
+    },
+    "5a1eacb3fcdbcb09800872be": {
+        "id": "5a1eacb3fcdbcb09800872be",
+        "name": "REAP-IR scope eyecup",
+        "shortName": "REAP-IR eyecup"
+    },
+    "56083eab4bdc2d26448b456a": {
+        "id": "56083eab4bdc2d26448b456a",
+        "name": "SV-98 anti-heat ribbon",
+        "shortName": "SV-98 HR"
+    },
+    "5c4eecde2e221602b3140418": {
+        "id": "5c4eecde2e221602b3140418",
+        "name": "Heat shield for SV-98 silencer",
+        "shortName": "SV-98 HS"
+    },
+    "5d123b7dd7ad1a004f01b262": {
+        "id": "5d123b7dd7ad1a004f01b262",
+        "name": "KAC stopper panel for URX 3/3.1",
+        "shortName": "KAC stoper"
+    },
+    "5d124c1ad7ad1a12227c53a7": {
+        "id": "5d124c1ad7ad1a12227c53a7",
+        "name": "KAC stopper panel for URX 3/3.1 FDE",
+        "shortName": "KAC stoper"
+    },
+    "5d123b70d7ad1a0ee35e0754": {
+        "id": "5d123b70d7ad1a0ee35e0754",
+        "name": "KAC long panel for URX 3/3.1",
+        "shortName": "KAC Long"
+    },
+    "5d124c0ed7ad1a10d168dd9b": {
+        "id": "5d124c0ed7ad1a10d168dd9b",
+        "name": "KAC long panel for URX 3/3.1 FDE",
+        "shortName": "KAC Long"
+    },
+    "5d123a3cd7ad1a004e476058": {
+        "id": "5d123a3cd7ad1a004e476058",
+        "name": "KAC short panel for URX 3/3.1",
+        "shortName": "KAC short"
+    },
+    "5d124c01d7ad1a115c7d59fb": {
+        "id": "5d124c01d7ad1a115c7d59fb",
+        "name": "KAC short panel for URX 3/3.1 FDE",
+        "shortName": "KAC short"
+    },
+    "5b3cbc235acfc4001863ac44": {
+        "id": "5b3cbc235acfc4001863ac44",
+        "name": "Vulcan MG scope eyecup",
+        "shortName": "Vulcan MG eyecup"
+    },
+    "5f3e772a670e2a7b01739a52": {
+        "id": "5f3e772a670e2a7b01739a52",
+        "name": "Trigger for M45A1",
+        "shortName": "M45A1 Trig."
+    },
+    "55818afb4bdc2dde698b456d": {
+        "id": "55818afb4bdc2dde698b456d",
+        "name": "Bipod",
+        "shortName": "Item"
+    },
+    "55818b0e4bdc2dde698b456e": {
+        "id": "55818b0e4bdc2dde698b456e",
+        "name": "Laser designator",
+        "shortName": "Item"
+    },
+    "55818b164bdc2ddc698b456c": {
+        "id": "55818b164bdc2ddc698b456c",
+        "name": "Comb. tact. device",
+        "shortName": "Item"
+    },
+    "55818b084bdc2d5b648b4571": {
+        "id": "55818b084bdc2d5b648b4571",
+        "name": "Flashlight",
+        "shortName": "Item"
+    },
+    "55818af64bdc2d5b648b4570": {
+        "id": "55818af64bdc2d5b648b4570",
+        "name": "Foregrip",
+        "shortName": "Item"
+    },
+    "55818b1d4bdc2d5b648b4572": {
+        "id": "55818b1d4bdc2d5b648b4572",
+        "name": "Rail covers",
+        "shortName": "Item"
+    },
+    "56ea9461d2720b67698b456f": {
+        "id": "56ea9461d2720b67698b456f",
+        "name": "Gas block",
+        "shortName": "Item"
+    },
+    "5a74651486f7744e73386dd1": {
+        "id": "5a74651486f7744e73386dd1"
+    },
+    "5448fe394bdc2d0d028b456c": {
+        "id": "5448fe394bdc2d0d028b456c",
+        "name": "Muzzle device",
+        "shortName": "Item"
+    },
+    "5448fe7a4bdc2d6f028b456b": {
+        "id": "5448fe7a4bdc2d6f028b456b",
+        "name": "Sights",
+        "shortName": "Item"
+    },
+    "5bb20dbcd4351e44f824c04e": {
+        "id": "5bb20dbcd4351e44f824c04e",
+        "name": "HK Extended latch Charging Handle",
+        "shortName": "Extended latch"
+    },
+    "56ea7165d2720b6e518b4583": {
+        "id": "56ea7165d2720b6e518b4583",
+        "name": "Badger Ordnance Tactical Charging Handle Latch ",
+        "shortName": "BOTL"
+    },
+    "5c0faf68d174af02a96260b8": {
+        "id": "5c0faf68d174af02a96260b8",
+        "name": "ADAR 2-15 charging handle for AR-15",
+        "shortName": "ADAR 2-15 Charge"
+    },
+    "55d44fd14bdc2d962f8b456e": {
+        "id": "55d44fd14bdc2d962f8b456e",
+        "name": " Colt AR-15 charging handle for AR-15",
+        "shortName": "AR-15 Charge"
+    },
+    "5d2f2d5748f03572ec0c0139": {
+        "id": "5d2f2d5748f03572ec0c0139",
+        "name": "MP5 Kurz Cocking Handle",
+        "shortName": "MP5k hnd."
+    },
+    "5926c32286f774616e42de99": {
+        "id": "5926c32286f774616e42de99",
+        "name": "MP5 Cocking Handle",
+        "shortName": "MP5 Cocking"
+    },
+    "5cc6ea78e4a949000e1ea3c1": {
+        "id": "5cc6ea78e4a949000e1ea3c1",
+        "name": "FN charge handle for P90",
+        "shortName": "FN Chrg."
+    },
+    "58949fac86f77409483e16aa": {
+        "id": "58949fac86f77409483e16aa",
+        "name": "SIG single latch charging handle for MPX",
+        "shortName": "MPX Charge"
+    },
+    "5cc6ea85e4a949000e1ea3c3": {
+        "id": "5cc6ea85e4a949000e1ea3c3",
+        "name": "K&M The Handler charge handle for P90",
+        "shortName": "Handler"
+    },
+    "5df8e085bb49d91fb446d6a8": {
+        "id": "5df8e085bb49d91fb446d6a8",
+        "name": "KAC Ambidextrous Charging Handle for AR-10",
+        "shortName": "Ambi SR-25"
+    },
+    "5df8e053bb49d91fb446d6a6": {
+        "id": "5df8e053bb49d91fb446d6a6",
+        "name": "KAC Charging Handle for SR-25",
+        "shortName": "SR-25 Chrg."
+    },
+    "5de922d4b11454561e39239f": {
+        "id": "5de922d4b11454561e39239f",
+        "name": "B&T charging handle for MP9",
+        "shortName": "MP9 Chr."
+    },
+    "5648ac824bdc2ded0b8b457d": {
+        "id": "5648ac824bdc2ded0b8b457d",
+        "name": "Zenit RP-1 charge handle for AK",
+        "shortName": "RP-1"
+    },
+    "5ea16d4d5aad6446a939753d": {
+        "id": "5ea16d4d5aad6446a939753d",
+        "name": "Geissele ACH charging handle for AR-15",
+        "shortName": "ACH"
+    },
+    "5b2240bf5acfc40dc528af69": {
+        "id": "5b2240bf5acfc40dc528af69",
+        "name": "Raptor charging handle for AR-15",
+        "shortName": "Raptor Charge"
+    },
+    "5d44334ba4b9362b346d1948": {
+        "id": "5d44334ba4b9362b346d1948",
+        "name": "Raptor charging handle for AR-15 Grey",
+        "shortName": "Raptor grey"
+    },
+    "5c5db6b32e221600102611a0": {
+        "id": "5c5db6b32e221600102611a0",
+        "name": "Geissele \"SCH\" charging handle for MPX",
+        "shortName": "SCH Charge"
+    },
+    "5f633ff5c444ce7e3c30a006": {
+        "id": "5f633ff5c444ce7e3c30a006",
+        "name": "Avalanche Mod.2 charging handle for AR-15",
+        "shortName": "AR-15 Charge"
+    },
+    "5fbcc640016cce60e8341acc": {
+        "id": "5fbcc640016cce60e8341acc",
+        "name": "Sig-Sauer charging handle for MCX",
+        "shortName": "MCX Chr."
+    },
+    "58949edd86f77409483e16a9": {
+        "id": "58949edd86f77409483e16a9",
+        "name": "SIG double latch charging handle for MPX",
+        "shortName": "MPX Charge"
+    },
+    "5648b62b4bdc2d9d488b4585": {
+        "id": "5648b62b4bdc2d9d488b4585",
+        "name": "GP-34 underbarrel grenade launcher",
+        "shortName": "GP-34"
+    },
+    "5448c12b4bdc2d02308b456f": {
+        "id": "5448c12b4bdc2d02308b456f",
+        "name": "90-93 9x18PM Magazine, for 8 PM rounds",
+        "shortName": "PM 90-93"
+    },
+    "55d484b44bdc2d1d4e8b456d": {
+        "id": "55d484b44bdc2d1d4e8b456d",
+        "name": "6-shell MP-133x6 12ga magazine",
+        "shortName": "MP-133x6"
+    },
+    "56deee15d2720bee328b4567": {
+        "id": "56deee15d2720bee328b4567",
+        "name": "МP-153 forend cap",
+        "shortName": "МP153x4"
+    },
+    "5ba2657ed4351e0035628ff2": {
+        "id": "5ba2657ed4351e0035628ff2",
+        "name": "Standard MP7 30-round 4.6x30 magazine",
+        "shortName": "MP7 30"
+    },
+    "5ba264f6d4351e0034777d52": {
+        "id": "5ba264f6d4351e0034777d52",
+        "name": "Standard MP7 20-round 4.6x30 magazine",
+        "shortName": "MP7 20"
+    },
+    "55d485be4bdc2d962f8b456f": {
+        "id": "55d485be4bdc2d962f8b456f",
+        "name": "PM/PPSH 9x18PM 84-round drum mag for PM",
+        "shortName": "PM/PPSH"
+    },
+    "5888988e24597752fe43a6fa": {
+        "id": "5888988e24597752fe43a6fa",
+        "name": "10-round .308 DVL-10 magazine",
+        "shortName": "DVL-10"
+    },
+    "5882163224597757561aa920": {
+        "id": "5882163224597757561aa920",
+        "name": "МP-153 7-rd magazine extension",
+        "shortName": "МP153x7"
+    },
+    "59fafc5086f7740dbe19f6c3": {
+        "id": "59fafc5086f7740dbe19f6c3",
+        "name": "Palm US AK30 7.62x39 magazine for AK and compatibles, 30-round capacity (black)",
+        "shortName": "AK30"
+    },
+    "5894a05586f774094708ef75": {
+        "id": "5894a05586f774094708ef75",
+        "name": "Standard MPX 30-round 9x19 magazine",
+        "shortName": "9x19 MPX"
+    },
+    "57616a9e2459773c7a400234": {
+        "id": "57616a9e2459773c7a400234",
+        "name": "Sb.5 5-round 12/76 magazine for SOK-12 and compatible weapons",
+        "shortName": "Sb.5"
+    },
+    "55d485804bdc2d8c2f8b456b": {
+        "id": "55d485804bdc2d8c2f8b456b",
+        "name": "8-shell MP-133x8 12ga magazine",
+        "shortName": "MP-133x8"
+    },
+    "57838f9f2459774a150289a0": {
+        "id": "57838f9f2459774a150289a0",
+        "name": "20-round 6L25 9x39 VSS magazine",
+        "shortName": "6L25"
+    },
+    "5bfea7ad0db834001c38f1ee": {
+        "id": "5bfea7ad0db834001c38f1ee",
+        "name": "5-round .308 M700 magazine",
+        "shortName": "Wyatt 5rnd"
+    },
+    "5882163e24597758206fee8c": {
+        "id": "5882163e24597758206fee8c",
+        "name": "МP-153 5-rd magazine extension",
+        "shortName": "МP153x5"
+    },
+    "56deeefcd2720bc8328b4568": {
+        "id": "56deeefcd2720bc8328b4568",
+        "name": "МP-153 8-rd magazine extension",
+        "shortName": "МP153x8"
+    },
+    "5ba26586d4351e44f824b340": {
+        "id": "5ba26586d4351e44f824b340",
+        "name": "Standard MP7 40-round4.6x30 magazine",
+        "shortName": "MP7 40"
+    },
+    "5926c3b286f774640d189b6b": {
+        "id": "5926c3b286f774640d189b6b",
+        "name": "Standard MP5 30-round 9x19 magazine",
+        "shortName": "9x19 MP5"
+    },
+    "5882163824597757561aa922": {
+        "id": "5882163824597757561aa922",
+        "name": "МP-153 6-rd magazine extension",
+        "shortName": "МP153x6"
+    },
+    "56d59948d2720bb7418b4582": {
+        "id": "56d59948d2720bb7418b4582",
+        "name": "P226 magazine",
+        "shortName": "9x19 P226"
+    },
+    "5bfeaa0f0db834001b734927": {
+        "id": "5bfeaa0f0db834001b734927",
+        "name": "10-round .308 M700 magazine",
+        "shortName": "Wyatt 10rnd"
+    },
+    "5b1fd4e35acfc40018633c39": {
+        "id": "5b1fd4e35acfc40018633c39",
+        "name": "Izhmash 7.62x39 AK aluminium magazine for AK and compatibles, 10-round capacity",
+        "shortName": "AK al. 10"
+    },
+    "544a378f4bdc2d30388b4567": {
+        "id": "544a378f4bdc2d30388b4567",
+        "name": "40-round PMAG GEN M3 40 5.56x45 STANAG magazine",
+        "shortName": "GEN M3 40"
+    },
+    "564ca99c4bdc2d16268b4589": {
+        "id": "564ca99c4bdc2d16268b4589",
+        "name": "6L20 30-round 5.45x39 magazine for АК-74 and compatible weapons",
+        "shortName": "6L20"
+    },
+    "5ac66bea5acfc43b321d4aec": {
+        "id": "5ac66bea5acfc43b321d4aec",
+        "name": "30-round 7.62x39 magazine for АК-103 and compatible weapons",
+        "shortName": "АК-103 Mag"
+    },
+    "571a29dc2459771fb2755a6a": {
+        "id": "571a29dc2459771fb2755a6a",
+        "name": "tt-105 7.62x25 ТТ Magazine",
+        "shortName": "tt-105"
+    },
+    "59e5d83b86f7745aed03d262": {
+        "id": "59e5d83b86f7745aed03d262",
+        "name": "7.62x39 ribbed metal magazine for AK and compatibles, 10-round capacity",
+        "shortName": "AK custom"
+    },
+    "5a718b548dc32e000d46d262": {
+        "id": "5a718b548dc32e000d46d262",
+        "name": "Glock 9x19 magazine",
+        "shortName": "9x19 Glock"
+    },
+    "5a38ed75c4a28232996e40c6": {
+        "id": "5a38ed75c4a28232996e40c6",
+        "name": "4-shot MC 20-01 Sb.3 20ga magazine for TOZ-106",
+        "shortName": "Sb.3x4"
+    },
+    "5aaa5e60e5b5b000140293d6": {
+        "id": "5aaa5e60e5b5b000140293d6",
+        "name": "PMAG GEN M3 10 5.56x45 STANAG 10-round magazine",
+        "shortName": "GEN M3 10"
+    },
+    "59c1383d86f774290a37e0ca": {
+        "id": "59c1383d86f774290a37e0ca",
+        "name": "Magpul PMAG D-60 5.56x45 60-round magazine",
+        "shortName": "PMAG D-60"
+    },
+    "57838f0b2459774a256959b2": {
+        "id": "57838f0b2459774a256959b2",
+        "name": "10-round 6L24 9x39 VSS magazine",
+        "shortName": "6L24"
+    },
+    "587df3a12459772c28142567": {
+        "id": "587df3a12459772c28142567",
+        "name": "10 rnds. SKS internal box magazine 7.62x39",
+        "shortName": "SKS int."
+    },
+    "55d480c04bdc2d1d4e8b456a": {
+        "id": "55d480c04bdc2d1d4e8b456a",
+        "name": "30-round 6L23 5.45x39 magazine for АК-74 and compatibles",
+        "shortName": "6L23"
+    },
+    "5aaa5dfee5b5b000140293d3": {
+        "id": "5aaa5dfee5b5b000140293d3",
+        "name": "PMAG GEN M3 30 5.56x45 STANAG 30-round magazine",
+        "shortName": "GEN M3 30"
+    },
+    "5bae13ded4351e44f824bf38": {
+        "id": "5bae13ded4351e44f824bf38",
+        "name": "7.62x54r ProMag OPFOR for Archangel Mosin rifle kit, 10-round capacity",
+        "shortName": "AA762R 02"
+    },
+    "5b7bef9c5acfc43d102852ec": {
+        "id": "5b7bef9c5acfc43d102852ec",
+        "name": "X-FAL FAL/SA-58 7.62x51 50 rnd magazine",
+        "shortName": "X-FAL 7.62"
+    },
+    "5b099ac65acfc400186331e1": {
+        "id": "5b099ac65acfc400186331e1",
+        "name": "FAL/SA-58 7.62x51 20 rnd",
+        "shortName": "FAL 20 7.62"
+    },
+    "5ac66c5d5acfc4001718d314": {
+        "id": "5ac66c5d5acfc4001718d314",
+        "name": "6L29 30-round 5.56x45 magazine for АК-101 and compatible weapons",
+        "shortName": "6L29"
+    },
+    "5b7c2d1d5acfc43d1028532a": {
+        "id": "5b7c2d1d5acfc43d1028532a",
+        "name": "FAL/SA-58 \"MMW\" 7.62x51 20 rnd plastic mag",
+        "shortName": "MMW Fal 7.62"
+    },
+    "57d14e1724597714010c3f4b": {
+        "id": "57d14e1724597714010c3f4b",
+        "name": "Standard 9x18PM 20-round magazine for PP-91",
+        "shortName": "PP91 Std"
+    },
+    "5b7bef5d5acfc43bca7067a3": {
+        "id": "5b7bef5d5acfc43bca7067a3",
+        "name": "FAL/SA-58 7.62x51 30 rnd",
+        "shortName": "FAL 30 7.62"
+    },
+    "5a38ee51c4a282000c5a955c": {
+        "id": "5a38ee51c4a282000c5a955c",
+        "name": "2-shot MC 20-01 Sb.3 20ga magazine for ТОZ-106",
+        "shortName": "20-01 Sb.3x2"
+    },
+    "599860ac86f77436b225ed1a": {
+        "id": "599860ac86f77436b225ed1a",
+        "name": "Standard PP-19-01 30-round 9x19 magazine",
+        "shortName": "9x19 PP-19-01"
+    },
+    "5a17fb03fcdbcbcae668728f": {
+        "id": "5a17fb03fcdbcbcae668728f",
+        "name": "Standard APS 9x18PM 20-round magazine",
+        "shortName": "APS std."
+    },
+    "57d1519e24597714373db79d": {
+        "id": "57d1519e24597714373db79d",
+        "name": "Standard 9x18PM 30-round magazine for PP-91",
+        "shortName": "PP91 Std"
+    },
+    "5a718f958dc32e00094b97e7": {
+        "id": "5a718f958dc32e00094b97e7",
+        "name": "SGMT Drum mag for Glock 9x19, 50 rounds capacity",
+        "shortName": "G 50rnd"
+    },
+    "5a966f51a2750c00156aacf6": {
+        "id": "5a966f51a2750c00156aacf6",
+        "name": "SAI-02 10-round 12x76 magazine for SOK-12 and compatible weapons",
+        "shortName": "SAI-02"
+    },
+    "55d4887d4bdc2d962f8b4570": {
+        "id": "55d4887d4bdc2d962f8b4570",
+        "name": "Colt AR-15 5.56x45 STANAG 30-round magazine",
+        "shortName": "STANAG"
+    },
+    "5ae0973a5acfc4001562206c": {
+        "id": "5ae0973a5acfc4001562206c",
+        "name": "Regular 4rnd magazine for Mosin rifle ",
+        "shortName": "Mos.Std."
+    },
+    "55d481904bdc2d8c2f8b456a": {
+        "id": "55d481904bdc2d8c2f8b456a",
+        "name": "45-round 6L26 5.45x39 magazine for АК-74 and compatibles",
+        "shortName": "6L26"
+    },
+    "5a351711c4a282000b1521a4": {
+        "id": "5a351711c4a282000b1521a4",
+        "name": "X Products X-5 MP5 50-round 9x19 magazine",
+        "shortName": "X-5 MP5"
+    },
+    "5addcce35acfc4001a5fc635": {
+        "id": "5addcce35acfc4001a5fc635",
+        "name": "M14 30 round 7.62x51 magazine",
+        "shortName": "M14 30 7.62"
+    },
+    "576a5ed62459771e9c2096cb": {
+        "id": "576a5ed62459771e9c2096cb",
+        "name": "MP-443 9x19 18-round magazine",
+        "shortName": "9x19 MP-443"
+    },
+    "55d482194bdc2d1d4e8b456b": {
+        "id": "55d482194bdc2d1d4e8b456b",
+        "name": "60-round 6L31 5.45x39 magazine for АК-74 and compatibles",
+        "shortName": "6L31"
+    },
+    "5ea034f65aad6446a939737e": {
+        "id": "5ea034f65aad6446a939737e",
+        "name": "71-round 7.62x25 magazine for PPSH-41",
+        "shortName": "71 PPSH"
+    },
+    "5ce69cbad7f00c00b61c5098": {
+        "id": "5ce69cbad7f00c00b61c5098",
+        "name": "Magpul PMAG .308 AC 5-round M700 magazine",
+        "shortName": "PMAG .308 AC"
+    },
+    "564ca9df4bdc2d35148b4569": {
+        "id": "564ca9df4bdc2d35148b4569",
+        "name": "6L18 45-round 5.45x39 magazine for АК-74 and compatible weapons",
+        "shortName": "6L18"
+    },
+    "59d625f086f774661516605d": {
+        "id": "59d625f086f774661516605d",
+        "name": "Izhmash AK magazine (issued ‘55 or later) 30-round for 7.62x39 AK and compatibles",
+        "shortName": "AK55"
+    },
+    "59f99a7d86f7745b134aa97b": {
+        "id": "59f99a7d86f7745b134aa97b",
+        "name": "SR1-MP magazine",
+        "shortName": "9x21 SR1-MP"
+    },
+    "5d25af8f8abbc3055079fec5": {
+        "id": "5d25af8f8abbc3055079fec5",
+        "name": "Promag AA-70 10-round .308 M700 magazine",
+        "shortName": "AA-70 10"
+    },
+    "5c503ac82e221602b21d6e9a": {
+        "id": "5c503ac82e221602b21d6e9a",
+        "name": "7.62x51 metal magazine for VPO-101 and compatibles, 5-round capacity",
+        "shortName": "VPO-101"
+    },
+    "5a9e81fba2750c00164f6b11": {
+        "id": "5a9e81fba2750c00164f6b11",
+        "name": "30-round SR3M.130 9x39 SR3M magazine",
+        "shortName": "SR3M.130"
+    },
+    "544a37c44bdc2d25388b4567": {
+        "id": "544a37c44bdc2d25388b4567",
+        "name": "60-round MAG5-60 5.56x45 STANAG magazine",
+        "shortName": "MAG5-60"
+    },
+    "5df8f541c41b2312ea3335e3": {
+        "id": "5df8f541c41b2312ea3335e3",
+        "name": "KAC Steel 20 7.62x51 20 rnd",
+        "shortName": "KAC 20 7.62"
+    },
+    "5a0060fc86f7745793204432": {
+        "id": "5a0060fc86f7745793204432",
+        "name": "Izhmash 7.62x39 AKMS aluminium magazine for AK and compatibles, 30-round capacity",
+        "shortName": "AKMS al."
+    },
+    "5c6d42cb2e2216000e69d7d1": {
+        "id": "5c6d42cb2e2216000e69d7d1",
+        "name": "HK Polymer mag 30 5.56x45 STANAG 30-round magazine",
+        "shortName": "Polymer mag"
+    },
+    "5a7882dcc5856700177af662": {
+        "id": "5a7882dcc5856700177af662",
+        "name": "4-shell M870 12ga magazine cap",
+        "shortName": "M870x4"
+    },
+    "5c5db6552e2216001026119d": {
+        "id": "5c5db6552e2216001026119d",
+        "name": "Standard MPX 20-round 9x19 magazine",
+        "shortName": "9x19 MPX"
+    },
+    "5d25a6a48abbc306c62e6310": {
+        "id": "5d25a6a48abbc306c62e6310",
+        "name": "12-round .308 MDT AICS M700 magazine",
+        "shortName": "MDT 12rnd"
+    },
+    "5df8f535bb49d91fb446d6b0": {
+        "id": "5df8f535bb49d91fb446d6b0",
+        "name": "KAC Steel 10 7.62x51 10 rnd",
+        "shortName": "KAC 10 7.62"
+    },
+    "5c5970672e221602b21d7855": {
+        "id": "5c5970672e221602b21d7855",
+        "name": "ProMag AALVX 35 7.62x39 35-round SKS magazine.",
+        "shortName": "AALVX 35"
+    },
+    "59fafc9386f774067d462453": {
+        "id": "59fafc9386f774067d462453",
+        "name": "Palm US AK30 7.62x39 magazine for AK and compatibles, 30-round capacity (FDE)",
+        "shortName": "AK30"
+    },
+    "5aaf8a0be5b5b00015693243": {
+        "id": "5aaf8a0be5b5b00015693243",
+        "name": "M1A 20 round 7.62x51 magazine",
+        "shortName": "M1A 20 7.62"
+    },
+    "5c0548ae0db834001966a3c2": {
+        "id": "5c0548ae0db834001966a3c2",
+        "name": "Arsenal CWP 30-round 5.56x45 magazine for SLR-106 and compatible weapons",
+        "shortName": "CWP"
+    },
+    "5cbdaf89ae9215000e5b9c94": {
+        "id": "5cbdaf89ae9215000e5b9c94",
+        "name": "30-round 6L23 Plum 5.45x39 magazine for АК-74 and compatibles",
+        "shortName": "6L23 Plum"
+    },
+    "5bed625c0db834001c062946": {
+        "id": "5bed625c0db834001c062946",
+        "name": "95-round 5.45x39 magazine for RPK-16 and compatibles",
+        "shortName": "RPK-16 std."
+    },
+    "5caf1109ae9215753c44119f": {
+        "id": "5caf1109ae9215753c44119f",
+        "name": "12.7x55 magazine for ASh-12, 20-round capacity",
+        "shortName": "ASh-12"
+    },
+    "5de8eac42a78646d96665d91": {
+        "id": "5de8eac42a78646d96665d91",
+        "name": "Standard 9x19 30-round magazine for MP9",
+        "shortName": "MP9 30"
+    },
+    "5ea034eb5aad6446a939737b": {
+        "id": "5ea034eb5aad6446a939737b",
+        "name": "35-round 7.62x25 magazine for PPSH-41",
+        "shortName": "35 PPSH"
+    },
+    "5de8eaadbbaf010b10528a6d": {
+        "id": "5de8eaadbbaf010b10528a6d",
+        "name": "Standard 9x19 25-round magazine for MP9",
+        "shortName": "MP9 25"
+    },
+    "5cf12a15d7f00c05464b293f": {
+        "id": "5cf12a15d7f00c05464b293f",
+        "name": "Promag AA-70 20-round .308 M700 magazine",
+        "shortName": "AA-70 20"
+    },
+    "5d25a4a98abbc30b917421a4": {
+        "id": "5d25a4a98abbc30b917421a4",
+        "name": "5-round .308 AICS M700 magazine",
+        "shortName": "AICS 5rnd"
+    },
+    "5a01c29586f77474660c694c": {
+        "id": "5a01c29586f77474660c694c",
+        "name": "Izhmash 6L10 7.62x39 magazine for AK and compatibles, 30-round capacity",
+        "shortName": "6L10"
+    },
+    "5de8ea8ffd6b4e6e2276dc35": {
+        "id": "5de8ea8ffd6b4e6e2276dc35",
+        "name": "Standard 9x19 20-round magazine for MP9",
+        "shortName": "MP9 20"
+    },
+    "5b7d37845acfc400170e2f87": {
+        "id": "5b7d37845acfc400170e2f87",
+        "name": "British FAL/L1A1 7.62x51 30 rnd magazine",
+        "shortName": "L1A1 30 7.62"
+    },
+    "5cadc2e0ae9215051e1c21e7": {
+        "id": "5cadc2e0ae9215051e1c21e7",
+        "name": "M9A3 9x19 17-round magazine",
+        "shortName": "9x19 M9A3"
+    },
+    "5cfe8010d7ad1a59283b14c6": {
+        "id": "5cfe8010d7ad1a59283b14c6",
+        "name": "X-47 AK 7.62x39 50 rnd magazine",
+        "shortName": "X-47 7.62"
+    },
+    "5d2f213448f0355009199284": {
+        "id": "5d2f213448f0355009199284",
+        "name": "Standard MP5 20-round 9x19 magazine",
+        "shortName": "9x19 MP5"
+    },
+    "5c88f24b2e22160bc12c69a6": {
+        "id": "5c88f24b2e22160bc12c69a6",
+        "name": "20-round SVD 7.62x54 magazine",
+        "shortName": "SVD 7.62x54"
+    },
+    "5cbdc23eae9215001136a407": {
+        "id": "5cbdc23eae9215001136a407",
+        "name": "Molot magazine for AK and compatibles, 75-round capacity",
+        "shortName": "Molot Drum"
+    },
+    "5cc70093e4a949033c734312": {
+        "id": "5cc70093e4a949033c734312",
+        "name": "FN magazine for P90, 50-round capacity",
+        "shortName": "FN reg."
+    },
+    "5de8e8dafd6b4e6e2276dc32": {
+        "id": "5de8e8dafd6b4e6e2276dc32",
+        "name": "Standard 9x19 15-round magazine for MP9",
+        "shortName": "MP9 15"
+    },
+    "5c5db6742e2216000f1b2852": {
+        "id": "5c5db6742e2216000f1b2852",
+        "name": "F5 MPX Drum mag 50-round 9x19 magazine",
+        "shortName": "MPX Drum"
+    },
+    "5d52d479a4b936793d58c76b": {
+        "id": "5d52d479a4b936793d58c76b",
+        "name": "AGS-30 30-Grenades box 30x29 ",
+        "shortName": "AGS-30"
+    },
+    "5caf1041ae92157c28402e3f": {
+        "id": "5caf1041ae92157c28402e3f",
+        "name": "12.7x55 magazine for ASh-12, 10-round capacity",
+        "shortName": "ASh-12 10rd."
+    },
+    "5c920e902e221644f31c3c99": {
+        "id": "5c920e902e221644f31c3c99",
+        "name": "P226 Extended magazine 9x19",
+        "shortName": "9x19 P226"
+    },
+    "5bed61680db834001d2c45ab": {
+        "id": "5bed61680db834001d2c45ab",
+        "name": "30-round 5.45x39 magazine for АК-12 and compatibles",
+        "shortName": "АК-12 std."
+    },
+    "5d25a6538abbc306c62e630d": {
+        "id": "5d25a6538abbc306c62e630d",
+        "name": "10-round .308 AICS M700 magazine",
+        "shortName": "AICS 10rnd"
+    },
+    "587df583245977373c4f1129": {
+        "id": "587df583245977373c4f1129",
+        "name": "ProMag SKS-A5 7.62x39 20-round SKS magazine.",
+        "shortName": "SKS-A5"
+    },
+    "5c6592372e221600133e47d7": {
+        "id": "5c6592372e221600133e47d7",
+        "name": "100-round MAG5-100 5.56x45 STANAG magazine",
+        "shortName": "MAG5-100"
+    },
+    "5f647d9f8499b57dc40ddb93": {
+        "id": "5f647d9f8499b57dc40ddb93",
+        "name": "3-shell KS-23M 23mm magazine cap",
+        "shortName": "KS-23Mx3"
+    },
+    "5d1340b3d7ad1a0b52682ed7": {
+        "id": "5d1340b3d7ad1a0b52682ed7",
+        "name": "PMAG GEN M3 30 5.56x45 STANAG 30-round magazine",
+        "shortName": "GEN M3 30"
+    },
+    "5e87080c81c4ed43e83cefda": {
+        "id": "5e87080c81c4ed43e83cefda",
+        "name": "8-shell M590A1 12ga magazine cap",
+        "shortName": "M590A1x8"
+    },
+    "5fb651dc85f90547f674b6f4": {
+        "id": "5fb651dc85f90547f674b6f4",
+        "name": "Magex G30 magazine for Glock .45 ACP",
+        "shortName": "Magex G30"
+    },
+    "5c503ad32e2216398b5aada2": {
+        "id": "5c503ad32e2216398b5aada2",
+        "name": "7.62x51 metal magazine for VPO-101 and compatibles, 10-round capacity",
+        "shortName": "VPO-101"
+    },
+    "55802d5f4bdc2dac148b458e": {
+        "id": "55802d5f4bdc2dac148b458e",
+        "name": "PMAG GEN M3 W 30 5.56x45 STANAG 30-round magazine",
+        "shortName": "GEN M3 30"
+    },
+    "59d6272486f77466146386ff": {
+        "id": "59d6272486f77466146386ff",
+        "name": "Pmag 30 AK/AKM GEN M3 7.62x39 magazine for AK and compatibles, 30-round capacity\n",
+        "shortName": "Pmag30 AK/AKM GEN M3"
+    },
+    "5a3501acc4a282000d72293a": {
+        "id": "5a3501acc4a282000d72293a",
+        "name": "PMAG SR/LR GEN M3 20 7.62x51 20 rnd",
+        "shortName": "PMAG 20 7.62"
+    },
+    "5c6d46132e221601da357d56": {
+        "id": "5c6d46132e221601da357d56",
+        "name": "TROY Battlemag 5.56x45 STANAG 30-round magazine",
+        "shortName": "Battlemag"
+    },
+    "5c0672ed0db834001b7353f3": {
+        "id": "5c0672ed0db834001b7353f3",
+        "name": "PUFGUN SG-919 30 30-round 9x19 magazine for PP-19-01",
+        "shortName": "SG-919 30"
+    },
+    "5d1340bdd7ad1a0e8d245aab": {
+        "id": "5d1340bdd7ad1a0e8d245aab",
+        "name": "40-round PMAG GEN M3 FDE 40 5.56x45 STANAG magazine",
+        "shortName": "GEN M3 40 FDE"
+    },
+    "5cffa483d7ad1a049e54ef1c": {
+        "id": "5cffa483d7ad1a049e54ef1c",
+        "name": "100 rounds belt",
+        "shortName": "ammo belt"
+    },
+    "5a718da68dc32e000d46d264": {
+        "id": "5a718da68dc32e000d46d264",
+        "name": "Pmag GL9 polymer magazine",
+        "shortName": "G PMAG 21"
+    },
+    "5c6161fb2e221600113fbde5": {
+        "id": "5c6161fb2e221600113fbde5",
+        "name": "5-shot MC 20-01 Sb.3 20ga magazine for TOZ-106",
+        "shortName": "Sb.3x5"
+    },
+    "5448c1d04bdc2dff2f8b4569": {
+        "id": "5448c1d04bdc2dff2f8b4569",
+        "name": "PMAG GEN M3 20 5.56x45 STANAG 20-round magazine",
+        "shortName": "GEN M3 20"
+    },
+    "59e5f5a486f7746c530b3ce2": {
+        "id": "59e5f5a486f7746c530b3ce2",
+        "name": "Molot 6P2.Sb-11 7.62x39 magazine for AK and compatibles, 40-round capacity",
+        "shortName": "6P2 Sb-11"
+    },
+    "5d25a7b88abbc3054f3e60bc": {
+        "id": "5d25a7b88abbc3054f3e60bc",
+        "name": "Magpul PMAG .308 AC 10-round M700 magazine",
+        "shortName": "PMAG .308 AC"
+    },
+    "5c05413a0db834001c390617": {
+        "id": "5c05413a0db834001c390617",
+        "name": "HK Steel Maritime 5.56x45 STANAG 30-round magazine",
+        "shortName": "HK Steel"
+    },
+    "5aaa4194e5b5b055d06310a5": {
+        "id": "5aaa4194e5b5b055d06310a5",
+        "name": "Pmag 30 AK74 GEN M3 5.45x39 magazine for AK and compatibles, 30-round capacity\r\n",
+        "shortName": "Pmag30 AK74 GEN M3"
+    },
+    "5a78830bc5856700137e4c90": {
+        "id": "5a78830bc5856700137e4c90",
+        "name": "7-shell M870x7 12ga magazine",
+        "shortName": "M870x7"
+    },
+    "5c6175362e221600133e3b94": {
+        "id": "5c6175362e221600133e3b94",
+        "name": "ProMag AK-A-16 73-round 7.62x39 magazine for AKM and compatibles",
+        "shortName": "AK-A-16"
+    },
+    "5fb651b52b1b027b1f50bcff": {
+        "id": "5fb651b52b1b027b1f50bcff",
+        "name": "Glock .45 ACP magazine",
+        "shortName": ".45 Glock"
+    },
+    "5a78832ec5856700155a6ca3": {
+        "id": "5a78832ec5856700155a6ca3",
+        "name": "10-shell M870x10 12ga magazine",
+        "shortName": "M870x10"
+    },
+    "5addccf45acfc400185c2989": {
+        "id": "5addccf45acfc400185c2989",
+        "name": "X-14 M14 50 round 7.62x51 magazine",
+        "shortName": "X-14"
+    },
+    "5b1fb3e15acfc4001637f068": {
+        "id": "5b1fb3e15acfc4001637f068",
+        "name": "Bakelite 7.62x39 magazine for AK and compatibles, 40-round capacity",
+        "shortName": "6P2 Bak"
+    },
+    "5fc3e466187fea44d52eda90": {
+        "id": "5fc3e466187fea44d52eda90",
+        "name": "Standard UMP 25-round .45 ACP magazine",
+        "shortName": "UMP 45"
+    },
+    "5de653abf76fdc1ce94a5a2a": {
+        "id": "5de653abf76fdc1ce94a5a2a",
+        "name": "Metal magazine for VPO-215 and compatibles, .366 TKM 4-round capacity",
+        "shortName": "215 366"
+    },
+    "5c0673fb0db8340023300271": {
+        "id": "5c0673fb0db8340023300271",
+        "name": "PUFGUN SG-919 20 20-round 9x19 magazine for  PP-19-01",
+        "shortName": "SG-919 20"
+    },
+    "55d4837c4bdc2d1d4e8b456c": {
+        "id": "55d4837c4bdc2d1d4e8b456c",
+        "name": "10-round Saiga 545 5.45x39 magazine for АК-74 and compatibles",
+        "shortName": "Saiga 545"
+    },
+    "559ba5b34bdc2d1f1a8b4582": {
+        "id": "559ba5b34bdc2d1f1a8b4582",
+        "name": "10-round polymer magazine 7.62x54R for SV-98",
+        "shortName": "SV-98 polymer"
+    },
+    "5c5db6652e221600113fba51": {
+        "id": "5c5db6652e221600113fba51",
+        "name": "MPX with TTI Base pad +11 41-round 9x19 magazine",
+        "shortName": "9x19 MPX"
+    },
+    "5cf8f3b0d7f00c00217872ef": {
+        "id": "5cf8f3b0d7f00c00217872ef",
+        "name": "MaxRounds Powermag 20-round 12/76 magazine for SOK-12 and compatible weapons",
+        "shortName": "Powermag 20"
+    },
+    "5c471c442e221602b542a6f8": {
+        "id": "5c471c442e221602b542a6f8",
+        "name": "10-round SVD 7.62x54 magazine",
+        "shortName": "SVD 7.62x54"
+    },
+    "5ef3448ab37dfd6af863525c": {
+        "id": "5ef3448ab37dfd6af863525c",
+        "name": "Mec-Gar .45 ACP 11-round magazine for M1911A1",
+        "shortName": "Mec-Gar"
+    },
+    "5fc23426900b1d5091531e15": {
+        "id": "5fc23426900b1d5091531e15",
+        "name": "Sword Int. Mk-18 .338 LM 10-round magazine",
+        "shortName": "Mk-18 10"
+    },
+    "5f3e77b26cda304dcc634057": {
+        "id": "5f3e77b26cda304dcc634057",
+        "name": "M45A1 .45 ACP 7-round magazine",
+        "shortName": "M45A1"
+    },
+    "5df25b6c0b92095fd441e4cf": {
+        "id": "5df25b6c0b92095fd441e4cf",
+        "name": "5-round .308 T-5000 magazine",
+        "shortName": "T-5000 5rnd"
+    },
+    "5e81c4ca763d9f754677befa": {
+        "id": "5e81c4ca763d9f754677befa",
+        "name": "M1911 .45 ACP 7-round magazine",
+        "shortName": "M1911"
+    },
+    "5b7bef1e5acfc43d82528402": {
+        "id": "5b7bef1e5acfc43d82528402",
+        "name": "FAL/SA-58 7.62x51 10 rnd",
+        "shortName": "FAL 10 7.62"
+    },
+    "5a7ad2e851dfba0016153692": {
+        "id": "5a7ad2e851dfba0016153692",
+        "name": "\"Big Stick\" 9x19 magazine for Glock 9x19",
+        "shortName": "Big Stick"
+    },
+    "5d3eb5eca4b9363b1f22f8e4": {
+        "id": "5d3eb5eca4b9363b1f22f8e4",
+        "name": "Five-seveN 20-Round 5.7x28 magazine",
+        "shortName": "5.7x28 57 mag."
+    },
+    "5c6d450c2e221600114c997d": {
+        "id": "5c6d450c2e221600114c997d",
+        "name": "HK PM Gen.2 5.56x45 STANAG 30-round magazine",
+        "shortName": "PM Gen.2"
+    },
+    "5d1340cad7ad1a0b0b249869": {
+        "id": "5d1340cad7ad1a0b0b249869",
+        "name": "PMAG GEN M3 FDE W 30 5.56x45 STANAG 30-round magazine",
+        "shortName": "GEN M3 30 FDE"
+    },
+    "5e21a3c67e40bd02257a008a": {
+        "id": "5e21a3c67e40bd02257a008a",
+        "name": "Pmag 30 AK/AKM GEN M3 7.62x39 magazine for AK and compatibles, 30-round capacity (banana)\n",
+        "shortName": "Pmag30"
+    },
+    "5998529a86f774647f44f421": {
+        "id": "5998529a86f774647f44f421",
+        "name": "10-round Izh.9x19 Sb.7 magazine",
+        "shortName": "9x19 Sb.7"
+    },
+    "57ffaea724597779f52b3a4d": {
+        "id": "57ffaea724597779f52b3a4d",
+        "name": "B-12 Mount",
+        "shortName": "B-12"
+    },
+    "57a3459f245977764a01f703": {
+        "id": "57a3459f245977764a01f703",
+        "name": "B-3 mount",
+        "shortName": "B-3"
+    },
+    "5a1ead28fcdbcb001912fa9f": {
+        "id": "5a1ead28fcdbcb001912fa9f",
+        "name": "UNV DLOC-IRD Mount for sights",
+        "shortName": "DLOC-IRD"
+    },
+    "5649a2464bdc2d91118b45a8": {
+        "id": "5649a2464bdc2d91118b45a8",
+        "name": "NcStar MPR45 Backup mount",
+        "shortName": "MPR45"
+    },
+    "58a5c12e86f7745d585a2b9e": {
+        "id": "58a5c12e86f7745d585a2b9e",
+        "name": "SIG MPX Gen1 Handguard 4 inch rail adapter",
+        "shortName": "4In. Gen1\n"
+    },
+    "5926dad986f7741f82604363": {
+        "id": "5926dad986f7741f82604363",
+        "name": "MFI HK Universal Low Profile Scope Mount",
+        "shortName": "MFIHKMOUNT"
+    },
+    "5c11046cd174af02a012e42b": {
+        "id": "5c11046cd174af02a012e42b",
+        "name": "Wilcox Interface for PVS-7",
+        "shortName": "W-PVS7"
+    },
+    "59eb7ebe86f7740b373438ce": {
+        "id": "59eb7ebe86f7740b373438ce",
+        "name": "TOZ 6P29M Mount",
+        "shortName": "6P29M"
+    },
+    "5e569a132642e66b0b68015c": {
+        "id": "5e569a132642e66b0b68015c",
+        "name": "CAA DRG L-1 mount for SVD",
+        "shortName": "DRG L-1"
+    },
+    "5a33b2c9c4a282000c5a9511": {
+        "id": "5a33b2c9c4a282000c5a9511",
+        "name": "Low profile mount for Trijicon RMR",
+        "shortName": "RM33"
+    },
+    "5eeb2ff5ea4f8b73c827350b": {
+        "id": "5eeb2ff5ea4f8b73c827350b",
+        "name": "Tactical rail for M590",
+        "shortName": "M590 rail"
+    },
+    "5b800ed086f7747baf6e2f9e": {
+        "id": "5b800ed086f7747baf6e2f9e",
+        "name": "Short length rail for Hexagon",
+        "shortName": "Hex."
+    },
+    "5a7893c1c585673f2b5c374d": {
+        "id": "5a7893c1c585673f2b5c374d",
+        "name": "MTU-028SG rail for M870",
+        "shortName": "mtu028sg"
+    },
+    "5dfe14f30b92095fd441edaf": {
+        "id": "5dfe14f30b92095fd441edaf",
+        "name": "ETMI-019 Mount",
+        "shortName": "ETMI-019"
+    },
+    "57ffb0062459777a045af529": {
+        "id": "57ffb0062459777a045af529",
+        "name": "B-18 Mount",
+        "shortName": "B-18"
+    },
+    "59db7eed86f77461f8380365": {
+        "id": "59db7eed86f77461f8380365",
+        "name": "TA51 Mount for sights",
+        "shortName": "TA51"
+    },
+    "576a7c512459771e796e0e17": {
+        "id": "576a7c512459771e796e0e17",
+        "name": "B-8 mount",
+        "shortName": "B-8"
+    },
+    "58a56f8d86f774651579314c": {
+        "id": "58a56f8d86f774651579314c",
+        "name": "SIG MPX Gen1 Handguard 2 inch rail adapter",
+        "shortName": "2In. Gen1"
+    },
+    "5c86592b2e2216000e69e77c": {
+        "id": "5c86592b2e2216000e69e77c",
+        "name": "34mm one piece magmount made by I-E-A Mil Optics",
+        "shortName": "KH/F 34mm"
+    },
+    "57ee59b42459771c7b045da5": {
+        "id": "57ee59b42459771c7b045da5",
+        "name": "Rotor 43 RIS mount for PP Kedr",
+        "shortName": "Kedr RIS"
+    },
+    "5a27b281c4a28200741e1e52": {
+        "id": "5a27b281c4a28200741e1e52",
+        "name": "SR1MP single rail mount",
+        "shortName": "SR1MP 1x"
+    },
+    "587e08ee245977446b4410cf": {
+        "id": "587e08ee245977446b4410cf",
+        "name": "Dovetail OP-SKS mount.",
+        "shortName": "OPSKS DT"
+    },
+    "5bc5a372d4351e44f824d17f": {
+        "id": "5bc5a372d4351e44f824d17f",
+        "name": "Aim Sports MNG rail for Mosin rifle",
+        "shortName": "MNG"
+    },
+    "5addc00b5acfc4001669f144": {
+        "id": "5addc00b5acfc4001669f144",
+        "name": "CASV 14 mount for M14",
+        "shortName": "CASV 14"
+    },
+    "5c7d55f52e221644f31bff6a": {
+        "id": "5c7d55f52e221644f31bff6a",
+        "name": "Aimpoint LRP mount for COMP M4 sights.",
+        "shortName": "LRP"
+    },
+    "5addbffe5acfc4001714dfac": {
+        "id": "5addbffe5acfc4001714dfac",
+        "name": "M14 DCSB",
+        "shortName": "M14 DCSB"
+    },
+    "5dff77c759400025ea5150cf": {
+        "id": "5dff77c759400025ea5150cf",
+        "name": "25mm rings made by UTG",
+        "shortName": "UTG 25mm"
+    },
+    "55d48ebc4bdc2d8c2f8b456c": {
+        "id": "55d48ebc4bdc2d8c2f8b456c",
+        "name": "Delta-tek Sprut mount for pump-action shotguns",
+        "shortName": "Sprut"
+    },
+    "5648b6ff4bdc2d3d1c8b4581": {
+        "id": "5648b6ff4bdc2d3d1c8b4581",
+        "name": "Tactica Tula 10000 mount",
+        "shortName": "ТТ 10000"
+    },
+    "5b84038986f774774913b0c1": {
+        "id": "5b84038986f774774913b0c1",
+        "name": "Short length rail for Hexagon(Anodized Red)",
+        "shortName": "Hex."
+    },
+    "5beecbb80db834001d2c465e": {
+        "id": "5beecbb80db834001d2c465e",
+        "name": "Izhmash RPK-16 rail",
+        "shortName": "RPK-16 rail"
+    },
+    "5d0a29fed7ad1a002769ad08": {
+        "id": "5d0a29fed7ad1a002769ad08",
+        "name": "KMZ 1P69 Weaver mount",
+        "shortName": "1P69 mount"
+    },
+    "5a16b8a9fcdbcb00165aa6ca": {
+        "id": "5a16b8a9fcdbcb00165aa6ca",
+        "name": "Norotos Titanium Advanced Tactical Mount ",
+        "shortName": "TATM"
+    },
+    "5a16b93dfcdbcbcae6687261": {
+        "id": "5a16b93dfcdbcbcae6687261",
+        "name": "Dual Dovetail Mount for PVS-14 monocular",
+        "shortName": "DDT"
+    },
+    "5c61a40d2e2216001403158d": {
+        "id": "5c61a40d2e2216001403158d",
+        "name": "B-13 rail platform",
+        "shortName": "B-13"
+    },
+    "5d0a29ead7ad1a0026013f27": {
+        "id": "5d0a29ead7ad1a0026013f27",
+        "name": "KMZ 1P59 Dovetail mount",
+        "shortName": "1P59 mount"
+    },
+    "5b800ebc86f774394e230a90": {
+        "id": "5b800ebc86f774394e230a90",
+        "name": "Medium length rail for Hexagon",
+        "shortName": "Hexagon Med"
+    },
+    "57d17e212459775a1179a0f5": {
+        "id": "57d17e212459775a1179a0f5",
+        "name": "25 mm mount ring",
+        "shortName": "25 mm ring"
+    },
+    "5de8fbf2b74cd90030650c79": {
+        "id": "5de8fbf2b74cd90030650c79",
+        "name": "B&T MP9 bottom rail",
+        "shortName": "B&T bottom"
+    },
+    "5a9fc7e6a2750c0032157184": {
+        "id": "5a9fc7e6a2750c0032157184",
+        "name": "B-3 mount combo",
+        "shortName": "B-3 combo"
+    },
+    "5bbdb811d4351e45020113c7": {
+        "id": "5bbdb811d4351e45020113c7",
+        "name": "Aim Sports \"Tri-Rail\" rail for Mosin rifle",
+        "shortName": "Tri-Rail"
+    },
+    "57c69dd424597774c03b7bbc": {
+        "id": "57c69dd424597774c03b7bbc",
+        "name": "30mm Scope mount",
+        "shortName": "30mm Mount"
+    },
+    "5c90c3622e221601da359851": {
+        "id": "5c90c3622e221601da359851",
+        "name": "B-13V rail platform above reciever \"Classic\"",
+        "shortName": "B-13V"
+    },
+    "55d48a634bdc2d8b2f8b456a": {
+        "id": "55d48a634bdc2d8b2f8b456a",
+        "name": "Kiba Arms International SPRM mount for pump-action shotguns\n",
+        "shortName": "SPRM"
+    },
+    "5a27bad7c4a282000b15184b": {
+        "id": "5a27bad7c4a282000b15184b",
+        "name": "SR1MP quad rail mount",
+        "shortName": "SR1MP 4x"
+    },
+    "591ee00d86f774592f7b841e": {
+        "id": "591ee00d86f774592f7b841e",
+        "name": "Axion Cobra mount",
+        "shortName": "Cobra"
+    },
+    "5cc7012ae4a949001252b43e": {
+        "id": "5cc7012ae4a949001252b43e",
+        "name": "FN EFFEN 90 rail",
+        "shortName": "EFFEN 90"
+    },
+    "58d39d3d86f77445bb794ae7": {
+        "id": "58d39d3d86f77445bb794ae7",
+        "name": "Aimpoint mount for the sights of Micro series.",
+        "shortName": "AMM"
+    },
+    "59c63b4486f7747afb151c1c": {
+        "id": "59c63b4486f7747afb151c1c",
+        "name": "B&T MP5 SD Tri Rail Ring Mount",
+        "shortName": "SD TRR"
+    },
+    "5b3f7c005acfc4704b4a1de8": {
+        "id": "5b3f7c005acfc4704b4a1de8",
+        "name": "PU 3.5x ring mount",
+        "shortName": "PU 3.5x ring"
+    },
+    "5a7ad4af51dfba0013379717": {
+        "id": "5a7ad4af51dfba0013379717",
+        "name": "Aimtech glock base",
+        "shortName": "G Base"
+    },
+    "593d1fa786f7746da62d61ac": {
+        "id": "593d1fa786f7746da62d61ac",
+        "name": "UTG SKS SOCOM Rail mount",
+        "shortName": "SKS SOCOM"
+    },
+    "5b8403a086f7747ff856f4e2": {
+        "id": "5b8403a086f7747ff856f4e2",
+        "name": "Medium length rail for Hexagon(Anodized Red)",
+        "shortName": "Hex."
+    },
+    "5a33b652c4a28232996e407c": {
+        "id": "5a33b652c4a28232996e407c",
+        "name": "High profile mount for Trijicon RMR",
+        "shortName": "AC32062"
+    },
+    "5b3f7bf05acfc433000ecf6b": {
+        "id": "5b3f7bf05acfc433000ecf6b",
+        "name": "Kochetov Mount for Mosin rifle",
+        "shortName": "Kochetov Mount"
+    },
+    "5a33bab6c4a28200741e22f8": {
+        "id": "5a33bab6c4a28200741e22f8",
+        "name": "Trijicon RMR mount for ACOG scopes",
+        "shortName": "RM35"
+    },
+    "5a32aa0cc4a28232996e405f": {
+        "id": "5a32aa0cc4a28232996e405f",
+        "name": "Trijicon RMR mount for a Sig-Sauer pistols",
+        "shortName": "RM50"
+    },
+    "5bfe7fb30db8340018089fed": {
+        "id": "5bfe7fb30db8340018089fed",
+        "name": "Stock adapter Tactica Tula 12003 for MP-133/153",
+        "shortName": "12003"
+    },
+    "5b3a08b25acfc4001754880c": {
+        "id": "5b3a08b25acfc4001754880c",
+        "name": "Bridge Sight Mount for P226",
+        "shortName": "Bridge P226"
+    },
+    "58d39b0386f77443380bf13c": {
+        "id": "58d39b0386f77443380bf13c",
+        "name": "Aimpoint Micro Spacer High",
+        "shortName": "AMSH"
+    },
+    "5d7b6bafa4b93652786f4c76": {
+        "id": "5d7b6bafa4b93652786f4c76",
+        "name": "FN RMR Mount for 5-7 Mk.2",
+        "shortName": "57 RMR mount"
+    },
+    "5a7ad55551dfba0015068f42": {
+        "id": "5a7ad55551dfba0015068f42",
+        "name": "Aimtech Tiger Shark ",
+        "shortName": "G Ti Sh"
+    },
+    "5b2389515acfc4771e1be0c0": {
+        "id": "5b2389515acfc4771e1be0c0",
+        "name": "30mm ring-mount AR- P.E.P.R. made by Burris",
+        "shortName": "AR- P.E.P.R. "
+    },
+    "5a966ec8a2750c00171b3f36": {
+        "id": "5a966ec8a2750c00171b3f36",
+        "name": "B&T 3x rail mount for MP5",
+        "shortName": "B&T 3x"
+    },
+    "5b7be4575acfc400161d0832": {
+        "id": "5b7be4575acfc400161d0832",
+        "name": "Vltor CASV 2 inch guide",
+        "shortName": "2 in. Vltor"
+    },
+    "5c6162682e22160010261a2b": {
+        "id": "5c6162682e22160010261a2b",
+        "name": "Dovetail mount for TOZ-106",
+        "shortName": "TOZ-106 DT"
+    },
+    "5e569a2e56edd02abe09f280": {
+        "id": "5e569a2e56edd02abe09f280",
+        "name": "CAA XD RGL mount for SVD",
+        "shortName": " XD RGL"
+    },
+    "58d2664f86f7747fec5834f6": {
+        "id": "58d2664f86f7747fec5834f6",
+        "name": "Cross Slot Mount base for Deltapoint scopes",
+        "shortName": "DPCSM"
+    },
+    "5a37ca54c4a282000d72296a": {
+        "id": "5a37ca54c4a282000d72296a",
+        "name": "30mm ring-mount made by JP",
+        "shortName": "JP 30mm"
+    },
+    "5df35e970b92095fd441e4d2": {
+        "id": "5df35e970b92095fd441e4d2",
+        "name": "Orsis scope mount for T-5000M",
+        "shortName": "T-5000 opt."
+    },
+    "5bfebc5e0db834001a6694e5": {
+        "id": "5bfebc5e0db834001a6694e5",
+        "name": "30mm ring-mount Remington integral for model 700 rifles",
+        "shortName": "Rem. integr."
+    },
+    "5cdeaca5d7f00c00b61c4b70": {
+        "id": "5cdeaca5d7f00c00b61c4b70",
+        "name": "Magpul inline mount for PRO 700 chassis",
+        "shortName": "PRO700"
+    },
+    "577d128124597739d65d0e56": {
+        "id": "577d128124597739d65d0e56",
+        "name": "Burris FastFire Weaver Base",
+        "shortName": "FFWB"
+    },
+    "5c0695860db834001b735461": {
+        "id": "5c0695860db834001b735461",
+        "name": "PNV-10T dovetail adapter",
+        "shortName": "10T adapter"
+    },
+    "5b31163c5acfc400153b71cb": {
+        "id": "5b31163c5acfc400153b71cb",
+        "name": "Sig Sauer mount for the sights of Romeo series.",
+        "shortName": "Rom. Base"
+    },
+    "5f2aa493cd375f14e15eea72": {
+        "id": "5f2aa493cd375f14e15eea72",
+        "name": "Kel-Tec RFB handguard rail",
+        "shortName": "RFB HG rail"
+    },
+    "57acb6222459771ec34b5cb0": {
+        "id": "57acb6222459771ec34b5cb0",
+        "name": "Pilad 043-02 Mount",
+        "shortName": "043-02"
+    },
+    "5a398ab9c4a282000c5a9842": {
+        "id": "5a398ab9c4a282000c5a9842",
+        "name": "Ops Core Single Clamp Rail Adapter mount",
+        "shortName": "SCRA"
+    },
+    "5a398b75c4a282000a51a266": {
+        "id": "5a398b75c4a282000a51a266",
+        "name": "Ops Core Picatinny Rail Adapter mount",
+        "shortName": "PRA"
+    },
+    "5c7d560b2e22160bc12c6139": {
+        "id": "5c7d560b2e22160bc12c6139",
+        "name": "Standard Spacer for Aimpont sight",
+        "shortName": "AMSS"
+    },
+    "5a789261c5856700186c65d3": {
+        "id": "5a789261c5856700186c65d3",
+        "name": "Mesa Tactical magazine clamp for M870",
+        "shortName": "MT Clamp"
+    },
+    "5d024f5cd7ad1a04a067e91a": {
+        "id": "5d024f5cd7ad1a04a067e91a",
+        "name": "Arbalet Patriot K+W mount",
+        "shortName": "Patriot K+W"
+    },
+    "5cc70146e4a949000d73bf6b": {
+        "id": "5cc70146e4a949000d73bf6b",
+        "name": "FN side rail for regular P90 upper receiver",
+        "shortName": "FN side."
+    },
+    "5c0102aa0db834001b734ba1": {
+        "id": "5c0102aa0db834001b734ba1",
+        "name": "Remington RAHG 2 inch guide",
+        "shortName": "2 in. RAHG"
+    },
+    "5a7b4900e899ef197b331a2a": {
+        "id": "5a7b4900e899ef197b331a2a",
+        "name": "UM Tactical UM3 Sight Mount",
+        "shortName": "UM3"
+    },
+    "5b30bc165acfc40016387293": {
+        "id": "5b30bc165acfc40016387293",
+        "name": "Alexander Arms 3 inch guide",
+        "shortName": "Mk10 3 In."
+    },
+    "5cc7015ae4a949001152b4c6": {
+        "id": "5cc7015ae4a949001152b4c6",
+        "name": "FN top rail for regular P90 upper receiver",
+        "shortName": "FN top"
+    },
+    "5fbb976df9986c4cff3fe5f2": {
+        "id": "5fbb976df9986c4cff3fe5f2",
+        "name": "KRISS Vector Bottom rail",
+        "shortName": "Vector Bottom"
+    },
+    "5de8fc0b205ddc616a6bc51b": {
+        "id": "5de8fc0b205ddc616a6bc51b",
+        "name": "B&T MP9 side rail",
+        "shortName": "B&T side"
+    },
+    "5ab24ef9e5b5b00fe93c9209": {
+        "id": "5ab24ef9e5b5b00fe93c9209",
+        "name": "M1A Socom 16 upper part",
+        "shortName": "Socom 16 Upper"
+    },
+    "5f2aa49f9b44de6b1b4e68d4": {
+        "id": "5f2aa49f9b44de6b1b4e68d4",
+        "name": "Kel-Tec RFB scope mount rail",
+        "shortName": "RFB scope mount"
+    },
+    "5a27b3d0c4a282000d721ec1": {
+        "id": "5a27b3d0c4a282000d721ec1",
+        "name": "SR1MP silencer mount",
+        "shortName": "SR1MP s.mount"
+    },
+    "5addbfd15acfc40015621bde": {
+        "id": "5addbfd15acfc40015621bde",
+        "name": "M14 Mini Scout mount",
+        "shortName": "Mini Scout"
+    },
+    "5b3b6dc75acfc47a8773fb1e": {
+        "id": "5b3b6dc75acfc47a8773fb1e",
+        "name": "Armasight universal base",
+        "shortName": "Armasight"
+    },
+    "5df35ea9c41b2312ea3334d8": {
+        "id": "5df35ea9c41b2312ea3334d8",
+        "name": "Orsis long length rail",
+        "shortName": "Orsis long"
+    },
+    "5c1cdd302e221602b3137250": {
+        "id": "5c1cdd302e221602b3137250",
+        "name": "Compact mount for sights",
+        "shortName": "Compact mount"
+    },
+    "5c471c2d2e22164bef5d077f": {
+        "id": "5c471c2d2e22164bef5d077f",
+        "name": "SVDS Upper Band",
+        "shortName": "SVDS LB"
+    },
+    "5a78948ec5856700177b1124": {
+        "id": "5a78948ec5856700177b1124",
+        "name": "XS Short rail with Ghost ring for M870",
+        "shortName": "XS Short"
+    },
+    "5df35eb2b11454561e3923e2": {
+        "id": "5df35eb2b11454561e3923e2",
+        "name": "Orsis medium length rail",
+        "shortName": "Orsis med."
+    },
+    "5dff8db859400025ea5150d4": {
+        "id": "5dff8db859400025ea5150d4",
+        "name": "SVD Low sidemount",
+        "shortName": "SVD Low"
+    },
+    "5d133067d7ad1a33013f95b4": {
+        "id": "5d133067d7ad1a33013f95b4",
+        "name": "KAC URX 3 inch guide",
+        "shortName": "3 in. URX"
+    },
+    "5fc53954f8b6a877a729eaeb": {
+        "id": "5fc53954f8b6a877a729eaeb",
+        "name": "HK UMP Bottom rail",
+        "shortName": "rail bott."
+    },
+    "5fce0f9b55375d18a253eff2": {
+        "id": "5fce0f9b55375d18a253eff2",
+        "name": "KRISS Vector Side rail",
+        "shortName": "Vector side"
+    },
+    "5e569a0156edd02abe09f27d": {
+        "id": "5e569a0156edd02abe09f27d",
+        "name": "IzhMash modern rail for SVD",
+        "shortName": "IzhMash mod. rail"
+    },
+    "5c0102b20db834001d23eebc": {
+        "id": "5c0102b20db834001d23eebc",
+        "name": "Remington RAHG 4 inch guide",
+        "shortName": "4 in. RAHG"
+    },
+    "5b4736a986f774040571e998": {
+        "id": "5b4736a986f774040571e998",
+        "name": "Troy QARS 3.2 inch guide",
+        "shortName": "QARS 3.2in."
+    },
+    "5b7be4645acfc400170e2dcc": {
+        "id": "5b7be4645acfc400170e2dcc",
+        "name": "Vltor CASV 4 inch guide",
+        "shortName": "4 in. Vltor"
+    },
+    "59e0bdb186f774156f04ce82": {
+        "id": "59e0bdb186f774156f04ce82",
+        "name": "Vltor CASV KeyMod 2 inch guide",
+        "shortName": "2In. CASV"
+    },
+    "5aa66c72e5b5b00016327c93": {
+        "id": "5aa66c72e5b5b00016327c93",
+        "name": "34mm one piece magmount made by Nightforce with a Multimount rail",
+        "shortName": "NF 34mm RIS"
+    },
+    "5cde7b43d7f00c000d36b93e": {
+        "id": "5cde7b43d7f00c000d36b93e",
+        "name": "A*B Arms MOD X mount for M700",
+        "shortName": "MOD X"
+    },
+    "5b3b99265acfc4704b4a1afb": {
+        "id": "5b3b99265acfc4704b4a1afb",
+        "name": "30mm rings made by Nightforce",
+        "shortName": "NF 30mm"
+    },
+    "5c064c400db834001d23f468": {
+        "id": "5c064c400db834001d23f468",
+        "name": "La Rue Tactical picatinny riser QD LT-101 mount",
+        "shortName": "QD LT-101"
+    },
+    "5de6558e9f98ac2bc65950fc": {
+        "id": "5de6558e9f98ac2bc65950fc",
+        "name": "Scope mount for VPO-215",
+        "shortName": "215 mount"
+    },
+    "5ef5d994dfbc9f3c660ded95": {
+        "id": "5ef5d994dfbc9f3c660ded95",
+        "name": "Weigand Weig-a-tinny mount for M1911A1",
+        "shortName": "Weig-a-tinny"
+    },
+    "5fbb978207e8a97d1f0902d3": {
+        "id": "5fbb978207e8a97d1f0902d3",
+        "name": "KRISS Mk.5 Modular rail for Vector",
+        "shortName": "Mk.5 Modular"
+    },
+    "59e0be5d86f7742d48765bd2": {
+        "id": "59e0be5d86f7742d48765bd2",
+        "name": "Vltor CASV KeyMod 4 inch guide",
+        "shortName": "4 in. CASV"
+    },
+    "5b7be4895acfc400170e2dd5": {
+        "id": "5b7be4895acfc400170e2dd5",
+        "name": "Magpul M-LOK 4.1 inch guide",
+        "shortName": "4.1 in. M-LOK"
+    },
+    "59e0bed186f774156f04ce84": {
+        "id": "59e0bed186f774156f04ce84",
+        "name": "Vltor CASV keymod 6 inch guide",
+        "shortName": "6In. CASV"
+    },
+    "5b30bc285acfc47a8608615d": {
+        "id": "5b30bc285acfc47a8608615d",
+        "name": "Alexander Arms 10 inch guide",
+        "shortName": "Mk10 10 In."
+    },
+    "5b7be47f5acfc400170e2dd2": {
+        "id": "5b7be47f5acfc400170e2dd2",
+        "name": "Magpul M-LOK 2.5 inch guide",
+        "shortName": "2.5 in. M-LOK"
+    },
+    "5b4736b986f77405cb415c10": {
+        "id": "5b4736b986f77405cb415c10",
+        "name": "Troy QARS 4.2 inch guide",
+        "shortName": "QARS 4.2in."
+    },
+    "5b7be46e5acfc400170e2dcf": {
+        "id": "5b7be46e5acfc400170e2dcf",
+        "name": "Vltor CASV 5 inch guide",
+        "shortName": "5 in.Vltor"
+    },
+    "5aa66a9be5b5b0214e506e89": {
+        "id": "5aa66a9be5b5b0214e506e89",
+        "name": "34mm one piece magmount made by Nightforce",
+        "shortName": "NF 34mm"
+    },
+    "5addbfef5acfc400185c2857": {
+        "id": "5addbfef5acfc400185c2857",
+        "name": "M14 UTG 4 point locking deluxe mount",
+        "shortName": "UTG 4 "
+    },
+    "5fc5396e900b1d5091531e72": {
+        "id": "5fc5396e900b1d5091531e72",
+        "name": "HK UMP Side rail",
+        "shortName": "UMP side"
+    },
+    "5bfebc530db834001d23eb65": {
+        "id": "5bfebc530db834001d23eb65",
+        "name": "Weaver extended multi-slot base for Remington model 700",
+        "shortName": "Multi-slot"
+    },
+    "5addbfe15acfc4001a5fc58b": {
+        "id": "5addbfe15acfc4001a5fc58b",
+        "name": "Arms #18 mount  for M14",
+        "shortName": "Arms 18"
+    },
+    "5a9d6d21a2750c00137fa649": {
+        "id": "5a9d6d21a2750c00137fa649",
+        "name": "Strike industries bridge guide",
+        "shortName": "Bridge"
+    },
+    "5c61627a2e22160012542c55": {
+        "id": "5c61627a2e22160012542c55",
+        "name": "TOZ-106 scope mount",
+        "shortName": "106 mount"
+    },
+    "5ef369b08cef260c0642acaf": {
+        "id": "5ef369b08cef260c0642acaf",
+        "name": "NCStar Trigger guard mount for M1911A1",
+        "shortName": "TGM"
+    },
+    "5a9d6d00a2750c5c985b5305": {
+        "id": "5a9d6d00a2750c5c985b5305",
+        "name": "Strike industries keymod 4 inch guide",
+        "shortName": "4 in. SI"
+    },
+    "5a9d6d13a2750c00164f6b03": {
+        "id": "5a9d6d13a2750c00164f6b03",
+        "name": "Strike industries keymod 6 inch guide",
+        "shortName": "6In. SI"
+    },
+    "5addbfbb5acfc400194dbcf7": {
+        "id": "5addbfbb5acfc400194dbcf7",
+        "name": "M14 Ultimak M8 upper part",
+        "shortName": "Ultimak M8"
+    },
+    "5c0e2ff6d174af02a1659d4a": {
+        "id": "5c0e2ff6d174af02a1659d4a",
+        "name": "ADAR 2-15 wooden stock",
+        "shortName": "2-15 wood"
+    },
+    "5cf518cfd7f00c065b422214": {
+        "id": "5cf518cfd7f00c065b422214",
+        "name": "CAA AKTS AK-74 Buffer Tube for AK and compatible",
+        "shortName": "AKTS"
+    },
+    "5a33e75ac4a2826c6e06d759": {
+        "id": "5a33e75ac4a2826c6e06d759",
+        "name": "Hera Arms CQR pistol grip-stock",
+        "shortName": "HA CQR"
+    },
+    "5ab626e4d8ce87272e4c6e43": {
+        "id": "5ab626e4d8ce87272e4c6e43",
+        "name": "IzhMash metal stock for AKS-74 (6P21 Sb.5)",
+        "shortName": "6P21 Sb.5"
+    },
+    "5c5db6f82e2216003a0fe914": {
+        "id": "5c5db6f82e2216003a0fe914",
+        "name": "PMM \"ULSS\" foldable MCX/MPX stock",
+        "shortName": "ULSS"
+    },
+    "5cc700b9e4a949000f0f0f25": {
+        "id": "5cc700b9e4a949000f0f0f25",
+        "name": "FN P90 stock",
+        "shortName": "P90 Stock"
+    },
+    "5649be884bdc2d79388b4577": {
+        "id": "5649be884bdc2d79388b4577",
+        "name": "Colt buffer tube",
+        "shortName": "CST"
+    },
+    "5fc2369685fd526b824a5713": {
+        "id": "5fc2369685fd526b824a5713",
+        "name": "B5 Precision stock",
+        "shortName": "Precision"
+    },
+    "587e0531245977466077a0f7": {
+        "id": "587e0531245977466077a0f7",
+        "name": "Wooden stock for Molot OP-SKS",
+        "shortName": "OP-SKS W.s."
+    },
+    "5947c73886f7747701588af5": {
+        "id": "5947c73886f7747701588af5",
+        "name": "MFT BUS Stock",
+        "shortName": "BUS"
+    },
+    "5947eab886f77475961d96c5": {
+        "id": "5947eab886f77475961d96c5",
+        "name": "UBR GEN2 FDE stock",
+        "shortName": "UBR GEN2"
+    },
+    "591aef7986f774139d495f03": {
+        "id": "591aef7986f774139d495f03",
+        "name": "Troy M7A1 PDW Blk stock",
+        "shortName": "M7A1PDW"
+    },
+    "5a17fb9dfcdbcbcae6687291": {
+        "id": "5a17fb9dfcdbcbcae6687291",
+        "name": "APB detachable wire stock",
+        "shortName": "APB stock"
+    },
+    "5b39f8db5acfc40016387a1b": {
+        "id": "5b39f8db5acfc40016387a1b",
+        "name": "EMOD Stock",
+        "shortName": "EMOD"
+    },
+    "5b7d63b75acfc400170e2f8a": {
+        "id": "5b7d63b75acfc400170e2f8a",
+        "name": "Magpul PRS 2 polymer stock for FAL",
+        "shortName": "PRS 2 FAL"
+    },
+    "5c471b5d2e221602b21d4e14": {
+        "id": "5c471b5d2e221602b21d4e14",
+        "name": "Polymer stock for SVDS",
+        "shortName": "SVDS Stock"
+    },
+    "5eea217fc64c5d0dfc05712a": {
+        "id": "5eea217fc64c5d0dfc05712a",
+        "name": "SGA stock for M590",
+        "shortName": "SGA M590"
+    },
+    "5cf50fc5d7f00c056c53f83c": {
+        "id": "5cf50fc5d7f00c056c53f83c",
+        "name": "CAA AKTS AK-74 Buffer Tube for AK and compatible",
+        "shortName": "AKTS"
+    },
+    "56083be64bdc2d20478b456f": {
+        "id": "56083be64bdc2d20478b456f",
+        "name": "Plastic stock for MP-133/153",
+        "shortName": "133/153 Pl.s."
+    },
+    "591af10186f774139d495f0e": {
+        "id": "591af10186f774139d495f0e",
+        "name": "Troy M7A1 PDW FDE stock",
+        "shortName": "M7A1PDW"
+    },
+    "5c87a07c2e2216001219d4a2": {
+        "id": "5c87a07c2e2216001219d4a2",
+        "name": "HK E1 Stock for AR-15 and compatible",
+        "shortName": "HK E1"
+    },
+    "5b04473a5acfc40018632f70": {
+        "id": "5b04473a5acfc40018632f70",
+        "name": "Fab Defense UAS for AK",
+        "shortName": "UAS AK"
+    },
+    "5ae30c9a5acfc408fb139a03": {
+        "id": "5ae30c9a5acfc408fb139a03",
+        "name": "LMT Sopmod stock",
+        "shortName": " Sopmod"
+    },
+    "5c0faeddd174af02a962601f": {
+        "id": "5c0faeddd174af02a962601f",
+        "name": "ADAR buffer tube",
+        "shortName": "ADAR St."
+    },
+    "5cebec10d7f00c065703d185": {
+        "id": "5cebec10d7f00c065703d185",
+        "name": "FN PS90 stock",
+        "shortName": "PS90 Stock"
+    },
+    "5bd704e7209c4d00d7167c31": {
+        "id": "5bd704e7209c4d00d7167c31",
+        "name": "Regular stock for HK MP7A2",
+        "shortName": "A2 stock"
+    },
+    "56083cba4bdc2de22e8b456f": {
+        "id": "56083cba4bdc2de22e8b456f",
+        "name": "Wooden stock for MP-133/153",
+        "shortName": "133/153 W.s."
+    },
+    "59ecc3dd86f7746dc827481c": {
+        "id": "59ecc3dd86f7746dc827481c",
+        "name": "Zenit PT-3 \"Klassika\" stock",
+        "shortName": "PT-3"
+    },
+    "5ab372a310e891001717f0d8": {
+        "id": "5ab372a310e891001717f0d8",
+        "name": "Troy S.A.S.S. Chassis stock for M14",
+        "shortName": "S.A.S.S."
+    },
+    "5b222d405acfc400153af4fe": {
+        "id": "5b222d405acfc400153af4fe",
+        "name": "Zenit PT-1 \"Klassika\" stock",
+        "shortName": "PT-1"
+    },
+    "5926d40686f7740f152b6b7e": {
+        "id": "5926d40686f7740f152b6b7e",
+        "name": "HK A3 old stock model.",
+        "shortName": "HK A3"
+    },
+    "59ff3b6a86f77477562ff5ed": {
+        "id": "59ff3b6a86f77477562ff5ed",
+        "name": "Izhmash shoulder piece for AKMS (6P4 Sb.1-19)",
+        "shortName": "6P4 Sb.1-19"
+    },
+    "58ac1bf086f77420ed183f9f": {
+        "id": "58ac1bf086f77420ed183f9f",
+        "name": "SIG retractable stock pipe adapter",
+        "shortName": "SIG F.K."
+    },
+    "5c07c9660db834001a66b588": {
+        "id": "5c07c9660db834001a66b588",
+        "name": "HK End Cap Stock for MP5",
+        "shortName": "End Cap"
+    },
+    "5adf23995acfc400185c2aeb": {
+        "id": "5adf23995acfc400185c2aeb",
+        "name": "MC 20-01 stock",
+        "shortName": "MC 20-01"
+    },
+    "5a78813bc5856700186c4abe": {
+        "id": "5a78813bc5856700186c4abe",
+        "name": "SGA stock for M870",
+        "shortName": "SGA M870"
+    },
+    "59e89d0986f77427600d226e": {
+        "id": "59e89d0986f77427600d226e",
+        "name": "Molot wooden VPO-209 stock",
+        "shortName": "VPO-209"
+    },
+    "5bcf0213d4351e0085327c17": {
+        "id": "5bcf0213d4351e0085327c17",
+        "name": "Regular stock for HK MP7A1",
+        "shortName": "A1 stock"
+    },
+    "5bb20e70d4351e0035629f8f": {
+        "id": "5bb20e70d4351e0035629f8f",
+        "name": "HK Slim Line Stock",
+        "shortName": "Slim Line"
+    },
+    "574dad8024597745964bf05c": {
+        "id": "574dad8024597745964bf05c",
+        "name": "Wooden stock 56-A-231 Sb.5",
+        "shortName": "56-A-231 Sb.5"
+    },
+    "5d2f25bc48f03502573e5d85": {
+        "id": "5d2f25bc48f03502573e5d85",
+        "name": "HK End Cap Stock for MP5 Kurz",
+        "shortName": "MP5k End Cap"
+    },
+    "5b222d335acfc4771e1be099": {
+        "id": "5b222d335acfc4771e1be099",
+        "name": "AKM/AK-74 PT Lock",
+        "shortName": "AKM Lock"
+    },
+    "5a0c59791526d8dba737bba7": {
+        "id": "5a0c59791526d8dba737bba7",
+        "name": "Recoil pad from GP-25 for AK Accessory Kit",
+        "shortName": "6G15U"
+    },
+    "5926d3c686f77410de68ebc8": {
+        "id": "5926d3c686f77410de68ebc8",
+        "name": "HK A2 Stock",
+        "shortName": "HK A2"
+    },
+    "59e6227d86f77440d64f5dc2": {
+        "id": "59e6227d86f77440d64f5dc2",
+        "name": "Molot wooden VPO-136 stock",
+        "shortName": "VPO-136"
+    },
+    "5fc3e4ee7283c4046c5814af": {
+        "id": "5fc3e4ee7283c4046c5814af",
+        "name": "Polymer stock for UMP",
+        "shortName": "UMP Stock"
+    },
+    "5addc7005acfc4001669f275": {
+        "id": "5addc7005acfc4001669f275",
+        "name": "M14 M14ALCS(MOD. 0) stock",
+        "shortName": "M14ALCS(MOD. 0)"
+    },
+    "5ac78eaf5acfc4001926317a": {
+        "id": "5ac78eaf5acfc4001926317a",
+        "name": "AK74/АК100 PT Lock",
+        "shortName": "PT 74M/100"
+    },
+    "5e87116b81c4ed43e83cefdd": {
+        "id": "5e87116b81c4ed43e83cefdd",
+        "name": "Polymer stock for M590A1",
+        "shortName": "M590A1 stock"
+    },
+    "5bbdb870d4351e00367fb67d": {
+        "id": "5bbdb870d4351e00367fb67d",
+        "name": "ATI Monte Carlo Mosin rifle stock",
+        "shortName": "Monte Carlo"
+    },
+    "5afd7e095acfc40017541f61": {
+        "id": "5afd7e095acfc40017541f61",
+        "name": "Tapco buffer tube",
+        "shortName": "TAPCO Tube"
+    },
+    "5c5db6ee2e221600113fba54": {
+        "id": "5c5db6ee2e221600113fba54",
+        "name": "Maxim Defence CQB collapsing/telescoping MCX/MPX stock",
+        "shortName": "MD CQB"
+    },
+    "5c99f3592e221644fc633070": {
+        "id": "5c99f3592e221644fc633070",
+        "name": "Custom cut mosin stock for TOZ-106",
+        "shortName": "TOZ-106 Mosin"
+    },
+    "5b0e794b5acfc47a877359b2": {
+        "id": "5b0e794b5acfc47a877359b2",
+        "name": "Zhukov-S for AK",
+        "shortName": "Zhukov-S"
+    },
+    "57c450252459772d28133253": {
+        "id": "57c450252459772d28133253",
+        "name": "TSNIITochMash AS VAL stock",
+        "shortName": "VAL Stock"
+    },
+    "5ac50c185acfc400163398d4": {
+        "id": "5ac50c185acfc400163398d4",
+        "name": "Polymer stock for AK-74M (6P34 Sb.15)",
+        "shortName": "6P34 Sb.15"
+    },
+    "5649b0fc4bdc2d17108b4588": {
+        "id": "5649b0fc4bdc2d17108b4588",
+        "name": "Izhmash polymer АК-74 stock (6P20 Sb.7)",
+        "shortName": "6P20 Sb.7"
+    },
+    "58d2947e86f77447aa070d53": {
+        "id": "58d2947e86f77447aa070d53",
+        "name": "MOE Carbine stock SG",
+        "shortName": "MOE Stock SG"
+    },
+    "5947e98b86f774778f1448bc": {
+        "id": "5947e98b86f774778f1448bc",
+        "name": "UBR GEN2 black stock",
+        "shortName": "UBR GEN2"
+    },
+    "5ae096d95acfc400185c2c81": {
+        "id": "5ae096d95acfc400185c2c81",
+        "name": "Regular Mosin rifle stock",
+        "shortName": "Mosin Stock"
+    },
+    "5a33ca0fc4a282000d72292f": {
+        "id": "5a33ca0fc4a282000d72292f",
+        "name": "COLT \"A2\" buffer tube",
+        "shortName": "CA2"
+    },
+    "5d135ecbd7ad1a21c176542e": {
+        "id": "5d135ecbd7ad1a21c176542e",
+        "name": "Magpul CTR Carbine stock FDE",
+        "shortName": "CTR Stock"
+    },
+    "599851db86f77467372f0a18": {
+        "id": "599851db86f77467372f0a18",
+        "name": "Metal Izhmash stock for PP-19-01",
+        "shortName": "Stock PP-19-01"
+    },
+    "5bfe86df0db834001b734685": {
+        "id": "5bfe86df0db834001b734685",
+        "name": "Fab Defence GLR-16-S Stock",
+        "shortName": "GLR-16-S"
+    },
+    "58d2946386f774496974c37e": {
+        "id": "58d2946386f774496974c37e",
+        "name": "MOE Carbine stock FDE",
+        "shortName": "MOE Stock FDE"
+    },
+    "5d4406a8a4b9361e4f6eb8b7": {
+        "id": "5d4406a8a4b9361e4f6eb8b7",
+        "name": "Magpul PRS GEN3 Grey stock",
+        "shortName": "PRS GEN3 gr."
+    },
+    "5addc7ac5acfc400194dbd90": {
+        "id": "5addc7ac5acfc400194dbd90",
+        "name": "M14 M14ALCS(MOD. 0) stock",
+        "shortName": "M14ALCS Stock"
+    },
+    "5649b2314bdc2d79388b4576": {
+        "id": "5649b2314bdc2d79388b4576",
+        "name": "ME adapter for АК",
+        "shortName": "МЕ4"
+    },
+    "5a9eb32da2750c00171b3f9c": {
+        "id": "5a9eb32da2750c00171b3f9c",
+        "name": "Fab Defence GL Shock Stock",
+        "shortName": "GL Shock"
+    },
+    "59d6514b86f774171a068a08": {
+        "id": "59d6514b86f774171a068a08",
+        "name": "Izhmash wooden АКМ stock (6P1 Sb.5)",
+        "shortName": "6P1 Sb.5"
+    },
+    "57dc347d245977596754e7a1": {
+        "id": "57dc347d245977596754e7a1",
+        "name": "IzhMash metal stock for AKS-74U (6P26 Sb.5)",
+        "shortName": "6P26 Sb.5"
+    },
+    "5cde77a9d7f00c000f261009": {
+        "id": "5cde77a9d7f00c000f261009",
+        "name": "Buffer tube side folder adapter for M700",
+        "shortName": "fold.adapter"
+    },
+    "5de910da8b6c4240ba2651b5": {
+        "id": "5de910da8b6c4240ba2651b5",
+        "name": "Regular stock for B&T MP9",
+        "shortName": "MP9 stock"
+    },
+    "5beec8c20db834001d2c465c": {
+        "id": "5beec8c20db834001d2c465c",
+        "name": "Izhmash AK-12 regular stock",
+        "shortName": "AK-12 reg."
+    },
+    "5d1c702ad7ad1a632267f429": {
+        "id": "5d1c702ad7ad1a632267f429",
+        "name": "Fab Defence GLR-17 Stock for Glock and compatible",
+        "shortName": "GLR-17"
+    },
+    "5b0800175acfc400153aebd4": {
+        "id": "5b0800175acfc400153aebd4",
+        "name": "F93 Pro Stock",
+        "shortName": "F93 Pro Stock"
+    },
+    "57ade1442459771557167e15": {
+        "id": "57ade1442459771557167e15",
+        "name": "Armacon Baskak stock",
+        "shortName": "Baskak"
+    },
+    "56083a334bdc2dc8488b4571": {
+        "id": "56083a334bdc2dc8488b4571",
+        "name": "Plastic pistol grip for МP-133/153",
+        "shortName": "133/153 Pl.g."
+    },
+    "5d135e83d7ad1a21b83f42d8": {
+        "id": "5d135e83d7ad1a21b83f42d8",
+        "name": "Magpul CTR Carbine stock",
+        "shortName": "CTR Stock"
+    },
+    "5ea03e9400685063ec28bfa4": {
+        "id": "5ea03e9400685063ec28bfa4",
+        "name": "PPSH-41 stock",
+        "shortName": "PPSH-41 stock"
+    },
+    "5cc700cae4a949035e43ba72": {
+        "id": "5cc700cae4a949035e43ba72",
+        "name": "FN Butt pad for P90",
+        "shortName": "P90 butt"
+    },
+    "5addbf175acfc408fb13965b": {
+        "id": "5addbf175acfc408fb13965b",
+        "name": "M1A Archangel stock",
+        "shortName": "Archangel"
+    },
+    "578395e82459774a0e553c7b": {
+        "id": "578395e82459774a0e553c7b",
+        "name": "TSNIITochMash VSS Vintorez stock",
+        "shortName": "VSS Stock"
+    },
+    "5a33cae9c4a28232980eb086": {
+        "id": "5a33cae9c4a28232980eb086",
+        "name": "Magpul PRS GEN2 FDE stock",
+        "shortName": "PRS GEN2"
+    },
+    "59ecc28286f7746d7a68aa8c": {
+        "id": "59ecc28286f7746d7a68aa8c",
+        "name": "AKS-74/АКS-74U PT Lock",
+        "shortName": "PT 74S"
+    },
+    "5894a13e86f7742405482982": {
+        "id": "5894a13e86f7742405482982",
+        "name": "Early produced SIG collapsing/telescoping MCX/MPX stock",
+        "shortName": "MCX/MPX early"
+    },
+    "5d0236dad7ad1a0940739d29": {
+        "id": "5d0236dad7ad1a0940739d29",
+        "name": "Fab Defence UAS Stock for SKS",
+        "shortName": "FD UAS Stock"
+    },
+    "5e848dc4e4dbc5266a4ec63d": {
+        "id": "5e848dc4e4dbc5266a4ec63d",
+        "name": "Wired stock for KS-23M",
+        "shortName": "KS-23M steel"
+    },
+    "5e848db4681bea2ada00daa9": {
+        "id": "5e848db4681bea2ada00daa9",
+        "name": "Wooden stock for KS-23",
+        "shortName": "KS23 Wood"
+    },
+    "5b7d64555acfc4001876c8e2": {
+        "id": "5b7d64555acfc4001876c8e2",
+        "name": "DSA BRS stock for SA-58",
+        "shortName": "SA-58 BRS Stock"
+    },
+    "58d2946c86f7744e271174b5": {
+        "id": "58d2946c86f7744e271174b5",
+        "name": "MOE Carbine stock FG",
+        "shortName": "MOE Stock FG"
+    },
+    "5649b1c04bdc2d16268b457c": {
+        "id": "5649b1c04bdc2d16268b457c",
+        "name": "Izhmash wooden АК-74 stock (6P20 Sb.5)",
+        "shortName": "6P20 Sb.5"
+    },
+    "5ae35b315acfc4001714e8b0": {
+        "id": "5ae35b315acfc4001714e8b0",
+        "name": "LEO stock adapter for M870",
+        "shortName": "LEO M870"
+    },
+    "58889d0c2459775bc215d981": {
+        "id": "58889d0c2459775bc215d981",
+        "name": "LOBAEV Arms Stock",
+        "shortName": "LOBAEV Arms Stock"
+    },
+    "5b7d63de5acfc400170e2f8d": {
+        "id": "5b7d63de5acfc400170e2f8d",
+        "name": "DSA SPR stock for SA-58",
+        "shortName": "SA-58 SPR Stock"
+    },
+    "55d4ae6c4bdc2d8b2f8b456e": {
+        "id": "55d4ae6c4bdc2d8b2f8b456e",
+        "name": "High Standard M4SS Stock",
+        "shortName": "M4SS"
+    },
+    "5d120a28d7ad1a1c8962e295": {
+        "id": "5d120a28d7ad1a1c8962e295",
+        "name": "Double Star recoil pad 0.5 for ACE stock series",
+        "shortName": "Recoil pad"
+    },
+    "5d44069ca4b9361ebd26fc37": {
+        "id": "5d44069ca4b9361ebd26fc37",
+        "name": "Magpul PRS GEN3 stock",
+        "shortName": "PRS GEN3"
+    },
+    "58d2912286f7744e27117493": {
+        "id": "58d2912286f7744e27117493",
+        "name": "Magpul Rubber Butt-Pad for Carbine stock series",
+        "shortName": "RBP"
+    },
+    "5abcd472d8ce8700166032ae": {
+        "id": "5abcd472d8ce8700166032ae",
+        "name": "Izhmash shoulder piece for AKMSN (6P4 Sb.1-19)",
+        "shortName": "6P4N Sb.1-19"
+    },
+    "5d25d0ac8abbc3054f3e61f7": {
+        "id": "5d25d0ac8abbc3054f3e61f7",
+        "name": "AT AICS polymer stock for M700",
+        "shortName": "AICS M700"
+    },
+    "5bfd37c80db834001d23e842": {
+        "id": "5bfd37c80db834001d23e842",
+        "name": "Mosin rifle sniper carbine stock",
+        "shortName": "Mosin sniper carbine stock"
+    },
+    "5bfd35380db83400232fe5cc": {
+        "id": "5bfd35380db83400232fe5cc",
+        "name": "Infantry Mosin rifle stock",
+        "shortName": "Infantry mosin Stock"
+    },
+    "5bfe89510db834001808a127": {
+        "id": "5bfe89510db834001808a127",
+        "name": "Fab Defence buffer tube for AGR-870",
+        "shortName": "AGR-870 tube"
+    },
+    "5cdeac42d7f00c000d36ba73": {
+        "id": "5cdeac42d7f00c000d36ba73",
+        "name": "PRO 700 folding stock",
+        "shortName": "PRO700 stock "
+    },
+    "5ef1b9f0c64c5d0dfc0571a1": {
+        "id": "5ef1b9f0c64c5d0dfc0571a1",
+        "name": "LEO stock adapter gen.1 for M590",
+        "shortName": "LEO M590"
+    },
+    "5fb655b748c711690e3a8d5a": {
+        "id": "5fb655b748c711690e3a8d5a",
+        "name": "KRISS Vector non folding stock adapter",
+        "shortName": "Vector NFA"
+    },
+    "5fb655a72b1b027b1f50bd06": {
+        "id": "5fb655a72b1b027b1f50bd06",
+        "name": "Kriss Vector Pistol Sling Adapter",
+        "shortName": "Vector PSA"
+    },
+    "5beec8b20db834001961942a": {
+        "id": "5beec8b20db834001961942a",
+        "name": "Izhmash RPK-16 buffer tube",
+        "shortName": "RPK-16 Tube"
+    },
+    "5f63405df5750b524b45f114": {
+        "id": "5f63405df5750b524b45f114",
+        "name": "VPO-101 SVD style stock",
+        "shortName": "SVD style stock"
+    },
+    "5b099bf25acfc4001637e683": {
+        "id": "5b099bf25acfc4001637e683",
+        "name": "Buffer Tube adapter for SA-58",
+        "shortName": "SA-58 Tube"
+    },
+    "5c793fc42e221600114ca25d": {
+        "id": "5c793fc42e221600114ca25d",
+        "name": "SI Advanced receiver extension buffer tube (anodized red)",
+        "shortName": "Advanced Tube"
+    },
+    "5df35ddddfc58d14537c2036": {
+        "id": "5df35ddddfc58d14537c2036",
+        "name": "Orsis T-5000M Stock",
+        "shortName": "T-5000M Stock"
+    },
+    "5bfd384c0db834001a6691d3": {
+        "id": "5bfd384c0db834001a6691d3",
+        "name": "Mosin carbine stock",
+        "shortName": "Mosin carbine stock"
+    },
+    "5c793fde2e221601da358614": {
+        "id": "5c793fde2e221601da358614",
+        "name": "SI Viper Mod.1 Stock",
+        "shortName": "Viper Mod.1"
+    },
+    "5c503af12e221602b177ca02": {
+        "id": "5c503af12e221602b177ca02",
+        "name": "Regular VPO-101 \"Vepr Hunter\" stock",
+        "shortName": "VPO-101 stock"
+    },
+    "5bbde409d4351e003562b036": {
+        "id": "5bbde409d4351e003562b036",
+        "name": "Recoil pad from Aim Sports for Mosin rifle",
+        "shortName": "Recoil pad"
+    },
+    "5df35e59c41b2312ea3334d5": {
+        "id": "5df35e59c41b2312ea3334d5",
+        "name": "Orsis Aluminium body for T-5000",
+        "shortName": "T-5000 Hg."
+    },
+    "5fce16961f152d4312622bc9": {
+        "id": "5fce16961f152d4312622bc9",
+        "name": "KRISS Defiance DS150 FDE stock",
+        "shortName": "DS150 FDE"
+    },
+    "5a788169c5856700142fdd9e": {
+        "id": "5a788169c5856700142fdd9e",
+        "name": "Raptor grip for M870",
+        "shortName": "Raptor"
+    },
+    "5afd7ded5acfc40017541f5e": {
+        "id": "5afd7ded5acfc40017541f5e",
+        "name": "Tapco INTRAFUSE Stock for SKS",
+        "shortName": "Tapco intrafuse stock"
+    },
+    "5fbcc437d724d907e2077d5c": {
+        "id": "5fbcc437d724d907e2077d5c",
+        "name": "SIG Sauer Thin lightweight MCX/MPX stock",
+        "shortName": "MCX/MPX thin"
+    },
+    "5cbdb1b0ae9215000d50e105": {
+        "id": "5cbdb1b0ae9215000d50e105",
+        "name": "Izhmash polymer Plum AK-74 stock (6P20 Sb.7)",
+        "shortName": "6P20 Sb.7 Plum"
+    },
+    "58d2947686f774485c6a1ee5": {
+        "id": "58d2947686f774485c6a1ee5",
+        "name": "MOE Carbine stock OD",
+        "shortName": "MOE Stock OD"
+    },
+    "5b7d63cf5acfc4001876c8df": {
+        "id": "5b7d63cf5acfc4001876c8df",
+        "name": "DSA Folding stock for SA-58",
+        "shortName": "SA-58 Folding"
+    },
+    "5cc700d4e4a949000f0f0f28": {
+        "id": "5cc700d4e4a949000f0f0f28",
+        "name": "Damage Industries Butt-pad for P90",
+        "shortName": "DI Butt"
+    },
+    "5e217ba4c1434648c13568cd": {
+        "id": "5e217ba4c1434648c13568cd",
+        "name": "Hexagon \"Kocherga\" stock red",
+        "shortName": "Kocherga"
+    },
+    "5fbbaa86f9986c4cff3fe5f6": {
+        "id": "5fbbaa86f9986c4cff3fe5f6",
+        "name": "KRISS Defiance DS150 stock",
+        "shortName": "DS150 Stock"
+    },
+    "5de655be4a9f347bc92edb88": {
+        "id": "5de655be4a9f347bc92edb88",
+        "name": "Regular VPO-215 stock",
+        "shortName": "VPO-215 stock"
+    },
+    "5c793fb92e221644f31bfb64": {
+        "id": "5c793fb92e221644f31bfb64",
+        "name": "SI Advanced receiver extension buffer tube",
+        "shortName": "Advanced Tube"
+    },
+    "5aaf8e43e5b5b00015693246": {
+        "id": "5aaf8e43e5b5b00015693246",
+        "name": "M1A Socom 16 stock",
+        "shortName": "Socom16"
+    },
+    "5d120a10d7ad1a4e1026ba85": {
+        "id": "5d120a10d7ad1a4e1026ba85",
+        "name": "Double Star Ace Socom gen.4 stock for AR-15",
+        "shortName": "Gen.4 stock"
+    },
+    "5cdeac22d7f00c000f26168f": {
+        "id": "5cdeac22d7f00c000f26168f",
+        "name": "Magpul PRO 700 chassis",
+        "shortName": "PRO 700"
+    },
+    "5bfd36290db834001966869a": {
+        "id": "5bfd36290db834001966869a",
+        "name": "Sawn off Mosin rifle sniper stock",
+        "shortName": "Sawn off sniper Mosin Stock"
+    },
+    "5bfeb32b0db834001a6694d9": {
+        "id": "5bfeb32b0db834001a6694d9",
+        "name": "Hogue \"Overmolded ghillie\" stock for Remington Model 700",
+        "shortName": "Overmolded ghillie"
+    },
+    "56eabf3bd2720b75698b4569": {
+        "id": "56eabf3bd2720b75698b4569",
+        "name": "MOE Carbine stock",
+        "shortName": "MOE Stock"
+    },
+    "5a38ef1fc4a282000b1521f6": {
+        "id": "5a38ef1fc4a282000b1521f6",
+        "name": "TOZ stock for TOZ-106",
+        "shortName": "TOZ-106 Stock"
+    },
+    "5cf13123d7f00c1085616a50": {
+        "id": "5cf13123d7f00c1085616a50",
+        "name": "Promag Archangel polymer stock for M700",
+        "shortName": "Archangel M700"
+    },
+    "5bb20e58d4351e00320205d7": {
+        "id": "5bb20e58d4351e00320205d7",
+        "name": "HK \"Enhanced Tube\" buffer tube",
+        "shortName": "Enhanced Tube"
+    },
+    "5a7880d0c5856700142fdd9d": {
+        "id": "5a7880d0c5856700142fdd9d",
+        "name": "Remington SPS Polymer stock for M870",
+        "shortName": "SPS M870"
+    },
+    "5bae13bad4351e00320204af": {
+        "id": "5bae13bad4351e00320204af",
+        "name": "ProMag Archangel OPFOR PRS Mosin rifle stock",
+        "shortName": "Archangel OPFOR PRS"
+    },
+    "5fb6558ad6f0b2136f2d7eb7": {
+        "id": "5fb6558ad6f0b2136f2d7eb7",
+        "name": "KRISSVector Gen.2 folding stock",
+        "shortName": "Vector fold."
+    },
+    "5b7d645e5acfc400170e2f90": {
+        "id": "5b7d645e5acfc400170e2f90",
+        "name": "Polymer stock DSA humpback for SA-58",
+        "shortName": "SA-58 Humpback"
+    },
+    "5bfd36ad0db834001c38ef66": {
+        "id": "5bfd36ad0db834001c38ef66",
+        "name": "Sawn off regular Mosin rifle stock",
+        "shortName": "Sawn off Mosin stock"
+    },
+    "5fbcc429900b1d5091531dd7": {
+        "id": "5fbcc429900b1d5091531dd7",
+        "name": "SIG Sauer telescoping MCX/MPX stock",
+        "shortName": "MCX/MPX telescoping"
+    },
+    "5ef1ba28c64c5d0dfc0571a5": {
+        "id": "5ef1ba28c64c5d0dfc0571a5",
+        "name": "Mesa Tactical Crosshair Hydraulic buffer tube",
+        "shortName": "Mesa Crosshair"
+    },
+    "5cde739cd7f00c0010373bd3": {
+        "id": "5cde739cd7f00c0010373bd3",
+        "name": "M700 MOD X Gen.3 stock",
+        "shortName": "MOD X Gen.3"
+    },
+    "57616ca52459773c69055192": {
+        "id": "57616ca52459773c69055192",
+        "name": "Izhmash SOK-12 АК type stock",
+        "shortName": "SOK-12АК Stock"
+    },
+    "55818a594bdc2db9688b456a": {
+        "id": "55818a594bdc2db9688b456a",
+        "name": "Stock",
+        "shortName": "Item"
+    },
+    "55818a6f4bdc2db9688b456b": {
+        "id": "55818a6f4bdc2db9688b456b",
+        "name": "Charging handle",
+        "shortName": "Item"
+    },
+    "55818b224bdc2dde698b456f": {
+        "id": "55818b224bdc2dde698b456f",
+        "name": "Mount",
+        "shortName": "Item"
+    },
+    "55818b014bdc2ddc698b456b": {
+        "id": "55818b014bdc2ddc698b456b",
+        "name": "UBGL",
+        "shortName": "Item"
+    },
+    "55818a604bdc2db5418b457e": {
+        "id": "55818a604bdc2db5418b457e",
+        "name": "Mag shaft",
+        "shortName": "Item"
+    },
+    "5448bc234bdc2d3c308b4569": {
+        "id": "5448bc234bdc2d3c308b4569",
+        "name": "Magazine",
+        "shortName": "Item"
+    },
+    "5c5db5852e2216003a0fe71a": {
+        "id": "5c5db5852e2216003a0fe71a",
+        "name": "4.5\" 9x19 barrel for MPX",
+        "shortName": "4.5\" MPX 9x19"
+    },
+    "560836fb4bdc2d773f8b4569": {
+        "id": "560836fb4bdc2d773f8b4569",
+        "name": "660mm barrel for МR-133 12ga shotgun",
+        "shortName": "660mm МR-133"
+    },
+    "588200af24597742fa221dfb": {
+        "id": "588200af24597742fa221dfb",
+        "name": "610 mm barrel for MP-153 12ga shotgun",
+        "shortName": "610mm МР-153 12ga"
+    },
+    "588200c224597743990da9ed": {
+        "id": "588200c224597743990da9ed",
+        "name": "660 mm barrel for MP-153 12ga shotgun",
+        "shortName": "660mm МР-153 12ga"
+    },
+    "58aeaaa886f7744fc1560f81": {
+        "id": "58aeaaa886f7744fc1560f81",
+        "name": "165 mm 9x19 barrel for MPX-SD",
+        "shortName": "165mm MPXSD 9x19"
+    },
+    "5e848d2eea0a7c419c2f9bfd": {
+        "id": "5e848d2eea0a7c419c2f9bfd",
+        "name": "700mm barrel for KS-23 23x75mm",
+        "shortName": "700mm KS23 23mm"
+    },
+    "5c5db5962e2216000e5e46eb": {
+        "id": "5c5db5962e2216000e5e46eb",
+        "name": "6.5\" 9x19 barrel for MPX",
+        "shortName": "6.5\" MPX 9x19"
+    },
+    "560837824bdc2d57468b4568": {
+        "id": "560837824bdc2d57468b4568",
+        "name": "750mm barrel for MP-133 12ga shotgun",
+        "shortName": "750mm MP-133"
+    },
+    "560836484bdc2d20478b456e": {
+        "id": "560836484bdc2d20478b456e",
+        "name": "540mm barrel for MP-133 12ga shotgun",
+        "shortName": "540mm MP-133"
+    },
+    "5c5db5c62e22160012542255": {
+        "id": "5c5db5c62e22160012542255",
+        "name": "14\" 9x19 barrel for MPX",
+        "shortName": "14\" MPX 9x19"
+    },
+    "55d3632e4bdc2d972f8b4569": {
+        "id": "55d3632e4bdc2d972f8b4569",
+        "name": "370mm barrel for AR-15 and compatible 5.56x45",
+        "shortName": "370mm AR-15 5.56x45"
+    },
+    "55d448594bdc2d8c2f8b4569": {
+        "id": "55d448594bdc2d8c2f8b4569",
+        "name": "610mm barrel for MP-133 12ga shotgun",
+        "shortName": "610mm MP-133 12ga"
+    },
+    "5fbbfabed5cb881a7363194e": {
+        "id": "5fbbfabed5cb881a7363194e",
+        "name": "171mm barrel for MCX and compatible .300 BLK",
+        "shortName": "171mm MCX .300 BLK"
+    },
+    "5888945a2459774bf43ba385": {
+        "id": "5888945a2459774bf43ba385",
+        "name": "500mm .308 barrel for DVL-10",
+        "shortName": "DVL-10 500mm .308"
+    },
+    "5a34fae7c4a2826c6e06d760": {
+        "id": "5a34fae7c4a2826c6e06d760",
+        "name": "22\" barrel for a AR-10 and compatible 7.62x51 NATO",
+        "shortName": "22\" AR-10"
+    },
+    "5cc701aae4a949000e1ea45c": {
+        "id": "5cc701aae4a949000e1ea45c",
+        "name": "10.5\" barrel for P90 5.7x28",
+        "shortName": "10.5\" P90 5.7x28"
+    },
+    "5608373c4bdc2dc8488b4570": {
+        "id": "5608373c4bdc2dc8488b4570",
+        "name": "710mm barrel for MP-133 12ga shotgun",
+        "shortName": "710mm MP-133"
+    },
+    "5fbbfacda56d053a3543f799": {
+        "id": "5fbbfacda56d053a3543f799",
+        "name": "229mm barrel for MCX and compatible .300 BLK",
+        "shortName": "229mm MCX .300 BLK"
+    },
+    "5d440b93a4b9364276578d4b": {
+        "id": "5d440b93a4b9364276578d4b",
+        "name": "18\" barrel for AR-15 and compatible 5.56x45",
+        "shortName": "18\" AR-15 5.56x45"
+    },
+    "5fc23678ab884124df0cd590": {
+        "id": "5fc23678ab884124df0cd590",
+        "name": "24\" barrel for Mk-18 .338 LM",
+        "shortName": "24\" Mk-18 .338 LM"
+    },
+    "5cc701d7e4a94900100ac4e7": {
+        "id": "5cc701d7e4a94900100ac4e7",
+        "name": "16\" barrel for P90 5.7x28",
+        "shortName": "16\" P90 5.7x28"
+    },
+    "5f2aa46b878ef416f538b567": {
+        "id": "5f2aa46b878ef416f538b567",
+        "name": "18\" barrel for RFB 7.62x51",
+        "shortName": "18\" RFB 7.62x51"
+    },
+    "5894a2c386f77427140b8342": {
+        "id": "5894a2c386f77427140b8342",
+        "name": "203 mm 9x19 barrel for MPX",
+        "shortName": "203mm MPX 9x19"
+    },
+    "588200cf2459774414733d55": {
+        "id": "588200cf2459774414733d55",
+        "name": "710 mm barrel for MP-153 12ga shotgun",
+        "shortName": "710mm МР-153 12ga"
+    },
+    "56deec93d2720bec348b4568": {
+        "id": "56deec93d2720bec348b4568",
+        "name": "750 mm barrel for MP-153 12ga shotgun",
+        "shortName": "750mm МР-153 12ga"
+    },
+    "5c0e2f94d174af029f650d56": {
+        "id": "5c0e2f94d174af029f650d56",
+        "name": "406mm Molot barrel for AR-15 and compatible 5.56x45",
+        "shortName": "406mm AR-15 5.56x45"
+    },
+    "5a34f7f1c4a2826c6e06d75d": {
+        "id": "5a34f7f1c4a2826c6e06d75d",
+        "name": "18\" barrel for a AR-10 and compatible 7.62x51 NATO",
+        "shortName": "18\" AR-10"
+    },
+    "5e848d1c264f7c180b5e35a9": {
+        "id": "5e848d1c264f7c180b5e35a9",
+        "name": "510mm barrel for KS-23 23x75mm",
+        "shortName": "510mm KS23 23mm"
+    },
+    "5c5db5b82e2216003a0fe71d": {
+        "id": "5c5db5b82e2216003a0fe71d",
+        "name": "10.5\" 9x19 barrel for MPX",
+        "shortName": "10.5\" MPX 9x19"
+    },
+    "55d4491a4bdc2d882f8b456e": {
+        "id": "55d4491a4bdc2d882f8b456e",
+        "name": "510mm barrel for MP-133 12ga",
+        "shortName": "510mm MP-133 12ga"
+    },
+    "55d35ee94bdc2d61338b4568": {
+        "id": "55d35ee94bdc2d61338b4568",
+        "name": "260mm barrel for AR-15 and compatible 5.56x45",
+        "shortName": "260mm AR-15 5.56x45"
+    },
+    "5d440b9fa4b93601354d480c": {
+        "id": "5d440b9fa4b93601354d480c",
+        "name": "20\" barrel for AR-15 and compatible 5.56x45",
+        "shortName": "20\" AR-15 5.56x45"
+    },
+    "5888956924597752983e182d": {
+        "id": "5888956924597752983e182d",
+        "name": "660mm .308 barrel for DVL-10 M2",
+        "shortName": "DVL-10 M2 660mm .308"
+    },
+    "5608379a4bdc2d26448b4569": {
+        "id": "5608379a4bdc2d26448b4569",
+        "name": "750mm barrel for MP-133 12ga shotgun with rib",
+        "shortName": "750mm MP-133 12ga"
+    },
+    "5a6b5f868dc32e000a311389": {
+        "id": "5a6b5f868dc32e000a311389",
+        "name": "Basic barrel for Glock 17 9x19",
+        "shortName": "G17 9x19"
+    },
+    "5d3eb59ea4b9361c284bb4b2": {
+        "id": "5d3eb59ea4b9361c284bb4b2",
+        "name": "Threaded barrel for Five-seveN 5.7x28",
+        "shortName": "57 tr. 5.7x28"
+    },
+    "5cadc1c6ae9215000f2775a4": {
+        "id": "5cadc1c6ae9215000f2775a4",
+        "name": "Threaded barrel for M9A3 9x19",
+        "shortName": "M9A3 tr. 9x19"
+    },
+    "5a787fadc5856700155a6ca1": {
+        "id": "5a787fadc5856700155a6ca1",
+        "name": "660mm vent rib barrel for M870 12ga",
+        "shortName": "660mm M870"
+    },
+    "5b099a765acfc47a8607efe3": {
+        "id": "5b099a765acfc47a8607efe3",
+        "name": "11\" barrel for SA-58 7.62x51",
+        "shortName": "11\" SA-58 7.62x51"
+    },
+    "5fbbc366ca32ed67276c1557": {
+        "id": "5fbbc366ca32ed67276c1557",
+        "name": "5\" barrel for Vector 9x19",
+        "shortName": "Vector 5\" 9x19"
+    },
+    "5a6b5e468dc32e001207faf5": {
+        "id": "5a6b5e468dc32e001207faf5",
+        "name": "Threaded barrel for Glock 9x19 manufactured by Double Diamond",
+        "shortName": "Glock 9x19 DD"
+    },
+    "5bfd4cc90db834001d23e846": {
+        "id": "5bfd4cc90db834001d23e846",
+        "name": "Sawn off 200mm Mosin barrel",
+        "shortName": "200mm Mosin barrel"
+    },
+    "560837154bdc2da74d8b4568": {
+        "id": "560837154bdc2da74d8b4568",
+        "name": "660mm barrel for MP-133 12ga shotgun with rib",
+        "shortName": "660mm MP-133 12ga"
+    },
+    "5a6b60158dc32e000a31138b": {
+        "id": "5a6b60158dc32e000a31138b",
+        "name": "Barrel with compensator for Glock 17 9x19",
+        "shortName": "G17 9x19 comp"
+    },
+    "5d3eb5b6a4b9361eab311902": {
+        "id": "5d3eb5b6a4b9361eab311902",
+        "name": "Barrel for Five-seveN 5.7x28",
+        "shortName": "57 5.7x28"
+    },
+    "5bb20d92d4351e00853263eb": {
+        "id": "5bb20d92d4351e00853263eb",
+        "name": "11\" barrel for 416A5 and compatible 5.56x45",
+        "shortName": "11\" 416A5 5.56x45"
+    },
+    "5d2702e88abbc31ed91efc44": {
+        "id": "5d2702e88abbc31ed91efc44",
+        "name": "26\" stainless steel barrel for a Remington M700 7.62x51 NATO",
+        "shortName": "26\" M700"
+    },
+    "56d5a1f7d2720bb3418b456a": {
+        "id": "56d5a1f7d2720bb3418b456a",
+        "name": "112mm barrel for P226 9x19",
+        "shortName": "112mm P226 9x19"
+    },
+    "5e81c519cb2b95385c177551": {
+        "id": "5e81c519cb2b95385c177551",
+        "name": "Standart barrel for M1911A1 .45 ACP",
+        "shortName": "M1911A1 .45"
+    },
+    "560836b64bdc2d57468b4567": {
+        "id": "560836b64bdc2d57468b4567",
+        "name": "540mm barrel for МR-133 12ga shotgun with rib",
+        "shortName": "540mm MP-133 12ga"
+    },
+    "5ae09bff5acfc4001562219d": {
+        "id": "5ae09bff5acfc4001562219d",
+        "name": "Regular 730mm Mosin barrel",
+        "shortName": "730mm Mosin barrel"
+    },
+    "5f3e7801153b8571434a924c": {
+        "id": "5f3e7801153b8571434a924c",
+        "name": "National match barrel for M1911 .45 ACP",
+        "shortName": "National match .45"
+    },
+    "5bb20da5d4351e0035629dbf": {
+        "id": "5bb20da5d4351e0035629dbf",
+        "name": "16.5\" barrel for 416A5 and compatible 5.56x45",
+        "shortName": "16.5\" 416A5 5.56x45"
+    },
+    "5e87071478f43e51ca2de5e1": {
+        "id": "5e87071478f43e51ca2de5e1",
+        "name": "20\" barrel for M590 12ga",
+        "shortName": "20\" M590"
+    },
+    "5bfebc320db8340019668d79": {
+        "id": "5bfebc320db8340019668d79",
+        "name": "20\" barrel for a Remington M700 7.62x51 NATO",
+        "shortName": "20\" M700 7.62x51"
+    },
+    "5bfd4cbe0db834001b73449f": {
+        "id": "5bfd4cbe0db834001b73449f",
+        "name": "Regular 514mm Mosin carbine barrel",
+        "shortName": "514mm Mosin barrel"
+    },
+    "5bb20d9cd4351e00334c9d8a": {
+        "id": "5bb20d9cd4351e00334c9d8a",
+        "name": "14.5\" barrel for 416A5 and compatible 5.56x45",
+        "shortName": "14.5\" 416A5 5.56x45"
+    },
+    "5bb20dadd4351e00367faeff": {
+        "id": "5bb20dadd4351e00367faeff",
+        "name": "20\" barrel for 416A5 and compatible 5.56x45",
+        "shortName": "20\" 416A5 5.56x45"
+    },
+    "5a6b5ed88dc32e000c52ec86": {
+        "id": "5a6b5ed88dc32e000c52ec86",
+        "name": "Threaded barrel for Glock 9x19 manufactured by Salient Arms",
+        "shortName": "Glock 9x19 SAI"
+    },
+    "5b7be1125acfc4001876c0e5": {
+        "id": "5b7be1125acfc4001876c0e5",
+        "name": "16\" barrel for SA-58 7.62x51",
+        "shortName": "16\" SA-58 7.62x51"
+    },
+    "5fb653962b1b027b1f50bd03": {
+        "id": "5fb653962b1b027b1f50bd03",
+        "name": "6\" Vector barrel .45 ACP",
+        "shortName": "Vector 6\" .45"
+    },
+    "5dfa397fb11454561e39246c": {
+        "id": "5dfa397fb11454561e39246c",
+        "name": "20\" barrel for SR-25 and compatible 7.62x51",
+        "shortName": "20\" SR-25 7.62x51"
+    },
+    "5c6d85e02e22165df16b81f4": {
+        "id": "5c6d85e02e22165df16b81f4",
+        "name": "10.6\" barrel for 416A5 and compatible 5.56x45",
+        "shortName": "10.6\" 416A5 5.56x45"
+    },
+    "587de4282459771bca0ec90b": {
+        "id": "587de4282459771bca0ec90b",
+        "name": "Threaded barrel for P226 9x19",
+        "shortName": "P226 tr. 9x19"
+    },
+    "5de65547883dde217541644b": {
+        "id": "5de65547883dde217541644b",
+        "name": "23\" barrel for a VPO-215 .366TKM",
+        "shortName": "23\" 215 .366TKM"
+    },
+    "55d449444bdc2d962f8b456d": {
+        "id": "55d449444bdc2d962f8b456d",
+        "name": "610mm barrel for MP-133 12ga shotgun with rib",
+        "shortName": "610mm MP-133 12ga"
+    },
+    "5df256570dee1b22f862e9c4": {
+        "id": "5df256570dee1b22f862e9c4",
+        "name": "660mm .308 barrel for T-5000",
+        "shortName": "T-5000 660mm .308"
+    },
+    "5a787fdfc5856700142fdd9a": {
+        "id": "5a787fdfc5856700142fdd9a",
+        "name": "Cut off 325mm barrel for M870 12ga",
+        "shortName": "325mm M870"
+    },
+    "5ea02bb600685063ec28bfa1": {
+        "id": "5ea02bb600685063ec28bfa1",
+        "name": "10.6\" barrel for PPSH-41 7.62x25",
+        "shortName": "10.6\" PPSH-41 7.62x25"
+    },
+    "5a787f7ac5856700177af660": {
+        "id": "5a787f7ac5856700177af660",
+        "name": "508mm barrel for M870 12ga",
+        "shortName": "508mm M870"
+    },
+    "5a787f25c5856700186c4ab9": {
+        "id": "5a787f25c5856700186c4ab9",
+        "name": "355mm barrel for M870 12ga",
+        "shortName": "355mm M870"
+    },
+    "5fc3e4a27283c4046c5814ab": {
+        "id": "5fc3e4a27283c4046c5814ab",
+        "name": "8\" barrel for UMP .45 ACP",
+        "shortName": "8\" UMP .45 ACP"
+    },
+    "560837544bdc2de22e8b456e": {
+        "id": "560837544bdc2de22e8b456e",
+        "name": "710mm barrel for МR-133 12ga shotgun with rib",
+        "shortName": "710mm MP-133 12ga"
+    },
+    "571a26d524597720680fbe8a": {
+        "id": "571a26d524597720680fbe8a",
+        "name": "116mm 7.62x25 ТТ barrel",
+        "shortName": "116mm st. ТТ"
+    },
+    "5f3e77f59103d430b93f94c1": {
+        "id": "5f3e77f59103d430b93f94c1",
+        "name": "Threaded barrel for M1911A1 .45 ACP",
+        "shortName": "M1911A1 .45"
+    },
+    "5fb65363d1409e5ca04b54f5": {
+        "id": "5fb65363d1409e5ca04b54f5",
+        "name": "5\" Vector barrel .45 ACP",
+        "shortName": "Vector 5\" .45"
+    },
+    "5b7be1265acfc400161d0798": {
+        "id": "5b7be1265acfc400161d0798",
+        "name": "21\" barrel for SA-58 7.62x51",
+        "shortName": "21\" SA-58 7.62x51"
+    },
+    "5dcbe9431e1f4616d354987e": {
+        "id": "5dcbe9431e1f4616d354987e",
+        "name": "16 inch .308 barrel for MDR and compatible",
+        "shortName": "16\" MDR 308"
+    },
+    "571a279b24597720b4066566": {
+        "id": "571a279b24597720b4066566",
+        "name": "Homespun 121mm 7.62x25 ТТ barrel with threading",
+        "shortName": "121mm thr. TT"
+    },
+    "5b1fa9ea5acfc40018633c0a": {
+        "id": "5b1fa9ea5acfc40018633c0a",
+        "name": "Barrel with compensator for Glock 18C 9x19",
+        "shortName": "G18C 9x19 comp"
+    },
+    "5b3baf8f5acfc40dc5296692": {
+        "id": "5b3baf8f5acfc40dc5296692",
+        "name": "116mm 7.62x25 TT gilded barrel",
+        "shortName": "116mm gld. ТТ"
+    },
+    "5a6b5b8a8dc32e001207faf3": {
+        "id": "5a6b5b8a8dc32e001207faf3",
+        "name": "Threaded barrel for Glock 9x19 manufactured by Lone Wolf.",
+        "shortName": "Glock 9x19 AW"
+    },
+    "5c48a2852e221602b21d5923": {
+        "id": "5c48a2852e221602b21d5923",
+        "name": "406mm barrel for MDR and compatible 5.56x45",
+        "shortName": "406mm MDR 5.56x45"
+    },
+    "5df917564a9f347bc92edca3": {
+        "id": "5df917564a9f347bc92edca3",
+        "name": "16\" barrel for SR-25 and compatible 7.62x51",
+        "shortName": "16\" SR-25 7.62x51"
+    },
+    "5beec1bd0db834001e6006f3": {
+        "id": "5beec1bd0db834001e6006f3",
+        "name": "15\" barrel for RPK-16 and compatible 5.45x39",
+        "shortName": "15\" RPK-16 5.45x39"
+    },
+    "5beec2820db834001b095426": {
+        "id": "5beec2820db834001b095426",
+        "name": "22\" barrel for RPK-16 and compatible 5.45x39",
+        "shortName": "22\"  RPK-16  5.45x39"
+    },
+    "5c471cb32e221602b177afaa": {
+        "id": "5c471cb32e221602b177afaa",
+        "name": "22\" barrel for a SVDS 7.62x54",
+        "shortName": "22\" SVDS"
+    },
+    "560835c74bdc2dc8488b456f": {
+        "id": "560835c74bdc2dc8488b456f",
+        "name": "510mm barrel for MP-133 12ga shotgun with rib",
+        "shortName": "510mm MP-133 12ga"
+    },
+    "5bfebc250db834001a6694e1": {
+        "id": "5bfebc250db834001a6694e1",
+        "name": "26\" barrel for a Remington M700 7.62x51 NATO",
+        "shortName": "26\" M700"
+    },
+    "5a787ebcc5856700142fdd98": {
+        "id": "5a787ebcc5856700142fdd98",
+        "name": "508mm barrel for M870 12ga with a fixed sight",
+        "shortName": "508mm M870 FS"
+    },
+    "5aaf9d53e5b5b00015042a52": {
+        "id": "5aaf9d53e5b5b00015042a52",
+        "name": "16\" barrel for a M1A 7.62x51 NATO",
+        "shortName": "16\" M1A 7.62x51"
+    },
+    "5addbac75acfc400194dbc56": {
+        "id": "5addbac75acfc400194dbc56",
+        "name": "22\" barrel for a M1A 7.62x51 NATO",
+        "shortName": "22\" M1A 7.62x51"
+    },
+    "5d2703038abbc3105103d94c": {
+        "id": "5d2703038abbc3105103d94c",
+        "name": "20\" stainless steel barrel for a Remington M700 7.62x51 NATO",
+        "shortName": "20\" M700 7.62x51"
+    },
+    "5bfd4cd60db834001c38f095": {
+        "id": "5bfd4cd60db834001c38f095",
+        "name": "Sawn off 220mm Mosin barrel",
+        "shortName": "220mm Mosin barrel"
+    },
+    "5fbbc383d5cb881a7363194a": {
+        "id": "5fbbc383d5cb881a7363194a",
+        "name": "6\" barrel for Vector 9x19",
+        "shortName": "Vector 6\" 9x19"
+    },
+    "5648b4534bdc2d3d1c8b4580": {
+        "id": "5648b4534bdc2d3d1c8b4580",
+        "name": "B-10М foregrip and rail mount B-19",
+        "shortName": "B-10М B-19"
+    },
+    "5b80242286f77429445e0b47": {
+        "id": "5b80242286f77429445e0b47",
+        "name": "Hexagon handguard for AK(anodized red)",
+        "shortName": "Hex red"
+    },
+    "5a9548c9159bd400133e97b3": {
+        "id": "5a9548c9159bd400133e97b3",
+        "name": "MP5 TL-99 Aluminum handguard",
+        "shortName": "TL-99"
+    },
+    "55d45f484bdc2d972f8b456d": {
+        "id": "55d45f484bdc2d972f8b456d",
+        "name": "Custom plastic MP-133 forestock with mounts",
+        "shortName": "Custom MP-133 plastic"
+    },
+    "5d1b198cd7ad1a604869ad72": {
+        "id": "5d1b198cd7ad1a604869ad72",
+        "name": "TDI AKM-L handguard for AK",
+        "shortName": "AKM-L"
+    },
+    "57cffe20245977632f391a9d": {
+        "id": "57cffe20245977632f391a9d",
+        "name": "Magpul MOE AKM HAND GUARD (Stealth Gray) for AK",
+        "shortName": "MOE AKM"
+    },
+    "5bb20de5d4351e0035629e59": {
+        "id": "5bb20de5d4351e0035629e59",
+        "name": "HK quadrail handguard for 416-compatible systems",
+        "shortName": "Quadrail"
+    },
+    "57ffa9f4245977728561e844": {
+        "id": "57ffa9f4245977728561e844",
+        "name": "B-11 AKS-74U Handguard",
+        "shortName": "B-11"
+    },
+    "57cff947245977638e6f2a19": {
+        "id": "57cff947245977638e6f2a19",
+        "name": "Magpul MOE AKM HAND GUARD (Black) for AK",
+        "shortName": "MOE AKM"
+    },
+    "5d010d1cd7ad1a59283b1ce7": {
+        "id": "5d010d1cd7ad1a59283b1ce7",
+        "name": "CAA HX-5 MP5 handguard",
+        "shortName": "HX-5"
+    },
+    "55f84c3c4bdc2d5f408b4576": {
+        "id": "55f84c3c4bdc2d5f408b4576",
+        "name": "Daniel Defence RIS II 9.5 foregrip for AR-15-compatible systems",
+        "shortName": "RIS II 9.5 FDE"
+    },
+    "5926c36d86f77467a92a8629": {
+        "id": "5926c36d86f77467a92a8629",
+        "name": "MP5 Wide Tropical Polymer handguard",
+        "shortName": "MP5WT"
+    },
+    "59fb375986f7741b681b81a6": {
+        "id": "59fb375986f7741b681b81a6",
+        "name": "Krebs Custom UFM Keymod System handguard for AKM",
+        "shortName": "UFM"
+    },
+    "5c617a5f2e2216000f1e81b3": {
+        "id": "5c617a5f2e2216000f1e81b3",
+        "name": "Zenit B-10 AK Handguard",
+        "shortName": "B-10"
+    },
+    "5926f34786f77469195bfe92": {
+        "id": "5926f34786f77469195bfe92",
+        "name": "MP5SD Polymer handguard",
+        "shortName": "MP5SD HG"
+    },
+    "5efaf417aeb21837e749c7f2": {
+        "id": "5efaf417aeb21837e749c7f2",
+        "name": "B-30 foregrip and rail mount B-31С",
+        "shortName": "B-30 B-31С"
+    },
+    "5b800e9286f7747a8b04f3ff": {
+        "id": "5b800e9286f7747a8b04f3ff",
+        "name": "Hexagon handguard for AK",
+        "shortName": "Hex Blk"
+    },
+    "57cffe0024597763b03fc60b": {
+        "id": "57cffe0024597763b03fc60b",
+        "name": "Magpul MOE AKM HAND GUARD (Plum) for AK",
+        "shortName": "MOE AKM"
+    },
+    "55d459824bdc2d892f8b4573": {
+        "id": "55d459824bdc2d892f8b4573",
+        "name": "Knight's Armament KAC RIS handguard for AR-15 and compatibles",
+        "shortName": "KAC RIS"
+    },
+    "57cffd8224597763b03fc609": {
+        "id": "57cffd8224597763b03fc609",
+        "name": "Magpul MOE AKM HAND GUARD (Flat Dark Earth) for AK",
+        "shortName": "MOE AKM"
+    },
+    "5f6331e097199b7db2128dc2": {
+        "id": "5f6331e097199b7db2128dc2",
+        "name": "X47 Tactical Handguard for AK and compatible",
+        "shortName": "X47"
+    },
+    "5c78f2492e221600114c9f04": {
+        "id": "5c78f2492e221600114c9f04",
+        "name": "SAI 14.5\" QD Rail foregrip for AR15",
+        "shortName": "SAI QD Rail"
+    },
+    "5a788068c5856700137e4c8f": {
+        "id": "5a788068c5856700137e4c8f",
+        "name": "Magpul MOE M870 forestock",
+        "shortName": "MOE 870"
+    },
+    "5c17664f2e2216398b5a7e3c": {
+        "id": "5c17664f2e2216398b5a7e3c",
+        "name": "VLTOR CMRD Keymod handguard for AK",
+        "shortName": "CMRD"
+    },
+    "5a788031c585673f2b5c1c79": {
+        "id": "5a788031c585673f2b5c1c79",
+        "name": "Fab Defence PR870 forestock",
+        "shortName": "PR870"
+    },
+    "5d4aaa54a4b9365392071170": {
+        "id": "5d4aaa54a4b9365392071170",
+        "name": "TDI AKM-L handguard for AK Anodized Red",
+        "shortName": "AKM-L AR"
+    },
+    "5bb20df1d4351e00347787d5": {
+        "id": "5bb20df1d4351e00347787d5",
+        "name": "HK quadrail handguard with a flip-up sight for 416-compatible systems",
+        "shortName": "Quad. sight"
+    },
+    "5d00e0cbd7ad1a6c6566a42d": {
+        "id": "5d00e0cbd7ad1a6c6566a42d",
+        "name": "Strike Industries Viper carbine length M-LOK foregrip for AR-15",
+        "shortName": "Viper"
+    },
+    "5a957c3fa2750c00137fa5f7": {
+        "id": "5a957c3fa2750c00137fa5f7",
+        "name": "XRSU47SU Tactical Handguard for AKS-74U",
+        "shortName": "XRSU47SU"
+    },
+    "5c9a1c3a2e2216000e69fb6a": {
+        "id": "5c9a1c3a2e2216000e69fb6a",
+        "name": "Magpul Zhukov-U HAND GUARD (FDE) for AK",
+        "shortName": "Zhukov-U"
+    },
+    "5c6d11072e2216000e69d2e4": {
+        "id": "5c6d11072e2216000e69d2e4",
+        "name": "Midwest 13.5\" M-LOK foregrip for 416A5",
+        "shortName": "Midwest M-LOK"
+    },
+    "5c48a14f2e2216152006edd7": {
+        "id": "5c48a14f2e2216152006edd7",
+        "name": "Desert Tech foregrip for MDR",
+        "shortName": "MDR Handguard"
+    },
+    "55d45d3f4bdc2d972f8b456c": {
+        "id": "55d45d3f4bdc2d972f8b456c",
+        "name": "Izhmekh MP-133 Beechwood forestock",
+        "shortName": "МR-133 Beechwood"
+    },
+    "5c9a07572e221644f31c4b32": {
+        "id": "5c9a07572e221644f31c4b32",
+        "name": "Magpul Zhukov-U HAND GUARD (Black) for AK",
+        "shortName": "Zhukov-U"
+    },
+    "5ae30db85acfc408fb139a05": {
+        "id": "5ae30db85acfc408fb139a05",
+        "name": "Colt M4 Length handguard for AR-15 and compatibles",
+        "shortName": "M4 Std."
+    },
+    "595cfa8b86f77427437e845b": {
+        "id": "595cfa8b86f77427437e845b",
+        "name": "Handguard War Sport LVOA-C blk. for use with AR-15 and compatible",
+        "shortName": "LVOA-C blk."
+    },
+    "59d64f2f86f77417193ef8b3": {
+        "id": "59d64f2f86f77417193ef8b3",
+        "name": "Wooden AK-74 handguard (6P1 Sb.6-1)",
+        "shortName": "6P1 Sb.6-1"
+    },
+    "5c5db5f22e2216000e5e47e8": {
+        "id": "5c5db5f22e2216000e5e47e8",
+        "name": "Midwest 4.5 inch M-LOK foregrip for MPX",
+        "shortName": "Midwest 4.5 inch"
+    },
+    "5c5db63a2e2216000f1b284a": {
+        "id": "5c5db63a2e2216000f1b284a",
+        "name": "Midwest 14 inch M-LOK foregrip for MPX",
+        "shortName": "Midwest 14 inch"
+    },
+    "5c78f26f2e221601da3581d1": {
+        "id": "5c78f26f2e221601da3581d1",
+        "name": "Magpul MOE SL mid length M-LOK foregrip for AR15",
+        "shortName": "MOE SL"
+    },
+    "5eea21647547d6330471b3c9": {
+        "id": "5eea21647547d6330471b3c9",
+        "name": "Magpul MOE M590 forestock",
+        "shortName": "MOE M590"
+    },
+    "57cffddc24597763133760c6": {
+        "id": "57cffddc24597763133760c6",
+        "name": "Magpul MOE AKM HAND GUARD (Flat Dark Earth) for AK",
+        "shortName": "MOE AKM"
+    },
+    "5b7bee755acfc400196d5383": {
+        "id": "5b7bee755acfc400196d5383",
+        "name": "Vltor CASV FAS foregrip for FAL",
+        "shortName": "CASV FAS Handguard"
+    },
+    "5cbda9f4ae9215000e5b9bfc": {
+        "id": "5cbda9f4ae9215000e5b9bfc",
+        "name": "Polymer AK-74 foregrip (6P20 Sb.9) Plum",
+        "shortName": "6P20 Sb.9 Plum"
+    },
+    "5c59529a2e221602b177d160": {
+        "id": "5c59529a2e221602b177d160",
+        "name": "Lancer OEM 14 inch M-LOK foregrip for MPX",
+        "shortName": "OEM 14 inch"
+    },
+    "5b7bebc85acfc43bca706666": {
+        "id": "5b7bebc85acfc43bca706666",
+        "name": "Aim sport Universal M-LOK foregrip for FAL",
+        "shortName": "M-LOK Handguard"
+    },
+    "588b56d02459771481110ae2": {
+        "id": "588b56d02459771481110ae2",
+        "name": "Daniel Defence RIS II 9.5 foregrip for AR-15-compatible systems",
+        "shortName": "RIS II 9.5 BLK"
+    },
+    "5dfcd0e547101c39625f66f9": {
+        "id": "5dfcd0e547101c39625f66f9",
+        "name": "SAG MK1 Freefloat Chassis for SVD",
+        "shortName": "SAG MK1"
+    },
+    "5cdaa99dd7f00c002412d0b2": {
+        "id": "5cdaa99dd7f00c002412d0b2",
+        "name": "Polymer ASh-12 foregrip",
+        "shortName": "ASh-12 polym"
+    },
+    "5f2aa47a200e2c0ee46efa71": {
+        "id": "5f2aa47a200e2c0ee46efa71",
+        "name": "Kel-Tec RFB regular handguard",
+        "shortName": "RFB HG"
+    },
+    "5648ae314bdc2d3d1c8b457f": {
+        "id": "5648ae314bdc2d3d1c8b457f",
+        "name": "CAA RS47 foregrip for AK-compatible systems",
+        "shortName": "CAA RS47"
+    },
+    "5c6d10fa2e221600106f3f23": {
+        "id": "5c6d10fa2e221600106f3f23",
+        "name": "Midwest 9\" M-LOK foregrip for 416A5",
+        "shortName": "Midwest M-LOK"
+    },
+    "5c6d10e82e221601da357b07": {
+        "id": "5c6d10e82e221601da357b07",
+        "name": "HK MRS 14\" keymod foregrip for 416A5",
+        "shortName": "HK Keymod"
+    },
+    "5a9d6d34a2750c00141e07da": {
+        "id": "5a9d6d34a2750c00141e07da",
+        "name": "Strike industries TRAX 2",
+        "shortName": "TRAX 2"
+    },
+    "5c0e2f5cd174af02a012cfc9": {
+        "id": "5c0e2f5cd174af02a012cfc9",
+        "name": "ADAR 2-15 wooden stock for AR-15 and compatibles",
+        "shortName": "2-15 wood"
+    },
+    "5d123102d7ad1a004e475fe5": {
+        "id": "5d123102d7ad1a004e475fe5",
+        "name": "URX 3 8\" handguard for AR15",
+        "shortName": "URX 3 8\""
+    },
+    "595cf16b86f77427440c32e2": {
+        "id": "595cf16b86f77427440c32e2",
+        "name": "Handguard War Sport LVOA-S blk. for use with AR-15 and compatible",
+        "shortName": "LVOA-S blk."
+    },
+    "5648b0744bdc2d363b8b4578": {
+        "id": "5648b0744bdc2d363b8b4578",
+        "name": "Wooden AK-74 handguard (6P20 Sb.6)",
+        "shortName": "6P20 Sb.6"
+    },
+    "56deed6ed2720b4c698b4583": {
+        "id": "56deed6ed2720b4c698b4583",
+        "name": "Izhmekh МP-153 Polymer stock",
+        "shortName": "МP-153 Polymer"
+    },
+    "5c5db5fc2e2216000f1b2842": {
+        "id": "5c5db5fc2e2216000f1b2842",
+        "name": "Midwest 6.5 inch M-LOK foregrip for MPX",
+        "shortName": "Midwest 6.5 inch"
+    },
+    "5648b1504bdc2d9d488b4584": {
+        "id": "5648b1504bdc2d9d488b4584",
+        "name": "Polymer AK-74 foregrip (6P20 Sb.9)",
+        "shortName": "6P20 Sb.9"
+    },
+    "5d4aaa73a4b9365392071175": {
+        "id": "5d4aaa73a4b9365392071175",
+        "name": "TDI AKM-L handguard for AK Anodized Bronze",
+        "shortName": "AKM-L AB"
+    },
+    "5c9a25172e2216000f20314e": {
+        "id": "5c9a25172e2216000f20314e",
+        "name": "Daniel Defence RIS II 12.25 foregrip for AR-15-compatible systems",
+        "shortName": "RIS II 12.25 FDE"
+    },
+    "5a9d56c8a2750c0032157146": {
+        "id": "5a9d56c8a2750c0032157146",
+        "name": "Strike industries TRAX 1 foregrip",
+        "shortName": "TRAX 1"
+    },
+    "5e5699df2161e06ac158df6f": {
+        "id": "5e5699df2161e06ac158df6f",
+        "name": "CAA XRS DRG for SVD",
+        "shortName": "XRS DRG"
+    },
+    "5b7bedd75acfc43d825283f9": {
+        "id": "5b7bedd75acfc43d825283f9",
+        "name": "Vltor CASV FAL foregrip for FAL",
+        "shortName": "CASV FAL Handguard"
+    },
+    "5c9a1c422e221600106f69f0": {
+        "id": "5c9a1c422e221600106f69f0",
+        "name": "Magpul Zhukov-U HAND GUARD (Plum) for AK",
+        "shortName": "Zhukov-U"
+    },
+    "5c471c6c2e221602b66cd9ae": {
+        "id": "5c471c6c2e221602b66cd9ae",
+        "name": "Polymer SVDS handguard",
+        "shortName": "SVDS FG"
+    },
+    "5e848d51e4dbc5266a4ec63b": {
+        "id": "5e848d51e4dbc5266a4ec63b",
+        "name": "TOZ KS-23M forestock",
+        "shortName": "KS-23M for."
+    },
+    "5dcbd6b46ec07c0c4347a564": {
+        "id": "5dcbd6b46ec07c0c4347a564",
+        "name": "Desert Tech foregrip for MDR blk",
+        "shortName": "MDR Handguard"
+    },
+    "59e6284f86f77440d569536f": {
+        "id": "59e6284f86f77440d569536f",
+        "name": "Wooden VPO-136 handguard",
+        "shortName": "VPO-136"
+    },
+    "5beec3e30db8340019619424": {
+        "id": "5beec3e30db8340019619424",
+        "name": "Izhmash RPK-16 regular handguard",
+        "shortName": "RPK-16 HG"
+    },
+    "5827272a24597748c74bdeea": {
+        "id": "5827272a24597748c74bdeea",
+        "name": "SOK-12 aluminum handguard MTU002 Long Top",
+        "shortName": "MTU002 L"
+    },
+    "5a329052c4a28200741e22d3": {
+        "id": "5a329052c4a28200741e22d3",
+        "name": "Remington Arms handguard for a R11 RSASS",
+        "shortName": "RSASS"
+    },
+    "5d00ef6dd7ad1a0940739b16": {
+        "id": "5d00ef6dd7ad1a0940739b16",
+        "name": "Noveske SWS N6 Split handguard for AR-10-compatible systems",
+        "shortName": "N6 Split"
+    },
+    "5cbda392ae92155f3c17c39f": {
+        "id": "5cbda392ae92155f3c17c39f",
+        "name": "Polymer AK-100 series foregrip",
+        "shortName": "AK polym"
+    },
+    "5a788089c5856700142fdd9c": {
+        "id": "5a788089c5856700142fdd9c",
+        "name": "Speedfeed short M870 forestock",
+        "shortName": "Speedfeed"
+    },
+    "576169e62459773c69055191": {
+        "id": "576169e62459773c69055191",
+        "name": "SOK-12 polymer handguard Sb.7-1",
+        "shortName": "Sb.7-1"
+    },
+    "5c6d5d8b2e221644fc630b39": {
+        "id": "5c6d5d8b2e221644fc630b39",
+        "name": "Stngr Vypr 10\" M-LOK foregrip for AR15",
+        "shortName": "Stngr Vypr"
+    },
+    "58272b392459774b4c7b3ccd": {
+        "id": "58272b392459774b4c7b3ccd",
+        "name": "SOK-12 aluminum handguard MTU002 Short Top",
+        "shortName": "MTU002 S"
+    },
+    "5c78f2792e221600106f4683": {
+        "id": "5c78f2792e221600106f4683",
+        "name": "Magpul MOE SL carbine length M-LOK foregrip for AR-15",
+        "shortName": "MOE SL"
+    },
+    "5c78f2612e221600114c9f0d": {
+        "id": "5c78f2612e221600114c9f0d",
+        "name": "SAI 10\" QD Rail foregrip for AR15",
+        "shortName": "SAI QD Rail"
+    },
+    "5ea16acdfadf1d18c87b0784": {
+        "id": "5ea16acdfadf1d18c87b0784",
+        "name": "Geissele SMR Mk.16 9.5 inch M-LOK handguard for AR-15",
+        "shortName": "SMR Mk.16 9.5"
+    },
+    "5d2f259b48f0355a844acd74": {
+        "id": "5d2f259b48f0355a844acd74",
+        "name": "MP5k Polymer handguard",
+        "shortName": "MP5k"
+    },
+    "5b7bed205acfc400161d08cc": {
+        "id": "5b7bed205acfc400161d08cc",
+        "name": "Original Austrian foregrip for a FAL",
+        "shortName": "Fal Handguard"
+    },
+    "5d00ede1d7ad1a0940739a76": {
+        "id": "5d00ede1d7ad1a0940739a76",
+        "name": "Noveske SWS N6 10.5 inch foregrip for AR-10-compatible systems",
+        "shortName": "N6 10.5 inch"
+    },
+    "5d15ce51d7ad1a1eff619092": {
+        "id": "5d15ce51d7ad1a1eff619092",
+        "name": "Alfa Arms Goliaf AKS-74U Handguard",
+        "shortName": "Goliaf"
+    },
+    "5c5db6302e2216000e5e47f0": {
+        "id": "5c5db6302e2216000e5e47f0",
+        "name": "Midwest 10.5 inch M-LOK foregrip for MPX",
+        "shortName": "Midwest 10.5 inch"
+    },
+    "5fbc227aa56d053a3543f79e": {
+        "id": "5fbc227aa56d053a3543f79e",
+        "name": "SIG 12\" keymod foregrip for MCX",
+        "shortName": "MCX 12\""
+    },
+    "5c6c2c9c2e2216000f2002e4": {
+        "id": "5c6c2c9c2e2216000f2002e4",
+        "name": "Troy Industries 13\" M-LOK foregrip for 416A5",
+        "shortName": "Troy M-LOK"
+    },
+    "5fc235db2770a0045c59c683": {
+        "id": "5fc235db2770a0045c59c683",
+        "name": "Sword int. 18 inch handguard for Mk-18",
+        "shortName": "Sword 18 ich"
+    },
+    "5d00f63bd7ad1a59283b1c1e": {
+        "id": "5d00f63bd7ad1a59283b1c1e",
+        "name": "Strike Industries Viper carbine length M-LOK foregrip (FDE) for AR-15",
+        "shortName": "Viper"
+    },
+    "5888976c24597754281f93f5": {
+        "id": "5888976c24597754281f93f5",
+        "name": "LOBAEV Arms DVL-10 М2 handguard",
+        "shortName": "DVL-10 М2"
+    },
+    "5b2cfa535acfc432ff4db7a0": {
+        "id": "5b2cfa535acfc432ff4db7a0",
+        "name": "Handguard MK 10 for use with AR-15 and compatible",
+        "shortName": "MK10 RL"
+    },
+    "5df916dfbb49d91fb446d6b9": {
+        "id": "5df916dfbb49d91fb446d6b9",
+        "name": "URX-4 handguard for AR-10 and compatible",
+        "shortName": " URX-4 14.5\""
+    },
+    "5ea16ada09aa976f2e7a51be": {
+        "id": "5ea16ada09aa976f2e7a51be",
+        "name": "Geissele SMR Mk.16 13.5 inch M-LOK handguard for AR-15",
+        "shortName": "SMR Mk.16 13.5"
+    },
+    "59e898ee86f77427614bd225": {
+        "id": "59e898ee86f77427614bd225",
+        "name": "Wooden AKM / VPO-209 handguard",
+        "shortName": "VPO-209"
+    },
+    "5df25d3bfd6b4e6e2276dc9a": {
+        "id": "5df25d3bfd6b4e6e2276dc9a",
+        "name": "Orsis handguard for T-5000",
+        "shortName": "T-5000 hg."
+    },
+    "5d19cd96d7ad1a4a992c9f52": {
+        "id": "5d19cd96d7ad1a4a992c9f52",
+        "name": "PTR Tri-Rail MP5 handguard",
+        "shortName": "Tri-Rail"
+    },
+    "5cde7afdd7f00c000d36b89d": {
+        "id": "5cde7afdd7f00c000d36b89d",
+        "name": "A*B Arms MOD X Gen.3 keymod handguard for M700",
+        "shortName": "MOD X"
+    },
+    "5fbc226eca32ed67276c155d": {
+        "id": "5fbc226eca32ed67276c155d",
+        "name": "SIG 8\" keymod foregrip for MCX",
+        "shortName": "MCX 8\""
+    },
+    "5b7d671b5acfc43d82528ddd": {
+        "id": "5b7d671b5acfc43d82528ddd",
+        "name": "DSA Belgian style foregrip for a FAL",
+        "shortName": "Fal Belgian style"
+    },
+    "5e87076ce2db31558c75a11d": {
+        "id": "5e87076ce2db31558c75a11d",
+        "name": "Speedfeed short M590A1 forestock",
+        "shortName": "Speedfeed"
+    },
+    "5d2c829448f0353a5c7d6674": {
+        "id": "5d2c829448f0353a5c7d6674",
+        "name": "Wooden CAF WASR 10-63 handguard",
+        "shortName": "WASR 10-63"
+    },
+    "5e56991336989c75ab4f03f6": {
+        "id": "5e56991336989c75ab4f03f6",
+        "name": "Izhmash modern handguard for SVD",
+        "shortName": "SVD Mod."
+    },
+    "5894a42086f77426d2590762": {
+        "id": "5894a42086f77426d2590762",
+        "name": "Handguard SIG MPX Gen. 1 for MPX",
+        "shortName": "MPX Gen. 1"
+    },
+    "5c9a26332e2216001219ea70": {
+        "id": "5c9a26332e2216001219ea70",
+        "name": "Daniel Defence FDE RIS II FSP 9.5 foregrip for AR-15-compatible systems",
+        "shortName": "RIS II FSP 9.5 FDE"
+    },
+    "5b7be2345acfc400196d524a": {
+        "id": "5b7be2345acfc400196d524a",
+        "name": "Aim sport Universal keymod foregrip for FAL",
+        "shortName": "Keymod Handguard"
+    },
+    "5d122e7bd7ad1a07102d6d7f": {
+        "id": "5d122e7bd7ad1a07102d6d7f",
+        "name": "URX 3.1 10.75\" handguard for AR15",
+        "shortName": "URX 3.1 10.75\""
+    },
+    "5648b2414bdc2d3b4c8b4578": {
+        "id": "5648b2414bdc2d3b4c8b4578",
+        "name": "UltiMAK M1-B handguard for AK",
+        "shortName": "M1-B"
+    },
+    "5b099a9d5acfc47a8607efe7": {
+        "id": "5b099a9d5acfc47a8607efe7",
+        "name": "DS Arms quad rail foregrip for SA-58",
+        "shortName": "Quad Rail"
+    },
+    "5bb20dfcd4351e00334c9e24": {
+        "id": "5bb20dfcd4351e00334c9e24",
+        "name": "HK extended quadrail handguard for 416-compatible systems",
+        "shortName": "Ext.Quad"
+    },
+    "5cf4e3f3d7f00c06595bc7f0": {
+        "id": "5cf4e3f3d7f00c06595bc7f0",
+        "name": "5.45 Design \"Aggressor\" handguard for AK",
+        "shortName": "Aggressor"
+    },
+    "5f63418ef5750b524b45f116": {
+        "id": "5f63418ef5750b524b45f116",
+        "name": "SOK-12 aluminum handguard Bravo-18",
+        "shortName": "Bravo-18"
+    },
+    "57dc32dc245977596d4ef3d3": {
+        "id": "57dc32dc245977596d4ef3d3",
+        "name": "Wooden AKS-74U Handguard (6P26 Sb.6)",
+        "shortName": "6P26 Sb.6"
+    },
+    "5d4405f0a4b9361e6a4e6bd9": {
+        "id": "5d4405f0a4b9361e6a4e6bd9",
+        "name": "Lone Star Ion Lite handguard for AR-15 and compatible",
+        "shortName": "Ion Lite"
+    },
+    "5b7be1ca5acfc400170e2d2f": {
+        "id": "5b7be1ca5acfc400170e2d2f",
+        "name": "DS Arms Quad Rail Full Length foregrip for SA-58",
+        "shortName": "Quad Rail"
+    },
+    "5c6d11152e2216000f2003e7": {
+        "id": "5c6d11152e2216000f2003e7",
+        "name": "Strike Industries CRUX 15\" M-LOK foregrip for 416A5",
+        "shortName": "CRUX Handguard"
+    },
+    "5f6336bbda967c74a42e9932": {
+        "id": "5f6336bbda967c74a42e9932",
+        "name": "Lancer LCH-7 12.5 inch M-LOK handguard for AR-10",
+        "shortName": "LCH-7 12.5"
+    },
+    "5cadc431ae921500113bb8d5": {
+        "id": "5cadc431ae921500113bb8d5",
+        "name": "Polymer pistol grip for M9A3",
+        "shortName": "PGripM9A3"
+    },
+    "5e2192a498a36665e8337386": {
+        "id": "5e2192a498a36665e8337386",
+        "name": "KGB MG-47 pistol grip for AK red",
+        "shortName": "MG-47"
+    },
+    "5dcbd6dddbd3d91b3e5468de": {
+        "id": "5dcbd6dddbd3d91b3e5468de",
+        "name": "Desert Tech pistol grip for MDR Black",
+        "shortName": "MDR reg."
+    },
+    "5649ae4a4bdc2d1b2b8b4588": {
+        "id": "5649ae4a4bdc2d1b2b8b4588",
+        "name": "Zenit RK-3 AK pistol grip",
+        "shortName": "RК-3"
+    },
+    "55802f5d4bdc2dac148b458f": {
+        "id": "55802f5d4bdc2dac148b458f",
+        "name": "Magpul MOE AR-15 pistol grip",
+        "shortName": "MOE Pistol"
+    },
+    "5894a51286f77426d13baf02": {
+        "id": "5894a51286f77426d13baf02",
+        "name": "Pistol grip SIG MPX",
+        "shortName": "MPX p. grip"
+    },
+    "5f3e778efcd9b651187d7201": {
+        "id": "5f3e778efcd9b651187d7201",
+        "name": "Standart polymerpistol grip for M45A1",
+        "shortName": "M45A1 P.Grip"
+    },
+    "57c55f092459772d291a8463": {
+        "id": "57c55f092459772d291a8463",
+        "name": "Hogue OverMolded Rubber Grip Ghillie Earth",
+        "shortName": "OMRG GE"
+    },
+    "5c48a2c22e221602b313fb6c": {
+        "id": "5c48a2c22e221602b313fb6c",
+        "name": "Desert Tech pistol grip for MDR",
+        "shortName": "MDR reg."
+    },
+    "571659bb2459771fb2755a12": {
+        "id": "571659bb2459771fb2755a12",
+        "name": "DI ECS FDE pistol grip for AR-15 based systems",
+        "shortName": "ECS FDE"
+    },
+    "5addc7db5acfc4001669f279": {
+        "id": "5addc7db5acfc4001669f279",
+        "name": "M14ALCS(MOD. 0) pistol grip for M14",
+        "shortName": "M14ALCS"
+    },
+    "5c6d7b3d2e221600114c9b7d": {
+        "id": "5c6d7b3d2e221600114c9b7d",
+        "name": "HK Grip V.2 pistol grip for AR-15 based systems",
+        "shortName": "Grip V.2"
+    },
+    "5bb20e18d4351e00320205d5": {
+        "id": "5bb20e18d4351e00320205d5",
+        "name": "HK \"Battle Grip\" pistol grip for AR-15 based systems",
+        "shortName": "Battle Grip"
+    },
+    "5a0071d486f77404e23a12b2": {
+        "id": "5a0071d486f77404e23a12b2",
+        "name": "Wooden Izhmash AKM pistol grip for AK",
+        "shortName": "AKM wood"
+    },
+    "5a17fc70fcdbcb0176308b3d": {
+        "id": "5a17fc70fcdbcb0176308b3d",
+        "name": "APS bakelite side-pieces",
+        "shortName": "APS Bakelite"
+    },
+    "5a69a2ed8dc32e000d46d1f1": {
+        "id": "5a69a2ed8dc32e000d46d1f1",
+        "name": "AS VAL Pistol grip-buffer tube",
+        "shortName": "Rotor 43 buffer"
+    },
+    "5cc9bcaed7f00c011c04e179": {
+        "id": "5cc9bcaed7f00c011c04e179",
+        "name": "Hera Arms HG-15 pistol grip for AR-15 based systems",
+        "shortName": "HG15"
+    },
+    "5b7d678a5acfc4001a5c4022": {
+        "id": "5b7d678a5acfc4001a5c4022",
+        "name": "Regular \"DS Arms\" pistol grip for SA-58",
+        "shortName": "DS SA-58"
+    },
+    "5bbde41ed4351e003562b038": {
+        "id": "5bbde41ed4351e003562b038",
+        "name": "Tacfire pistol grip for Mosin rifle",
+        "shortName": "pgmn"
+    },
+    "5bb20e0ed4351e3bac1212dc": {
+        "id": "5bb20e0ed4351e3bac1212dc",
+        "name": "HK Battle Grip with Beavertail pistol grip for AR-15 based systems",
+        "shortName": "Battle Grip"
+    },
+    "5649ad3f4bdc2df8348b4585": {
+        "id": "5649ad3f4bdc2df8348b4585",
+        "name": "Izhmash AK bakelite pistol grip (6P4 Sb.8V)",
+        "shortName": "6P4 Sb.8V"
+    },
+    "59e6318286f77444dd62c4cc": {
+        "id": "59e6318286f77444dd62c4cc",
+        "name": "Molot AK bakelite pistol grip",
+        "shortName": "Molot bak."
+    },
+    "59db3b0886f77429d72fb895": {
+        "id": "59db3b0886f77429d72fb895",
+        "name": "Stark AR Rifle Grip (FDE) for AR-15-compatible weapons",
+        "shortName": "Stark AR RG"
+    },
+    "5afd7e445acfc4001637e35a": {
+        "id": "5afd7e445acfc4001637e35a",
+        "name": "TAPCO SAW-Style pistol grip for SKS INTRAFUSE Kit",
+        "shortName": "SAW SKS"
+    },
+    "5b30ac585acfc433000eb79c": {
+        "id": "5b30ac585acfc433000eb79c",
+        "name": "Magpul MOE pistol grip for AK",
+        "shortName": "MOE AK"
+    },
+    "5cf54404d7f00c108840b2ef": {
+        "id": "5cf54404d7f00c108840b2ef",
+        "name": "KGB MG-47 pistol grip for AK",
+        "shortName": "MG-47"
+    },
+    "5998517986f7746017232f7e": {
+        "id": "5998517986f7746017232f7e",
+        "name": "PP-19-01 Izhmash pistol grip",
+        "shortName": "p. grip PP-19-01"
+    },
+    "56d5a2bbd2720bb8418b456a": {
+        "id": "56d5a2bbd2720bb8418b456a",
+        "name": "Black polymer Sig Sauer pistol grip for P226",
+        "shortName": "BPGripP226"
+    },
+    "5b099b965acfc400186331e6": {
+        "id": "5b099b965acfc400186331e6",
+        "name": "TAPCO SAW-Style black pistol grip for SA-58",
+        "shortName": "SAW SA-58"
+    },
+    "5a38eecdc4a282329a73b512": {
+        "id": "5a38eecdc4a282329a73b512",
+        "name": "TOZ 002 pistol grip for TOZ-106",
+        "shortName": "TOZ-106 PG"
+    },
+    "5beec8ea0db834001a6f9dbf": {
+        "id": "5beec8ea0db834001a6f9dbf",
+        "name": "Izhmash AK-12 regular pistol grip",
+        "shortName": "AK-12 reg."
+    },
+    "5c0006470db834001a6697fe": {
+        "id": "5c0006470db834001a6697fe",
+        "name": "Emperor scorpion Sig Sauer pistol grip for P226",
+        "shortName": "Scorpion P226"
+    },
+    "57e3dba62459770f0c32322b": {
+        "id": "57e3dba62459770f0c32322b",
+        "name": "Izhmash AK-74 Textolite pistol grip (6P4 Sb.9)",
+        "shortName": "6P4 Sb.9"
+    },
+    "5c6bf4aa2e2216001219b0ae": {
+        "id": "5c6bf4aa2e2216001219b0ae",
+        "name": "US Palm pistol grip for AK",
+        "shortName": "US Palm AK"
+    },
+    "57c55f172459772d27602381": {
+        "id": "57c55f172459772d27602381",
+        "name": "Hogue OverMolded Rubber Grip OD Green",
+        "shortName": "OMRG OD"
+    },
+    "5649ade84bdc2d1b2b8b4587": {
+        "id": "5649ade84bdc2d1b2b8b4587",
+        "name": "Izhmash AK polymer pistol grip (6P1 Sb.8)",
+        "shortName": "6P1 Sb.8"
+    },
+    "5f6341043ada5942720e2dc5": {
+        "id": "5f6341043ada5942720e2dc5",
+        "name": "Aeroknox scorpius pistol grip for AK",
+        "shortName": "Scorpius"
+    },
+    "5d15cf3bd7ad1a67e71518b2": {
+        "id": "5d15cf3bd7ad1a67e71518b2",
+        "name": "Magpul MOE AR-15 pistol grip (FDE)",
+        "shortName": "MOE"
+    },
+    "571a282c2459771fb2755a69": {
+        "id": "571a282c2459771fb2755a69",
+        "name": "Standard TT side grips",
+        "shortName": "TT grips"
+    },
+    "5d023784d7ad1a049d4aa7f2": {
+        "id": "5d023784d7ad1a049d4aa7f2",
+        "name": "Fab Defence AG-58 pistol grip for VZ-58",
+        "shortName": "AG-58"
+    },
+    "57c55efc2459772d2c6271e7": {
+        "id": "57c55efc2459772d2c6271e7",
+        "name": "Hogue OverMolded Rubber Grip Black",
+        "shortName": "OMRG Black"
+    },
+    "5cdeac5cd7f00c000f261694": {
+        "id": "5cdeac5cd7f00c000f261694",
+        "name": "Magpul Pistol Grip for Pro 700 Kit",
+        "shortName": "Pro700"
+    },
+    "59e62cc886f77440d40b52a1": {
+        "id": "59e62cc886f77440d40b52a1",
+        "name": "Izhmash AKM bakelite pistol grip",
+        "shortName": "AKM bak."
+    },
+    "5b07db875acfc40dc528a5f6": {
+        "id": "5b07db875acfc40dc528a5f6",
+        "name": "Skeletonized AR-15 pistol grip",
+        "shortName": "TD120001"
+    },
+    "5947f92f86f77427344a76b1": {
+        "id": "5947f92f86f77427344a76b1",
+        "name": "TAPCO SAW-Style black pistol grip for AK",
+        "shortName": "SAW"
+    },
+    "5bffef760db8340019668fe4": {
+        "id": "5bffef760db8340019668fe4",
+        "name": "Hogue Chain link pistol grip for P226",
+        "shortName": "Mascus P226"
+    },
+    "5b3cadf35acfc400194776a0": {
+        "id": "5b3cadf35acfc400194776a0",
+        "name": "Fancy TT side grips",
+        "shortName": "TT grips"
+    },
+    "5b39ffbd5acfc47a8773fb06": {
+        "id": "5b39ffbd5acfc47a8773fb06",
+        "name": "Rubber with finger grooves pistol grip for P226",
+        "shortName": "Hogue P226"
+    },
+    "5cf50850d7f00c056e24104c": {
+        "id": "5cf50850d7f00c056e24104c",
+        "name": "SI Enhanced pistol grip for AK",
+        "shortName": "EPG AK"
+    },
+    "59db3acc86f7742a2c4ab912": {
+        "id": "59db3acc86f7742a2c4ab912",
+        "name": "Stark AR Rifle Grip (black) for AR-15-compatible weapons",
+        "shortName": "Stark AR RG"
+    },
+    "576a63cd2459771e796e0e11": {
+        "id": "576a63cd2459771e796e0e11",
+        "name": "Polymer Izhmekh pistol grip for MP-443",
+        "shortName": "P.grip.MP443"
+    },
+    "57af48872459771f0b2ebf11": {
+        "id": "57af48872459771f0b2ebf11",
+        "name": "Hogue OverMolded Rubber Grip FDE",
+        "shortName": "OMRG FDE"
+    },
+    "5bffcf7a0db83400232fea79": {
+        "id": "5bffcf7a0db83400232fea79",
+        "name": "PM-Laser TT-206 side grips with LAM",
+        "shortName": "TT-206"
+    },
+    "57d152ec245977144076ccdf": {
+        "id": "57d152ec245977144076ccdf",
+        "name": "ZMZ Polymer pistol grip for PP-91",
+        "shortName": "PP91 Pol"
+    },
+    "5c471be12e221602b66cd9ac": {
+        "id": "5c471be12e221602b66cd9ac",
+        "name": "Izhmash SVDS pistol grip",
+        "shortName": "SVDS PG"
+    },
+    "5947fa2486f77425b47c1a9b": {
+        "id": "5947fa2486f77425b47c1a9b",
+        "name": "TAPCO SAW-Style FDE pistol grip for AK",
+        "shortName": "SAW"
+    },
+    "5a7b4960e899ef197b331a2d": {
+        "id": "5a7b4960e899ef197b331a2d",
+        "name": "Pachmayr tactical rubber grip",
+        "shortName": "Pach RG"
+    },
+    "5e81c6bf763d9f754677beff": {
+        "id": "5e81c6bf763d9f754677beff",
+        "name": "Standart polymerpistol grip for M1911A1",
+        "shortName": "M1911A1 P.Grip"
+    },
+    "5d025cc1d7ad1a53845279ef": {
+        "id": "5d025cc1d7ad1a53845279ef",
+        "name": "HK Ergo PSG-1 style pistol grip for AR-15 based systems",
+        "shortName": "Ergo PSG-1 style"
+    },
+    "5b7d679f5acfc4001a5c4024": {
+        "id": "5b7d679f5acfc4001a5c4024",
+        "name": "Fab AG FAL pistol grip for SA-58",
+        "shortName": "AG FAL"
+    },
+    "59db3a1d86f77429e05b4e92": {
+        "id": "59db3a1d86f77429e05b4e92",
+        "name": "Naroh Arms GRAL-S Pistol grip for AR-15-compatible weapons",
+        "shortName": "GRAL-S"
+    },
+    "57c44fa82459772d2d75e415": {
+        "id": "57c44fa82459772d2d75e415",
+        "name": "AS VAL Pistol grip",
+        "shortName": "VAL pol."
+    },
+    "55d4b9964bdc2d1d4e8b456e": {
+        "id": "55d4b9964bdc2d1d4e8b456e",
+        "name": "Colt A2 AR-15 pistol grip",
+        "shortName": "A2 Pistol"
+    },
+    "56e05a6ed2720bd0748b4567": {
+        "id": "56e05a6ed2720bd0748b4567",
+        "name": "TSNIITOCHMASH bakelite PB side grips",
+        "shortName": "Bakelite PB"
+    },
+    "5c0684e50db834002a12585a": {
+        "id": "5c0684e50db834002a12585a",
+        "name": "Hogue like TT rubber grips",
+        "shortName": "Hogue like"
+    },
+    "5c00076d0db834001d23ee1f": {
+        "id": "5c00076d0db834001d23ee1f",
+        "name": "Wooden Sig Sauer Elite pistol grip for P226",
+        "shortName": "Wooden Elite P226"
+    },
+    "5df38a5fb74cd90030650cb6": {
+        "id": "5df38a5fb74cd90030650cb6",
+        "name": "Orsis T-5000 Pistol Grip",
+        "shortName": "T-5000 Pg."
+    },
+    "5bffec120db834001c38f5fa": {
+        "id": "5bffec120db834001c38f5fa",
+        "name": "Axelson Tacical MK.25 pistol grip for P226",
+        "shortName": "Axelson P226"
+    },
+    "5c079ec50db834001966a706": {
+        "id": "5c079ec50db834001966a706",
+        "name": "Razor Arms TT rubber grips",
+        "shortName": "Razor A. TT"
+    },
+    "57c55f112459772d28133310": {
+        "id": "57c55f112459772d28133310",
+        "name": "Hogue OverMolded Rubber Grip Ghillie Green",
+        "shortName": "OMRG GG"
+    },
+    "5bfe86a20db834001d23e8f7": {
+        "id": "5bfe86a20db834001d23e8f7",
+        "name": "Fab Defence AGR-870 pistol grip for Remington-870",
+        "shortName": "AGR-870"
+    },
+    "5a339805c4a2826c6e06d73d": {
+        "id": "5a339805c4a2826c6e06d73d",
+        "name": "MIAD Pistol grip for AR-15 based systems",
+        "shortName": "MIAD Pistol"
+    },
+    "57c9a89124597704ee6faec1": {
+        "id": "57c9a89124597704ee6faec1",
+        "name": "Sig Sauer FDE pistol grip for P226 (Combat)",
+        "shortName": "226FDE"
+    },
+    "5cf508bfd7f00c056e24104e": {
+        "id": "5cf508bfd7f00c056e24104e",
+        "name": "SI Enhanced pistol grip for AK FDE",
+        "shortName": "EPG AK FDE"
+    },
+    "5ef366938cef260c0642acad": {
+        "id": "5ef366938cef260c0642acad",
+        "name": "Pachmayr \"American legend grip #423 for M1911A1",
+        "shortName": "ALG#423 P.Grip"
+    },
+    "5e848d99865c0f329958c83b": {
+        "id": "5e848d99865c0f329958c83b",
+        "name": "Polymer pistol grip for KS-23M",
+        "shortName": "KS23M Pgrip"
+    },
+    "5fbcbd6c187fea44d52eda14": {
+        "id": "5fbcbd6c187fea44d52eda14",
+        "name": "SIG MCX pistol grip",
+        "shortName": "MCX Pistol"
+    },
+    "5de8e67c4a9f347bc92edbd7": {
+        "id": "5de8e67c4a9f347bc92edbd7",
+        "name": "Upper receiver B&T 9x19 for MP9-N SMG",
+        "shortName": "MP9-N Upper"
+    },
+    "5d2f261548f03576f500e7b7": {
+        "id": "5d2f261548f03576f500e7b7",
+        "name": "HK MP5 Kurz Upper receiver",
+        "shortName": "MP5k Upper"
+    },
+    "59e6449086f7746c9f75e822": {
+        "id": "59e6449086f7746c9f75e822",
+        "name": "Molot АКM type dust cover",
+        "shortName": "АКM type"
+    },
+    "5d2c76ed48f03532f2136169": {
+        "id": "5d2c76ed48f03532f2136169",
+        "name": "AKademia Bastion dust cover for АК",
+        "shortName": "Bastion"
+    },
+    "5cc700ede4a949033c734315": {
+        "id": "5cc700ede4a949033c734315",
+        "name": "FN EFFEN 90 Upper receiver for P90",
+        "shortName": "EFFEN 90"
+    },
+    "59d6507c86f7741b846413a2": {
+        "id": "59d6507c86f7741b846413a2",
+        "name": "Izhmash АКM dust cover (6P1 0-1)",
+        "shortName": "6P1 0-1"
+    },
+    "5649af094bdc2df8348b4586": {
+        "id": "5649af094bdc2df8348b4586",
+        "name": "Izhmash АК-74 dust cover (6P1 0-1)",
+        "shortName": "6P1 0-1"
+    },
+    "5a6f5e048dc32e00094b97da": {
+        "id": "5a6f5e048dc32e00094b97da",
+        "name": "Glock 9x19 slide",
+        "shortName": "Glock slide"
+    },
+    "5926f2e086f7745aae644231": {
+        "id": "5926f2e086f7745aae644231",
+        "name": "HK MP5SD Upper receiver",
+        "shortName": "MP5SD"
+    },
+    "5b1faa0f5acfc40dc528aeb5": {
+        "id": "5b1faa0f5acfc40dc528aeb5",
+        "name": "Glock 18C 9x19 slide",
+        "shortName": "Glock 18C slide"
+    },
+    "5e81edc13397a21db957f6a1": {
+        "id": "5e81edc13397a21db957f6a1",
+        "name": "M1911A1 .45 ACP slide",
+        "shortName": "M1911A1 slide"
+    },
+    "5d2c770c48f0354b4a07c100": {
+        "id": "5d2c770c48f0354b4a07c100",
+        "name": "Fab Defence PDC dust cover for АК-74",
+        "shortName": "PDC"
+    },
+    "5fbcc3e4d6fa9c00c571bb58": {
+        "id": "5fbcc3e4d6fa9c00c571bb58",
+        "name": "Upper receiver of the first generation Sig-Sauer MCX",
+        "shortName": "MCX 1 gen."
+    },
+    "5649af884bdc2d1b2b8b4589": {
+        "id": "5649af884bdc2d1b2b8b4589",
+        "name": "Zenit B-33 dust cover for АК-74",
+        "shortName": "B-33"
+    },
+    "5f3e7823ddc4f03b010e2045": {
+        "id": "5f3e7823ddc4f03b010e2045",
+        "name": "M45A1 .45 ACP slide",
+        "shortName": "M45A1 slide"
+    },
+    "5ac50da15acfc4001718d287": {
+        "id": "5ac50da15acfc4001718d287",
+        "name": "Izhmash АК-74M dust cover (6P34 0-1)",
+        "shortName": "6P34 0-1"
+    },
+    "5cadc55cae921500103bb3be": {
+        "id": "5cadc55cae921500103bb3be",
+        "name": "M9A3 9x19 pistol slide",
+        "shortName": "M9A3 Slide"
+    },
+    "5894a5b586f77426d2590767": {
+        "id": "5894a5b586f77426d2590767",
+        "name": "Upper receiver of the first generation SIG MPX ",
+        "shortName": "MPX 1 gen."
+    },
+    "5a7afa25e899ef00135e31b0": {
+        "id": "5a7afa25e899ef00135e31b0",
+        "name": "Polymer80 PS9 Glock slide",
+        "shortName": "PS9"
+    },
+    "5cf7acfcd7f00c1084477cf2": {
+        "id": "5cf7acfcd7f00c1084477cf2",
+        "name": "FN Upper receiver for PS90",
+        "shortName": "PS90 Upper"
+    },
+    "5c0e2f26d174af02a9625114": {
+        "id": "5c0e2f26d174af02a9625114",
+        "name": "Upper receiver ADAR 2-15 5.56x45 for 2-15 assault rifle",
+        "shortName": "2-15 Upper"
+    },
+    "5c471bd12e221602b4129c3a": {
+        "id": "5c471bd12e221602b4129c3a",
+        "name": "Izhmash SVDS dust cover",
+        "shortName": "SVDS DC"
+    },
+    "578395402459774a256959b5": {
+        "id": "578395402459774a256959b5",
+        "name": "VSS Vintorez dust cover",
+        "shortName": "Ksk VSS"
+    },
+    "57c44f4f2459772d2c627113": {
+        "id": "57c44f4f2459772d2c627113",
+        "name": "AS VAL Dust cover",
+        "shortName": "VAL Dust cover"
+    },
+    "5ea03e5009aa976f2e7a514b": {
+        "id": "5ea03e5009aa976f2e7a514b",
+        "name": "PPSH-41 dust cover",
+        "shortName": "PPSH-41 dc"
+    },
+    "55d355e64bdc2d962f8b4569": {
+        "id": "55d355e64bdc2d962f8b4569",
+        "name": "Upper receiver Colt M4A1 5.56x45 for M4A1 assault rifle",
+        "shortName": "M4A1 Upper"
+    },
+    "56d5a407d2720bb3418b456b": {
+        "id": "56d5a407d2720bb3418b456b",
+        "name": "SIG Sauer P226R 9x19 pistol slide",
+        "shortName": "P226 Slide"
+    },
+    "5bb20d53d4351e4502010a69": {
+        "id": "5bb20d53d4351e4502010a69",
+        "name": "Upper receiver HK 416A5 5.56x45 for 416A5",
+        "shortName": "416A5 Upper"
+    },
+    "5cc70102e4a949035e43ba74": {
+        "id": "5cc70102e4a949035e43ba74",
+        "name": "FN Upper receiver for P90",
+        "shortName": "P90 Upper"
+    },
+    "5926c0df86f77462f647f764": {
+        "id": "5926c0df86f77462f647f764",
+        "name": "HK MP5 Upper receiver",
+        "shortName": "MP5 Upper"
+    },
+    "5c07a8770db8340023300450": {
+        "id": "5c07a8770db8340023300450",
+        "name": "Noveske Gen.3 5.56x45 Upper receiver for AR systems",
+        "shortName": "Gen.3"
+    },
+    "5c503d0a2e221602b542b7ef": {
+        "id": "5c503d0a2e221602b542b7ef",
+        "name": "Molot VPO-101 dust cover",
+        "shortName": "VPO-101"
+    },
+    "59bfe68886f7746004266202": {
+        "id": "59bfe68886f7746004266202",
+        "name": "Vltor MUR-1S 5.56x45 Upper receiver for AR systems",
+        "shortName": "MUR-1S Upper"
+    },
+    "5839a7742459773cf9693481": {
+        "id": "5839a7742459773cf9693481",
+        "name": "IzhMash AKS-74UB Dust cover",
+        "shortName": "AKS-74UB D.c."
+    },
+    "5c0125fc0db834001a669aa3": {
+        "id": "5c0125fc0db834001a669aa3",
+        "name": "P226 Sig Legion full size pistol slide",
+        "shortName": "Legion P226"
+    },
+    "59985a6c86f77414ec448d17": {
+        "id": "59985a6c86f77414ec448d17",
+        "name": "Izhmash Vityaz-SN receiver cover",
+        "shortName": "rec.cov. Vityaz-SN"
+    },
+    "5c010a700db834001d23ef5d": {
+        "id": "5c010a700db834001d23ef5d",
+        "name": "P226 Sig Emperor scorpion pistol slide",
+        "shortName": "Scorpion P226"
+    },
+    "59985a8086f77414ec448d1a": {
+        "id": "59985a8086f77414ec448d1a",
+        "name": "Izhmash Vityaz receiver cover",
+        "shortName": "rec.cov. Vityaz"
+    },
+    "5b7d6c105acfc40015109a5f": {
+        "id": "5b7d6c105acfc40015109a5f",
+        "name": "Regular dust cover for FAL",
+        "shortName": "FAL DC"
+    },
+    "5a7033908dc32e000a311392": {
+        "id": "5a7033908dc32e000a311392",
+        "name": "Glock Alpha Wolf Custom slide",
+        "shortName": "Glock AW C"
+    },
+    "5beec91a0db834001961942d": {
+        "id": "5beec91a0db834001961942d",
+        "name": "Izhmash regular dust cover for RPK-16",
+        "shortName": "RPK-16 Dust Cover"
+    },
+    "5dfce88fe9dc277128008b2e": {
+        "id": "5dfce88fe9dc277128008b2e",
+        "name": "Custom SVDS dust cover",
+        "shortName": "SVDS CS"
+    },
+    "5e0090f7e9dc277128008b93": {
+        "id": "5e0090f7e9dc277128008b93",
+        "name": "Upper receiver B&T 9x19 for MP9 SMG",
+        "shortName": "MP9 Upper"
+    },
+    "57dc334d245977597164366f": {
+        "id": "57dc334d245977597164366f",
+        "name": "AKS-74U Dust cover (6P26 Sb.7)",
+        "shortName": "6P26 Sb.7"
+    },
+    "5df8e4080b92095fd441e594": {
+        "id": "5df8e4080b92095fd441e594",
+        "name": "Upper receiver KAC 7.62x51 for SR-25 rifle",
+        "shortName": "SR-25 Upper"
+    },
+    "5a702d198dc32e000b452fc3": {
+        "id": "5a702d198dc32e000b452fc3",
+        "name": "Glock Alpha Wolf slide",
+        "shortName": "Glock AW"
+    },
+    "5bffe7c50db834001d23ece1": {
+        "id": "5bffe7c50db834001d23ece1",
+        "name": "P226 Axelson tactical Mk.25 pistol slide",
+        "shortName": "axelson"
+    },
+    "5b099bb25acfc400186331e8": {
+        "id": "5b099bb25acfc400186331e8",
+        "name": "DS Arms Extreme Duty dust cover for SA58",
+        "shortName": "Ext. Duty"
+    },
+    "5d3eb44aa4b93650d64e4979": {
+        "id": "5d3eb44aa4b93650d64e4979",
+        "name": "Five-seveN MK2 pistol slide",
+        "shortName": "57 Slide"
+    },
+    "5d2c772c48f0355d95672c25": {
+        "id": "5d2c772c48f0355d95672c25",
+        "name": "TWS Dog leg rail dust cover for АК",
+        "shortName": "Dog leg"
+    },
+    "5d4405aaa4b9361e6a4e6bd3": {
+        "id": "5d4405aaa4b9361e6a4e6bd3",
+        "name": "Lightweight upper 5.56x45 for TX15 rifle",
+        "shortName": "TX15 LW Upper"
+    },
+    "5a9685b1a2750c0032157104": {
+        "id": "5a9685b1a2750c0032157104",
+        "name": "Glock 9x19 Moto Cut slide",
+        "shortName": "Glock Moto Cut"
+    },
+    "5a6f5f078dc32e00094b97dd": {
+        "id": "5a6f5f078dc32e00094b97dd",
+        "name": "Glock 9x19 Viper Cut slide",
+        "shortName": "Glock Viper Cut"
+    },
+    "5a71e22f8dc32e00094b97f4": {
+        "id": "5a71e22f8dc32e00094b97f4",
+        "name": "Zev Tech Hex Gen3 slide",
+        "shortName": "G ZT Hex"
+    },
+    "5a71e4f48dc32e001207fb26": {
+        "id": "5a71e4f48dc32e001207fb26",
+        "name": "Glock Zev Tech Hex Spartan slide",
+        "shortName": "G ZT Spart"
+    },
+    "5fc278107283c4046c581489": {
+        "id": "5fc278107283c4046c581489",
+        "name": "Sword Int. Mk-18 mod 1 Upper receiver",
+        "shortName": "Mk-18 Upper"
+    },
+    "5c0009510db834001966907f": {
+        "id": "5c0009510db834001966907f",
+        "name": "P226 Sig Stainless elite pistol slide",
+        "shortName": "Stainless elite P226"
+    },
+    "57616c112459773cce774d66": {
+        "id": "57616c112459773cce774d66",
+        "name": "Izhmash SOK-12 Sb.0-2 dust cover",
+        "shortName": "Sb.0-2"
+    },
+    "55818a104bdc2db9688b4569": {
+        "id": "55818a104bdc2db9688b4569",
+        "name": "Handguard",
+        "shortName": "Item"
+    },
+    "55818a684bdc2ddd698b456d": {
+        "id": "55818a684bdc2ddd698b456d",
+        "name": "Pistol grip",
+        "shortName": "Item"
+    },
+    "555ef6e44bdc2de9068b457e": {
+        "id": "555ef6e44bdc2de9068b457e",
+        "name": "Barrel",
+        "shortName": "Item"
+    },
+    "55818a304bdc2db5418b457d": {
+        "id": "55818a304bdc2db5418b457d",
+        "name": "Receiver",
+        "shortName": "Item"
+    },
+    "55802f4a4bdc2ddb688b4569": {
+        "id": "55802f4a4bdc2ddb688b4569",
+        "name": "Essential mod",
+        "shortName": "Item"
+    },
+    "55802f3e4bdc2de7118b4584": {
+        "id": "55802f3e4bdc2de7118b4584",
+        "name": "Gear mod",
+        "shortName": "Item"
+    },
+    "550aa4154bdc2dd8348b456b": {
+        "id": "550aa4154bdc2dd8348b456b",
+        "name": "Functional mod",
+        "shortName": "Item"
+    },
+    "5c0e774286f77468413cc5b2": {
+        "id": "5c0e774286f77468413cc5b2",
+        "name": "Mystery Ranch Blackjack 50 backpack (multicam)",
+        "shortName": "Blackjack 50"
+    },
+    "56e335e4d2720b6c058b456d": {
+        "id": "56e335e4d2720b6c058b456d",
+        "name": "Scav Backpack",
+        "shortName": "ScavBP"
+    },
+    "56e294cdd2720b603a8b4575": {
+        "id": "56e294cdd2720b603a8b4575",
+        "name": "Mystery Ranch Terraplane Backpack",
+        "shortName": "Terraplane 85L"
+    },
+    "5df8a4d786f77412672a1e3b": {
+        "id": "5df8a4d786f77412672a1e3b",
+        "name": "6SH118 raid backpack",
+        "shortName": "6SH118"
+    },
+    "5f5e467b0bc58666c37e7821": {
+        "id": "5f5e467b0bc58666c37e7821",
+        "name": "Eberlestock F5 Switchblade backpack (dry earth)",
+        "shortName": "F5"
+    },
+    "5ab8ebf186f7742d8b372e80": {
+        "id": "5ab8ebf186f7742d8b372e80",
+        "name": "SSO \"Attack 2\" raid backpack",
+        "shortName": "Attack 2"
+    },
+    "5e997f0b86f7741ac73993e2": {
+        "id": "5e997f0b86f7741ac73993e2",
+        "name": "Sanitar bag",
+        "shortName": "Sanitar bag"
+    },
+    "545cdae64bdc2d39198b4568": {
+        "id": "545cdae64bdc2d39198b4568",
+        "name": "Camelbak Tri-Zip Backpack",
+        "shortName": "Tri-Zip"
+    },
+    "5b44c6ae86f7742d1627baea": {
+        "id": "5b44c6ae86f7742d1627baea",
+        "name": "Ana tactical Beta 2 battle backpack ",
+        "shortName": "Beta2"
+    },
+    "5c0e805e86f774683f3dd637": {
+        "id": "5c0e805e86f774683f3dd637",
+        "name": "3V G Paratus 3-Day Operator's Tactical Backpack",
+        "shortName": "Paratus"
+    },
+    "5e4abc6786f77406812bd572": {
+        "id": "5e4abc6786f77406812bd572",
+        "name": "LBT-2670 Slim Field Med Pack",
+        "shortName": "SFMP"
+    },
+    "5ab8ee7786f7742d8f33f0b9": {
+        "id": "5ab8ee7786f7742d8f33f0b9",
+        "name": "VKBO army bag",
+        "shortName": "ArmyBag"
+    },
+    "5ab8f04f86f774585f4237d8": {
+        "id": "5ab8f04f86f774585f4237d8",
+        "name": "Tactical sling bag",
+        "shortName": "Sling"
+    },
+    "5ca20d5986f774331e7c9602": {
+        "id": "5ca20d5986f774331e7c9602",
+        "name": "Wartech Berkut VV-102 backpack",
+        "shortName": "Berkut"
+    },
+    "56e33680d2720be2748b4576": {
+        "id": "56e33680d2720be2748b4576",
+        "name": "Transformer Bag",
+        "shortName": "T-Bag"
+    },
+    "544a5cde4bdc2d39388b456b": {
+        "id": "544a5cde4bdc2d39388b456b",
+        "name": "Flyye MBSS Backpack",
+        "shortName": "MBSS"
+    },
+    "59e763f286f7742ee57895da": {
+        "id": "59e763f286f7742ee57895da",
+        "name": "Pilgrim tourist backpack",
+        "shortName": "Pilgrim"
+    },
+    "5e9dcf5986f7746c417435b3": {
+        "id": "5e9dcf5986f7746c417435b3",
+        "name": "LBT-8005A Day Pack backpack",
+        "shortName": "Day Pack"
+    },
+    "5f5e46b96bdad616ad46d613": {
+        "id": "5f5e46b96bdad616ad46d613",
+        "name": "Eberlestock F4 Terminator load bearing backpack (tiger stripe)",
+        "shortName": "F4"
+    },
+    "5d5d940f86f7742797262046": {
+        "id": "5d5d940f86f7742797262046",
+        "name": "Oakley Mechanism heavy duty backpack (black)",
+        "shortName": "Mechanism"
+    },
+    "5f5e45cc5021ce62144be7aa": {
+        "id": "5f5e45cc5021ce62144be7aa",
+        "name": "LK 3F Transfer tourist backpack",
+        "shortName": "LK 3F"
+    },
+    "56e33634d2720bd8058b456b": {
+        "id": "56e33634d2720bd8058b456b",
+        "name": "Duffle bag",
+        "shortName": "Duffle"
+    },
+    "5914944186f774189e5e76c2": {
+        "id": "5914944186f774189e5e76c2",
+        "name": "Jacket",
+        "shortName": "Jacket"
+    },
+    "5937ef2b86f77408a47244b3": {
+        "id": "5937ef2b86f77408a47244b3",
+        "name": "Jacket",
+        "shortName": "Jacket"
+    },
+    "5909d50c86f774659e6aaebe": {
+        "id": "5909d50c86f774659e6aaebe",
+        "name": "Toolbox",
+        "shortName": "Toolbox"
+    },
+    "578f87ad245977356274f2cc": {
+        "id": "578f87ad245977356274f2cc",
+        "name": "Wooden crate",
+        "shortName": "Wooden crate"
+    },
+    "578f8782245977354405a1e3": {
+        "id": "578f8782245977354405a1e3",
+        "name": "Safe",
+        "shortName": "Safe"
+    },
+    "5d6d2b5486f774785c2ba8ea": {
+        "id": "5d6d2b5486f774785c2ba8ea",
+        "name": "Ground cache",
+        "shortName": "Ground cache"
+    },
+    "5d6fd45b86f774317075ed43": {
+        "id": "5d6fd45b86f774317075ed43",
+        "name": "Technical supply crate",
+        "shortName": "Technical supply crate"
+    },
+    "578f87b7245977356274f2cd": {
+        "id": "578f87b7245977356274f2cd",
+        "name": "Drawer",
+        "shortName": "Drawer"
+    },
+    "5909d89086f77472591234a0": {
+        "id": "5909d89086f77472591234a0",
+        "name": "Weapon box",
+        "shortName": "Weapon box"
+    },
+    "5909d5ef86f77467974efbd8": {
+        "id": "5909d5ef86f77467974efbd8",
+        "name": "Weapon box",
+        "shortName": "Weapon box"
+    },
+    "5d6fe50986f77449d97f7463": {
+        "id": "5d6fe50986f77449d97f7463",
+        "name": "Medical supply crate",
+        "shortName": "Medical supply crate"
+    },
+    "5d6fd13186f77424ad2a8c69": {
+        "id": "5d6fd13186f77424ad2a8c69",
+        "name": "Ration supply crate",
+        "shortName": "Ration supply crate"
+    },
+    "5909d4c186f7746ad34e805a": {
+        "id": "5909d4c186f7746ad34e805a",
+        "name": "Medcase",
+        "shortName": "Medcase"
+    },
+    "59387ac686f77401442ddd61": {
+        "id": "59387ac686f77401442ddd61",
+        "name": "Jacket",
+        "shortName": "Jacket"
+    },
+    "578f87a3245977356274f2cb": {
+        "id": "578f87a3245977356274f2cb",
+        "name": "Duffle bag",
+        "shortName": "Duffle bag"
+    },
+    "5d07b91b86f7745a077a9432": {
+        "id": "5d07b91b86f7745a077a9432",
+        "name": "Сommon fund stash",
+        "shortName": "Сommon fund stash"
+    },
+    "5909e4b686f7747f5b744fa4": {
+        "id": "5909e4b686f7747f5b744fa4",
+        "name": "Dead Scav",
+        "shortName": "Dead Scav"
+    },
+    "5909d7cf86f77470ee57d75a": {
+        "id": "5909d7cf86f77470ee57d75a",
+        "name": "Weapon box",
+        "shortName": "Weapon box"
+    },
+    "5909d76c86f77471e53d2adf": {
+        "id": "5909d76c86f77471e53d2adf",
+        "name": "Weapon box",
+        "shortName": "Weapon box"
+    },
+    "5909d45286f77465a8136dc6": {
+        "id": "5909d45286f77465a8136dc6",
+        "name": "Wooden ammo box",
+        "shortName": "Wooden ammo box"
+    },
+    "578f8778245977358849a9b5": {
+        "id": "578f8778245977358849a9b5",
+        "name": "Jacket",
+        "shortName": "Jacket"
+    },
+    "59139c2186f77411564f8e42": {
+        "id": "59139c2186f77411564f8e42",
+        "name": "PC block",
+        "shortName": "PC block"
+    },
+    "5ad74cf586f774391278f6f0": {
+        "id": "5ad74cf586f774391278f6f0",
+        "name": "Cash register TAR2-2",
+        "shortName": "Cash register TAR2-2"
+    },
+    "5c052cea86f7746b2101e8d8": {
+        "id": "5c052cea86f7746b2101e8d8",
+        "name": "Plastic suitcase",
+        "shortName": "Plastic suitcase"
+    },
+    "5909d24f86f77466f56e6855": {
+        "id": "5909d24f86f77466f56e6855",
+        "name": "Medbag SMU06",
+        "shortName": "Medbag SMU06"
+    },
+    "5d6d2bb386f774785b07a77a": {
+        "id": "5d6d2bb386f774785b07a77a",
+        "name": "Buried barrel cache",
+        "shortName": "Buried barrel cache"
+    },
+    "578f879c24597735401e6bc6": {
+        "id": "578f879c24597735401e6bc6",
+        "name": "Cash register",
+        "shortName": "Cash register"
+    },
+    "5909d36d86f774660f0bb900": {
+        "id": "5909d36d86f774660f0bb900",
+        "name": "Grenade box",
+        "shortName": "Grenade box"
+    },
+    "5c0a794586f77461c458f892": {
+        "id": "5c0a794586f77461c458f892",
+        "name": "Secure container Boss",
+        "shortName": "Boss container"
+    },
+    "5857a8b324597729ab0a0e7d": {
+        "id": "5857a8b324597729ab0a0e7d",
+        "name": "Secure container Beta",
+        "shortName": "Beta Container"
+    },
+    "59db794186f77448bc595262": {
+        "id": "59db794186f77448bc595262",
+        "name": "Secure container Epsilon",
+        "shortName": "Epsilon"
+    },
+    "5857a8bc2459772bad15db29": {
+        "id": "5857a8bc2459772bad15db29",
+        "name": "Secure container Gamma",
+        "shortName": "Gamma container"
+    },
+    "544a11ac4bdc2d470e8b456a": {
+        "id": "544a11ac4bdc2d470e8b456a",
+        "name": "Secure container Alpha",
+        "shortName": "Alpha Container"
+    },
+    "5c093ca986f7740a1867ab12": {
+        "id": "5c093ca986f7740a1867ab12",
+        "name": "Secure container Kappa",
+        "shortName": "Kappa"
+    },
+    "5732ee6a24597719ae0c0281": {
+        "id": "5732ee6a24597719ae0c0281",
+        "name": "Waist pouch",
+        "shortName": "Waistbag"
+    },
+    "5af99e9186f7747c447120b8": {
+        "id": "5af99e9186f7747c447120b8",
+        "name": "Pockets",
+        "shortName": "Pockets"
+    },
+    "557ffd194bdc2d28148b457f": {
+        "id": "557ffd194bdc2d28148b457f",
+        "name": "Pockets",
+        "shortName": "Pockets"
+    },
+    "592c2d1a86f7746dbe2af32a": {
+        "id": "592c2d1a86f7746dbe2af32a",
+        "name": "ANA Tactical Alpha chest rig",
+        "shortName": "Alpha"
+    },
+    "5d5d85c586f774279a21cbdb": {
+        "id": "5d5d85c586f774279a21cbdb",
+        "name": "Haley Strategic D3CRX Chest Harness",
+        "shortName": "D3CRX"
+    },
+    "5c0e6a1586f77404597b4965": {
+        "id": "5c0e6a1586f77404597b4965",
+        "name": "Belt-A + Belt-B gear rig",
+        "shortName": "Belt"
+    },
+    "5c0e722886f7740458316a57": {
+        "id": "5c0e722886f7740458316a57",
+        "name": "ANA Tactical M1 armored rig",
+        "shortName": "M1"
+    },
+    "5d5d646386f7742797261fd9": {
+        "id": "5d5d646386f7742797261fd9",
+        "name": "6B3TM-01M armored rig",
+        "shortName": "6B3TM-01M"
+    },
+    "5c0e9f2c86f77432297fe0a3": {
+        "id": "5c0e9f2c86f77432297fe0a3",
+        "name": "Blackhawk! Commando Chest Harness (black)",
+        "shortName": "Commando "
+    },
+    "5df8a42886f77412640e2e75": {
+        "id": "5df8a42886f77412640e2e75",
+        "name": "Velocity Systems Multi-Purpose Patrol Vest",
+        "shortName": "MPPV"
+    },
+    "5f5f41f56760b4138443b352": {
+        "id": "5f5f41f56760b4138443b352",
+        "name": "Direct Action Thunderbolt compact chest rig",
+        "shortName": "Thunderbolt"
+    },
+    "5e4abc1f86f774069619fbaa": {
+        "id": "5e4abc1f86f774069619fbaa",
+        "name": "Spiritus Systems Bank Robber Chest Rig",
+        "shortName": "Bank Robber"
+    },
+    "59e7643b86f7742cbf2c109a": {
+        "id": "59e7643b86f7742cbf2c109a",
+        "name": "Wartech gear rig (TV-109, TV-106)",
+        "shortName": "WTRig"
+    },
+    "5b44c8ea86f7742d1627baf1": {
+        "id": "5b44c8ea86f7742d1627baf1",
+        "name": "Blackhawk! Commando Chest Harness",
+        "shortName": "Commando "
+    },
+    "5d5d8ca986f7742798716522": {
+        "id": "5d5d8ca986f7742798716522",
+        "name": "SOE Micro Rig",
+        "shortName": "MRig"
+    },
+    "5d5d87f786f77427997cfaef": {
+        "id": "5d5d87f786f77427997cfaef",
+        "name": "Ars Arma A18 Skanda plate carrier",
+        "shortName": "A18"
+    },
+    "5ab8dced86f774646209ec87": {
+        "id": "5ab8dced86f774646209ec87",
+        "name": "ANA Tactical M2 armored rig",
+        "shortName": "M2"
+    },
+    "5648a69d4bdc2ded0b8b457b": {
+        "id": "5648a69d4bdc2ded0b8b457b",
+        "name": "BlackRock chest rig",
+        "shortName": "BlackRock"
+    },
+    "5c0e746986f7741453628fe5": {
+        "id": "5c0e746986f7741453628fe5",
+        "name": "Wartech TV-110 plate carrier",
+        "shortName": "TV-110"
+    },
+    "5ca20abf86f77418567a43f2": {
+        "id": "5ca20abf86f77418567a43f2",
+        "name": "Triton M43-A Chest Harness",
+        "shortName": "Triton"
+    },
+    "5b44cad286f77402a54ae7e5": {
+        "id": "5b44cad286f77402a54ae7e5",
+        "name": "5.11 Tactec plate carrier",
+        "shortName": "Tactec "
+    },
+    "544a5caa4bdc2d1a388b4568": {
+        "id": "544a5caa4bdc2d1a388b4568",
+        "name": "Crye Precision AVS platecarrier",
+        "shortName": "AVS"
+    },
+    "5e4ac41886f77406a511c9a8": {
+        "id": "5e4ac41886f77406a511c9a8",
+        "name": "Ars Arma CPC MOD.2 plate carrier",
+        "shortName": "AACPC"
+    },
+    "5fd4c4fa16cac650092f6771": {
+        "id": "5fd4c4fa16cac650092f6771",
+        "name": "DIY IDEA chest rig",
+        "shortName": "IDEA"
+    },
+    "5e4abfed86f77406a2713cf7": {
+        "id": "5e4abfed86f77406a2713cf7",
+        "name": "Splav Tarzan M22 Rig",
+        "shortName": "Tarzan"
+    },
+    "5fd4c5477a8d854fa0105061": {
+        "id": "5fd4c5477a8d854fa0105061",
+        "name": "Security vest",
+        "shortName": "Vest"
+    },
+    "5e9db13186f7742f845ee9d3": {
+        "id": "5e9db13186f7742f845ee9d3",
+        "name": "LBT-1961A Load Bearing Chest Vest",
+        "shortName": "LBT-1961A"
+    },
+    "572b7adb24597762ae139821": {
+        "id": "572b7adb24597762ae139821",
+        "name": "Scav Vest",
+        "shortName": "Scav Vest"
+    },
+    "5929a2a086f7744f4b234d43": {
+        "id": "5929a2a086f7744f4b234d43",
+        "name": "UMTBS 6sh112 Scout-Sniper",
+        "shortName": "6sh112"
+    },
+    "5fd4c60f875c30179f5d04c2": {
+        "id": "5fd4c60f875c30179f5d04c2",
+        "name": "Gear Craft GC-BSS-MK1 rig",
+        "shortName": "BSS-MK1"
+    },
+    "5ab8dab586f77441cd04f2a2": {
+        "id": "5ab8dab586f77441cd04f2a2",
+        "name": "Wartech MK3 chest rig (TV-104)",
+        "shortName": "MK3"
+    },
+    "5c0e3eb886f7742015526062": {
+        "id": "5c0e3eb886f7742015526062",
+        "name": "6B5-16 Zh -86 \"Uley\" armored rig",
+        "shortName": "6B5-16"
+    },
+    "5c0e446786f7742013381639": {
+        "id": "5c0e446786f7742013381639",
+        "name": "6B5-15 Zh -86 \"Uley\" armored rig",
+        "shortName": "6B5-15"
+    },
+    "557596e64bdc2dc2118b4571": {
+        "id": "557596e64bdc2dc2118b4571",
+        "name": "Pockets",
+        "shortName": "Item"
+    },
+    "566965d44bdc2d814c8b4571": {
+        "id": "566965d44bdc2d814c8b4571",
+        "name": "Loot container",
+        "shortName": "Item"
+    },
+    "5448e5284bdc2dcb718b4567": {
+        "id": "5448e5284bdc2dcb718b4567",
+        "name": "Chest rig",
+        "shortName": "Item"
+    },
+    "5448e53e4bdc2d60728b4567": {
+        "id": "5448e53e4bdc2d60728b4567",
+        "name": "Backpack",
+        "shortName": "Item"
+    },
+    "5448bf274bdc2dfc2f8b456a": {
+        "id": "5448bf274bdc2dfc2f8b456a",
+        "name": "Port. container",
+        "shortName": "Item"
+    },
+    "59fb016586f7746d0d4b423a": {
+        "id": "59fb016586f7746d0d4b423a",
+        "name": "Money case",
+        "shortName": "MCase"
+    },
+    "59fb023c86f7746d0d4b423c": {
+        "id": "59fb023c86f7746d0d4b423c",
+        "name": "Weapon case",
+        "shortName": "WCase"
+    },
+    "59fafd4b86f7745ca07e1232": {
+        "id": "59fafd4b86f7745ca07e1232",
+        "name": "Keytool",
+        "shortName": "Keytool"
+    },
+    "5c0a840b86f7742ffa4f2482": {
+        "id": "5c0a840b86f7742ffa4f2482",
+        "name": "T H I C C Items case",
+        "shortName": "T H I C C"
+    },
+    "5c093db286f7740a1b2617e3": {
+        "id": "5c093db286f7740a1b2617e3",
+        "name": "Mr. Holodilnick thermobag",
+        "shortName": "Holodilnick"
+    },
+    "590c60fc86f77412b13fddcf": {
+        "id": "590c60fc86f77412b13fddcf",
+        "name": "Documents case",
+        "shortName": "Docs"
+    },
+    "5aafbcd986f7745e590fff23": {
+        "id": "5aafbcd986f7745e590fff23",
+        "name": "Meds case",
+        "shortName": "MedCase"
+    },
+    "5b7c710788a4506dec015957": {
+        "id": "5b7c710788a4506dec015957",
+        "name": "Lucky Scav junkbox",
+        "shortName": "Lucky Scav junkbox"
+    },
+    "5aafbde786f774389d0cbc0f": {
+        "id": "5aafbde786f774389d0cbc0f",
+        "name": "Ammo case",
+        "shortName": "AmmoCase"
+    },
+    "5e2af55f86f7746d4159f07c": {
+        "id": "5e2af55f86f7746d4159f07c",
+        "name": "Grenade case",
+        "shortName": "Grenades"
+    },
+    "5c127c4486f7745625356c13": {
+        "id": "5c127c4486f7745625356c13",
+        "name": "Magazine case",
+        "shortName": "Magbox"
+    },
+    "5d235bb686f77443f4331278": {
+        "id": "5d235bb686f77443f4331278",
+        "name": "Small S I C C case",
+        "shortName": "SICC"
+    },
+    "5c093e3486f77430cb02e593": {
+        "id": "5c093e3486f77430cb02e593",
+        "name": "Dogtag case",
+        "shortName": "Dogtags"
+    },
+    "59fb042886f7746c5005a7b2": {
+        "id": "59fb042886f7746c5005a7b2",
+        "name": "Items case",
+        "shortName": "ICase"
+    },
+    "5b6d9ce188a4501afc1b2b25": {
+        "id": "5b6d9ce188a4501afc1b2b25",
+        "name": "T H I C C Weapon case",
+        "shortName": "T H I C C"
+    },
+    "5783c43d2459774bbe137486": {
+        "id": "5783c43d2459774bbe137486",
+        "name": "Empty Wallet",
+        "shortName": "Wallet"
+    },
+    "5963866b86f7747bfa1c4462": {
+        "id": "5963866b86f7747bfa1c4462",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "5963866286f7747bf429b572": {
+        "id": "5963866286f7747bf429b572",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "5811ce772459770e9e5f9532": {
+        "id": "5811ce772459770e9e5f9532",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "5811ce572459770cba1a34ea": {
+        "id": "5811ce572459770cba1a34ea",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "5811ce662459770f6f490f32": {
+        "id": "5811ce662459770f6f490f32",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "566abbc34bdc2d92178b4576": {
+        "id": "566abbc34bdc2d92178b4576",
+        "name": "Stash",
+        "shortName": "Stash"
+    },
+    "587e02ff24597743df3deaeb": {
+        "id": "587e02ff24597743df3deaeb",
+        "name": "Simonov Semi-Automatic Carbine SKS 7.62x39 Hunting Rifle\nVersion",
+        "shortName": "OP-SKS"
+    },
+    "574d967124597745970e7c94": {
+        "id": "574d967124597745970e7c94",
+        "name": "Simonov Semi-Automatic Carbine SKS 7.62x39",
+        "shortName": "SKS"
+    },
+    "5c501a4d2e221602b412b540": {
+        "id": "5c501a4d2e221602b412b540",
+        "name": "Vepr Hunter/VPO-101 7.62x51 carbine",
+        "shortName": "Hunter"
+    },
+    "57c44b372459772d2b39b8ce": {
+        "id": "57c44b372459772d2b39b8ce",
+        "name": "AS VAL",
+        "shortName": "AS VAL"
+    },
+    "57dc2fa62459775949412633": {
+        "id": "57dc2fa62459775949412633",
+        "name": "Kalashnikov AKS-74U 5.45x39",
+        "shortName": "AKS-74U"
+    },
+    "5ac66d015acfc400180ae6e4": {
+        "id": "5ac66d015acfc400180ae6e4",
+        "name": "AK-102 5.56x45 assault rifle",
+        "shortName": "AK-102"
+    },
+    "5dcbd56fdbd3d91b3e5468d5": {
+        "id": "5dcbd56fdbd3d91b3e5468d5",
+        "name": "DT MDR 7.62x51 Assault Rifle",
+        "shortName": "DT MDR .308"
+    },
+    "5b0bbe4e5acfc40dc528a72d": {
+        "id": "5b0bbe4e5acfc40dc528a72d",
+        "name": "DS Arms SA-58 7.62x51",
+        "shortName": "SA-58"
+    },
+    "59ff346386f77477562ff5e2": {
+        "id": "59ff346386f77477562ff5e2",
+        "name": "AKMS 7.62x39 assault rifle",
+        "shortName": "AKMS"
+    },
+    "5644bd2b4bdc2d3b4c8b4572": {
+        "id": "5644bd2b4bdc2d3b4c8b4572",
+        "name": "AK-74N 5.45x39 assault rifle",
+        "shortName": "AK-74N"
+    },
+    "5a0ec13bfcdbcb00165aa685": {
+        "id": "5a0ec13bfcdbcb00165aa685",
+        "name": "AKMN 7.62x39 assault rifle",
+        "shortName": "AKMN"
+    },
+    "5d43021ca4b9362eab4b5e25": {
+        "id": "5d43021ca4b9362eab4b5e25",
+        "name": "Lone Star TX-15 DML Rifle",
+        "shortName": "TX-15 DML"
+    },
+    "5bb2475ed4351e00853264e3": {
+        "id": "5bb2475ed4351e00853264e3",
+        "name": "HK 416A5 5.56x45 Assault Rifle",
+        "shortName": "HK 416A5"
+    },
+    "5839a40f24597726f856b511": {
+        "id": "5839a40f24597726f856b511",
+        "name": "Kalashnikov AKS-74UB 5.45x39",
+        "shortName": "AKS-74UB"
+    },
+    "5fbcc1d9016cce60e8341ab3": {
+        "id": "5fbcc1d9016cce60e8341ab3",
+        "name": "SIG MCX .300 AAC Blackout Assault Rifle",
+        "shortName": "SIG MCX 300 blk"
+    },
+    "59e6152586f77473dc057aa1": {
+        "id": "59e6152586f77473dc057aa1",
+        "name": "Vepr KM / VPO-136 7.62x39 carbine",
+        "shortName": "Vepr KM/VPO-136"
+    },
+    "5ac66d9b5acfc4001633997a": {
+        "id": "5ac66d9b5acfc4001633997a",
+        "name": "AK-105 5.45x39 assault rifle",
+        "shortName": "AK-105"
+    },
+    "5ac66cb05acfc40198510a10": {
+        "id": "5ac66cb05acfc40198510a10",
+        "name": "AK-101 5.56x45 assault rifle",
+        "shortName": "AK-101"
+    },
+    "583990e32459771419544dd2": {
+        "id": "583990e32459771419544dd2",
+        "name": "Kalashnikov AKS-74UN 5.45x39",
+        "shortName": "AKS-74UN"
+    },
+    "5bf3e0490db83400196199af": {
+        "id": "5bf3e0490db83400196199af",
+        "name": "АKS-74 5.45x39 assault rifle",
+        "shortName": "АKS-74"
+    },
+    "5bf3e03b0db834001d2c4a9c": {
+        "id": "5bf3e03b0db834001d2c4a9c",
+        "name": "АK-74 5.45x39 assault rifle",
+        "shortName": "АK-74"
+    },
+    "5ac66d725acfc43b321d4b60": {
+        "id": "5ac66d725acfc43b321d4b60",
+        "name": "AK-104 7.62x39 assault rifle",
+        "shortName": "AK-104"
+    },
+    "5ac66d2e5acfc43b321d4b53": {
+        "id": "5ac66d2e5acfc43b321d4b53",
+        "name": "AK-103 7.62x39 assault rifle",
+        "shortName": "AK-103"
+    },
+    "59d6088586f774275f37482f": {
+        "id": "59d6088586f774275f37482f",
+        "name": "AKM 7.62x39 assault rifle",
+        "shortName": "AKM"
+    },
+    "5ac4cd105acfc40016339859": {
+        "id": "5ac4cd105acfc40016339859",
+        "name": "AK-74M 5.45x39 assault rifle",
+        "shortName": "AK-74M"
+    },
+    "59e6687d86f77411d949b251": {
+        "id": "59e6687d86f77411d949b251",
+        "name": "Vepr AKM / VPO-209 366TKM carbine",
+        "shortName": "AKM/VPO-209"
+    },
+    "5abcbc27d8ce8700182eceeb": {
+        "id": "5abcbc27d8ce8700182eceeb",
+        "name": "AKMSN 7.62x39 assault rifle",
+        "shortName": "AKMSN"
+    },
+    "5ab8e9fcd8ce870019439434": {
+        "id": "5ab8e9fcd8ce870019439434",
+        "name": "AKS-74N 5.45x39 assault rifle",
+        "shortName": "AKS-74N"
+    },
+    "5c07c60e0db834002330051f": {
+        "id": "5c07c60e0db834002330051f",
+        "name": "ADAR 2-15 .223 Carbine",
+        "shortName": "ADAR 2-15"
+    },
+    "5cadfbf7ae92152ac412eeef": {
+        "id": "5cadfbf7ae92152ac412eeef",
+        "name": "ASh-12 12.7x55 assault rifle",
+        "shortName": "ASh-12"
+    },
+    "5447a9cd4bdc2dbd208b4567": {
+        "id": "5447a9cd4bdc2dbd208b4567",
+        "name": "Colt M4A1 5.56x45 Assault Rifle",
+        "shortName": "M4A1"
+    },
+    "5c488a752e221602b412af63": {
+        "id": "5c488a752e221602b412af63",
+        "name": "DT MDR 5.56x45 Assault Rifle",
+        "shortName": "DT MDR 5.56x45"
+    },
+    "5c46fbd72e2216398b5a8c9c": {
+        "id": "5c46fbd72e2216398b5a8c9c",
+        "name": "SVDS 7.62x54 Sniper rifle",
+        "shortName": "SVDS"
+    },
+    "5df8ce05b11454561e39243b": {
+        "id": "5df8ce05b11454561e39243b",
+        "name": "Knight's Armament Company SR-25 7.62x51",
+        "shortName": "SR-25"
+    },
+    "5f2a9575926fd9352339381f": {
+        "id": "5f2a9575926fd9352339381f",
+        "name": "Kel-Tec RFB 7.62x51",
+        "shortName": "RFB"
+    },
+    "5aafa857e5b5b00018480968": {
+        "id": "5aafa857e5b5b00018480968",
+        "name": "Springfield Armory M1A 7.62x51",
+        "shortName": "M1A"
+    },
+    "5a367e5dc4a282000e49738f": {
+        "id": "5a367e5dc4a282000e49738f",
+        "name": "Remington R11 RSASS 7.62x51",
+        "shortName": "RSASS"
+    },
+    "5fc22d7c187fea44d52eda44": {
+        "id": "5fc22d7c187fea44d52eda44",
+        "name": "Mk-18 .338 LM marksman rifle",
+        "shortName": "Mk-18 .338 LM"
+    },
+    "57838ad32459774a17445cd2": {
+        "id": "57838ad32459774a17445cd2",
+        "name": "Special Sniper Rifle VSS Vintorez ",
+        "shortName": "VSS"
+    },
+    "5448bd6b4bdc2dfc2f8b4569": {
+        "id": "5448bd6b4bdc2dfc2f8b4569",
+        "name": "PM 9x18PM pistol",
+        "shortName": "PM"
+    },
+    "5abccb7dd8ce87001773e277": {
+        "id": "5abccb7dd8ce87001773e277",
+        "name": "Silenced Stechkin Automatic Pistol 9x18PM",
+        "shortName": "APB"
+    },
+    "5b1fa9b25acfc40018633c01": {
+        "id": "5b1fa9b25acfc40018633c01",
+        "name": "GLOCK 18C 9x19 pistol",
+        "shortName": "GLOCK18C"
+    },
+    "579204f224597773d619e051": {
+        "id": "579204f224597773d619e051",
+        "name": "PM (t) 9x18PM pistol",
+        "shortName": "PM(t)"
+    },
+    "5d67abc1a4b93614ec50137f": {
+        "id": "5d67abc1a4b93614ec50137f",
+        "name": "FN Five-seveN MK2 FDE Frame 5.7x28 pistol",
+        "shortName": "FN 5-7 FDE"
+    },
+    "571a12c42459771f627b58a0": {
+        "id": "571a12c42459771f627b58a0",
+        "name": "TT pistol 7.62x25 TT",
+        "shortName": "TT"
+    },
+    "59f98b4986f7746f546d2cef": {
+        "id": "59f98b4986f7746f546d2cef",
+        "name": "9x21 Serdyukov automatic pistol SR1MP Gyurza",
+        "shortName": "SR-1MP"
+    },
+    "576a581d2459771e7b1bc4f1": {
+        "id": "576a581d2459771e7b1bc4f1",
+        "name": "Yarygin MP-443 Grach 9x19 pistol",
+        "shortName": "MP-443 \"Grach\""
+    },
+    "5d3eb3b0a4b93615055e84d2": {
+        "id": "5d3eb3b0a4b93615055e84d2",
+        "name": "FN Five-seveN MK2 5.7x28 pistol",
+        "shortName": "FN 5-7"
+    },
+    "5cadc190ae921500103bb3b6": {
+        "id": "5cadc190ae921500103bb3b6",
+        "name": "Beretta M9A3 9x19 pistol",
+        "shortName": "M9A3"
+    },
+    "56e0598dd2720bb5668b45a6": {
+        "id": "56e0598dd2720bb5668b45a6",
+        "name": "PB 9x18PM silenced pistol",
+        "shortName": "PB"
+    },
+    "5b3b713c5acfc4330140bd8d": {
+        "id": "5b3b713c5acfc4330140bd8d",
+        "name": "TT pistol 7.62x25 TT Gold",
+        "shortName": "TT"
+    },
+    "56d59856d2720bd8418b456a": {
+        "id": "56d59856d2720bd8418b456a",
+        "name": "P226R 9x19 pistol",
+        "shortName": "P226R"
+    },
+    "5a7ae0c351dfba0017554310": {
+        "id": "5a7ae0c351dfba0017554310",
+        "name": "GLOCK 17 9x19 pistol",
+        "shortName": "GLOCK17"
+    },
+    "5e81c3cbac2bb513793cdc75": {
+        "id": "5e81c3cbac2bb513793cdc75",
+        "name": "Colt M1911A1 .45 ACP pistol",
+        "shortName": "M1911A1"
+    },
+    "5f36a0e5fbf956000b716b65": {
+        "id": "5f36a0e5fbf956000b716b65",
+        "name": "Colt M45A1 .45 ACP pistol",
+        "shortName": "M45A1"
+    },
+    "5a17f98cfcdbcb0980087290": {
+        "id": "5a17f98cfcdbcb0980087290",
+        "name": "Stechkin Automatic Pistol 9x18PM",
+        "shortName": "APS"
+    },
+    "56dee2bdd2720bc8328b4567": {
+        "id": "56dee2bdd2720bc8328b4567",
+        "name": "MP-153 12ga semi-automatic shotgun",
+        "shortName": "MP-153"
+    },
+    "5a38e6bac4a2826c6e06d79b": {
+        "id": "5a38e6bac4a2826c6e06d79b",
+        "name": "TOZ-106 bolt-action shotgun",
+        "shortName": "TOZ-106"
+    },
+    "54491c4f4bdc2db1078b4568": {
+        "id": "54491c4f4bdc2db1078b4568",
+        "name": "MP-133 12ga shotgun",
+        "shortName": "MP-133"
+    },
+    "5e870397991fd70db46995c8": {
+        "id": "5e870397991fd70db46995c8",
+        "name": "Mossberg 590A1 12ga shotgun",
+        "shortName": "590A1"
+    },
+    "576165642459773c7a400233": {
+        "id": "576165642459773c7a400233",
+        "name": "Saiga 12ga ver. 10 12/76 shotgun",
+        "shortName": "Saiga 12ga v.10"
+    },
+    "5a7828548dc32e5a9c28b516": {
+        "id": "5a7828548dc32e5a9c28b516",
+        "name": "Remington Model 870 12ga shotgun",
+        "shortName": "M870"
+    },
+    "5e848cc2988a8701445df1e8": {
+        "id": "5e848cc2988a8701445df1e8",
+        "name": "TOZ KS-23M 23x75mm shotgun",
+        "shortName": "KS-23M"
+    },
+    "59f9cabd86f7743a10721f46": {
+        "id": "59f9cabd86f7743a10721f46",
+        "name": "Saiga-9 9x19 Carbine",
+        "shortName": "Saiga-9"
+    },
+    "57d14d2524597714373db789": {
+        "id": "57d14d2524597714373db789",
+        "name": "PP-91 Kedr 9x18PM SMG",
+        "shortName": "PP-91 Kedr"
+    },
+    "5ea03f7400685063ec28bfa8": {
+        "id": "5ea03f7400685063ec28bfa8",
+        "name": "Submachinegun PPSH-41 7.62x25",
+        "shortName": "PPSH-41"
+    },
+    "5de7bd7bfd6b4e6e2276dc25": {
+        "id": "5de7bd7bfd6b4e6e2276dc25",
+        "name": "B&T MP9-N 9x19 Submachinegun",
+        "shortName": "MP9-N"
+    },
+    "57f4c844245977379d5c14d1": {
+        "id": "57f4c844245977379d5c14d1",
+        "name": "PP-9 Klin 9x18PMM SMG",
+        "shortName": "PP-9 Klin"
+    },
+    "5926bb2186f7744b1c6c6e60": {
+        "id": "5926bb2186f7744b1c6c6e60",
+        "name": "HK MP5 9x19 submachinegun (Navy 3 Round Burst)",
+        "shortName": "MP5"
+    },
+    "5d2f0d8048f0356c925bc3b0": {
+        "id": "5d2f0d8048f0356c925bc3b0",
+        "name": "HK MP5 Kurz 9x19 submachinegun",
+        "shortName": "MP5K-N"
+    },
+    "57f3c6bd24597738e730fa2f": {
+        "id": "57f3c6bd24597738e730fa2f",
+        "name": "PP-91-01 Kedr-B 9x18PM SMG",
+        "shortName": "PP-91-01 Kedr-B"
+    },
+    "59984ab886f7743e98271174": {
+        "id": "59984ab886f7743e98271174",
+        "name": "Submachinegun PP-19-01 Vityaz-SN 9x19",
+        "shortName": "PP-19-01"
+    },
+    "5fc3f2d5900b1d5091531e57": {
+        "id": "5fc3f2d5900b1d5091531e57",
+        "name": "TDI Kriss Vector Gen.2 9x19 submachinegun",
+        "shortName": "Vector 9x19mm"
+    },
+    "5e00903ae9dc277128008b87": {
+        "id": "5e00903ae9dc277128008b87",
+        "name": "B&T MP9 9x19 submachinegun",
+        "shortName": "MP9 9x19"
+    },
+    "5fc3e272f8b6a877a729eac5": {
+        "id": "5fc3e272f8b6a877a729eac5",
+        "name": "HK UMP 45 submachinegun",
+        "shortName": "UMP 45"
+    },
+    "5bd70322209c4d00d7167b8f": {
+        "id": "5bd70322209c4d00d7167b8f",
+        "name": "HK MP7A2 4.6x30 submachinegun",
+        "shortName": "MP7A2"
+    },
+    "5fb64bc92b1b027b1f50bcf2": {
+        "id": "5fb64bc92b1b027b1f50bcf2",
+        "name": "TDI KRISS Vector Gen.2 .45 ACP submachinegun",
+        "shortName": "Vector .45"
+    },
+    "5cc82d76e24e8d00134b4b83": {
+        "id": "5cc82d76e24e8d00134b4b83",
+        "name": "FN P90 5.7x28 submachinegun",
+        "shortName": "P90"
+    },
+    "5ba26383d4351e00334c93d9": {
+        "id": "5ba26383d4351e00334c93d9",
+        "name": "HK MP7A1 4.6x30 submachinegun",
+        "shortName": "MP7A1"
+    },
+    "58948c8e86f77409493f7266": {
+        "id": "58948c8e86f77409493f7266",
+        "name": "SIG MPX 9x19 Submachine gun",
+        "shortName": "MPX"
+    },
+    "5bfd297f0db834001a669119": {
+        "id": "5bfd297f0db834001a669119",
+        "name": "Mosin bolt-action infantry rifle",
+        "shortName": "Mosin Inf."
+    },
+    "5ae08f0a5acfc408fb1398a1": {
+        "id": "5ae08f0a5acfc408fb1398a1",
+        "name": "Mosin bolt-action sniper rifle",
+        "shortName": "Mosin"
+    },
+    "55801eed4bdc2d89578b4588": {
+        "id": "55801eed4bdc2d89578b4588",
+        "name": "SV-98 bolt-action sniper rifle",
+        "shortName": "SV-98"
+    },
+    "5de652c31b7e3716273428be": {
+        "id": "5de652c31b7e3716273428be",
+        "name": "Molot VPO-215 .366 TKM rifle",
+        "shortName": "VPO-215"
+    },
+    "5df24cf80dee1b22f862e9bc": {
+        "id": "5df24cf80dee1b22f862e9bc",
+        "name": "Orsis T-5000 .308 sniper rifle",
+        "shortName": "T-5000 .308"
+    },
+    "588892092459774ac91d4b11": {
+        "id": "588892092459774ac91d4b11",
+        "name": "DVL-10 Saboteur sniper rifle",
+        "shortName": "DVL-10"
+    },
+    "5bfea6e90db834001b7347f3": {
+        "id": "5bfea6e90db834001b7347f3",
+        "name": "Remington Model 700 Sniper rifle",
+        "shortName": "M700"
+    },
+    "5cdeb229d7f00c000e7ce174": {
+        "id": "5cdeb229d7f00c000e7ce174",
+        "name": "NSV \"Utes\" 12.7x108 machine gun",
+        "shortName": "NSV"
+    },
+    "5d52cc5ba4b9367408500062": {
+        "id": "5d52cc5ba4b9367408500062",
+        "name": "AGS 30x29 mm automatic grenade launcher",
+        "shortName": "AGS"
+    },
+    "5beed0f50db834001c062b12": {
+        "id": "5beed0f50db834001c062b12",
+        "name": "RPK-16 5.45x39 light machine gun",
+        "shortName": "RPK-16"
+    },
+    "5e81ebcd8e146c7080625e15": {
+        "id": "5e81ebcd8e146c7080625e15",
+        "name": "FN GL40 Mk.2 grenade launcher",
+        "shortName": "GL40"
+    },
+    "5447b5fc4bdc2d87278b4567": {
+        "id": "5447b5fc4bdc2d87278b4567",
+        "name": "Assault carbine",
+        "shortName": "Item"
+    },
+    "5447b6194bdc2d67278b4567": {
+        "id": "5447b6194bdc2d67278b4567",
+        "name": "Marskman rifle",
+        "shortName": "Item"
+    },
+    "5447b6094bdc2dc3278b4567": {
+        "id": "5447b6094bdc2dc3278b4567",
+        "name": "Shotgun",
+        "shortName": "Item"
+    },
+    "5447bedf4bdc2d87278b4568": {
+        "id": "5447bedf4bdc2d87278b4568",
+        "name": "Grenade launcher",
+        "shortName": "Item"
+    },
+    "5447b6254bdc2dc3278b4568": {
+        "id": "5447b6254bdc2dc3278b4568",
+        "name": "Sniper rifle",
+        "shortName": "Item"
+    },
+    "5447b5cf4bdc2d65278b4567": {
+        "id": "5447b5cf4bdc2d65278b4567",
+        "name": "Handgun",
+        "shortName": "Pistol"
+    },
+    "5447b5f14bdc2d61278b4567": {
+        "id": "5447b5f14bdc2d61278b4567",
+        "name": "Assault rifle",
+        "shortName": "Item"
+    },
+    "5447b5e04bdc2d62278b4567": {
+        "id": "5447b5e04bdc2d62278b4567",
+        "name": "SMG",
+        "shortName": "Item"
+    },
+    "5447bee84bdc2dc3278b4569": {
+        "id": "5447bee84bdc2dc3278b4569",
+        "name": "Special weapon",
+        "shortName": "Item"
+    },
+    "5447bed64bdc2d97278b4568": {
+        "id": "5447bed64bdc2d97278b4568",
+        "name": "Machinegun",
+        "shortName": "Item"
+    },
+    "5b3f3af486f774679e752c1f": {
+        "id": "5b3f3af486f774679e752c1f",
+        "name": "Armband (blue)",
+        "shortName": "Armband"
+    },
+    "5b3f3b0186f774021a2afef7": {
+        "id": "5b3f3b0186f774021a2afef7",
+        "name": "Armband (green)",
+        "shortName": "Armband"
+    },
+    "5b3f3ade86f7746b6b790d8e": {
+        "id": "5b3f3ade86f7746b6b790d8e",
+        "name": "Armband (red)",
+        "shortName": "Armband "
+    },
+    "5b3f16c486f7747c327f55f7": {
+        "id": "5b3f16c486f7747c327f55f7",
+        "name": "Armband (white)",
+        "shortName": "Armband "
+    },
+    "5b3f3b0e86f7746752107cda": {
+        "id": "5b3f3b0e86f7746752107cda",
+        "name": "Armband (yellow)",
+        "shortName": "Armband "
+    },
+    "5f9949d869e2777a0e779ba5": {
+        "id": "5f9949d869e2777a0e779ba5",
+        "name": "Rivals 2020 armband",
+        "shortName": "Rivals"
+    },
+    "5ab8e79e86f7742d8b372e78": {
+        "id": "5ab8e79e86f7742d8b372e78",
+        "name": "BNTI Gzhel-K armor",
+        "shortName": "GZHEL-K"
+    },
+    "5ab8e4ed86f7742d8e50c7fa": {
+        "id": "5ab8e4ed86f7742d8e50c7fa",
+        "name": "MF-UNTAR armor vest",
+        "shortName": "MF-UN"
+    },
+    "545cdb794bdc2d3a198b456a": {
+        "id": "545cdb794bdc2d3a198b456a",
+        "name": "6B43 Zabralo-Sh 6A Armor",
+        "shortName": "6B43 6A"
+    },
+    "5c0e53c886f7747fa54205c7": {
+        "id": "5c0e53c886f7747fa54205c7",
+        "name": "6B13 assault armor (digital flora pattern)",
+        "shortName": "6B13"
+    },
+    "5c0e51be86f774598e797894": {
+        "id": "5c0e51be86f774598e797894",
+        "name": "6B13 assault armor (flora pattern)",
+        "shortName": "6B13"
+    },
+    "5c0e541586f7747fa54205c9": {
+        "id": "5c0e541586f7747fa54205c9",
+        "name": "6B13 M assault armor (tan)",
+        "shortName": "6B13M"
+    },
+    "5df8a2ca86f7740bfe6df777": {
+        "id": "5df8a2ca86f7740bfe6df777",
+        "name": "6B2 armor (flora)",
+        "shortName": "6B2"
+    },
+    "5c0e5bab86f77461f55ed1f3": {
+        "id": "5c0e5bab86f77461f55ed1f3",
+        "name": "6B23-1 armor (digital flora pattern)",
+        "shortName": "6B23-1"
+    },
+    "5c0e57ba86f7747fa141986d": {
+        "id": "5c0e57ba86f7747fa141986d",
+        "name": "6B23-2 armor (mountain flora pattern)",
+        "shortName": "6B23-2"
+    },
+    "5e9dacf986f774054d6b89f4": {
+        "id": "5e9dacf986f774054d6b89f4",
+        "name": "FORT Defender-2 body armor",
+        "shortName": "Defender-2"
+    },
+    "5b44cd8b86f774503d30cba2": {
+        "id": "5b44cd8b86f774503d30cba2",
+        "name": "IOTV Gen4 armor (full protection)",
+        "shortName": "Gen4 Full"
+    },
+    "5b44cf1486f77431723e3d05": {
+        "id": "5b44cf1486f77431723e3d05",
+        "name": "IOTV Gen4 armor (assault kit)",
+        "shortName": "Gen4 Assault"
+    },
+    "5b44d0de86f774503d30cba8": {
+        "id": "5b44d0de86f774503d30cba8",
+        "name": "IOTV Gen4 armor (high mobility kit)",
+        "shortName": "Gen4 HMK"
+    },
+    "5b44d22286f774172b0c9de8": {
+        "id": "5b44d22286f774172b0c9de8",
+        "name": "BNTI Kirasa-N armor",
+        "shortName": "Kirasa"
+    },
+    "5f5f41476bdad616ad46d631": {
+        "id": "5f5f41476bdad616ad46d631",
+        "name": "BNTI Korund-VM armor",
+        "shortName": "Korund-VM"
+    },
+    "5ca2151486f774244a3b8d30": {
+        "id": "5ca2151486f774244a3b8d30",
+        "name": "FORT Redut-M body armor",
+        "shortName": "Redut-M"
+    },
+    "5ca21c6986f77479963115a7": {
+        "id": "5ca21c6986f77479963115a7",
+        "name": "FORT Redut-T5 body armor",
+        "shortName": "Redut-T5"
+    },
+    "5c0e655586f774045612eeb2": {
+        "id": "5c0e655586f774045612eeb2",
+        "name": "Highcom Trooper TFO armor (multicam)",
+        "shortName": "Trooper"
+    },
+    "5c0e5edb86f77461f55ed1f7": {
+        "id": "5c0e5edb86f77461f55ed1f7",
+        "name": "Zhuk-3 Press armor",
+        "shortName": "Zhuk-3"
+    },
+    "5c0e625a86f7742d77340f62": {
+        "id": "5c0e625a86f7742d77340f62",
+        "name": "Zhuk-6a heavy armor",
+        "shortName": "Zhuk-6a"
+    },
+    "59e7635f86f7742cbf2c1095": {
+        "id": "59e7635f86f7742cbf2c1095",
+        "name": "Module-3M bodyarmor",
+        "shortName": "3M"
+    },
+    "5fd4c474dd870108a754b241": {
+        "id": "5fd4c474dd870108a754b241",
+        "name": "5.11 Hexgrid plate carrier",
+        "shortName": "HGrid"
+    },
+    "5e4abb5086f77406975c9342": {
+        "id": "5e4abb5086f77406975c9342",
+        "name": "LBT 6094A Slick Plate Carrier",
+        "shortName": "Slick"
+    },
+    "5648a7494bdc2d9d488b4583": {
+        "id": "5648a7494bdc2d9d488b4583",
+        "name": "PACA Soft Armor",
+        "shortName": "PACA"
+    },
+    "572b7f1624597762ae139822": {
+        "id": "572b7f1624597762ae139822",
+        "name": "Balaclava",
+        "shortName": "Balaclava"
+    },
+    "5ab8f39486f7745cd93a1cca": {
+        "id": "5ab8f39486f7745cd93a1cca",
+        "name": "Cold Fear Infrared balaclava",
+        "shortName": "CF"
+    },
+    "58ac60eb86f77401897560ff": {
+        "id": "58ac60eb86f77401897560ff",
+        "name": "Balaclava_dev",
+        "shortName": "Balaclava_dev"
+    },
+    "5ab8f4ff86f77431c60d91ba": {
+        "id": "5ab8f4ff86f77431c60d91ba",
+        "name": "Ghost balaclava",
+        "shortName": "Ghost"
+    },
+    "5c1a1e3f2e221602b66cc4c2": {
+        "id": "5c1a1e3f2e221602b66cc4c2",
+        "name": "Fake white beard",
+        "shortName": "Beard"
+    },
+    "5bd071d786f7747e707b93a3": {
+        "id": "5bd071d786f7747e707b93a3",
+        "name": "Jason mask",
+        "shortName": "Mask"
+    },
+    "5bd0716d86f774171822ef4b": {
+        "id": "5bd0716d86f774171822ef4b",
+        "name": "Misha Mayorov's mask",
+        "shortName": "Mask"
+    },
+    "5b432c305acfc40019478128": {
+        "id": "5b432c305acfc40019478128",
+        "name": "GP-5 gasmask",
+        "shortName": "GP-5"
+    },
+    "5b432f3d5acfc4704b4a1dfb": {
+        "id": "5b432f3d5acfc4704b4a1dfb",
+        "name": "Momex balaclava",
+        "shortName": "Momex"
+    },
+    "5b4326435acfc433000ed01d": {
+        "id": "5b4326435acfc433000ed01d",
+        "name": "Neoprene mask",
+        "shortName": "Mask"
+    },
+    "5e71f6be86f77429f2683c44": {
+        "id": "5e71f6be86f77429f2683c44",
+        "name": " Twitch Rivals 2020 mask",
+        "shortName": "Rivals"
+    },
+    "5b432b2f5acfc4771e1c6622": {
+        "id": "5b432b2f5acfc4771e1c6622",
+        "name": "Light armored Shattered mask",
+        "shortName": "Shattered"
+    },
+    "5b4325355acfc40019478126": {
+        "id": "5b4325355acfc40019478126",
+        "name": "Shemagh (var. 2)",
+        "shortName": "Shemagh"
+    },
+    "5e54f76986f7740366043752": {
+        "id": "5e54f76986f7740366043752",
+        "name": "Shroud half-mask",
+        "shortName": "Shroud"
+    },
+    "5b432b6c5acfc4001a599bf0": {
+        "id": "5b432b6c5acfc4001a599bf0",
+        "name": "Deadly skull mask",
+        "shortName": "Skull"
+    },
+    "5e71fad086f77422443d4604": {
+        "id": "5e71fad086f77422443d4604",
+        "name": "Twitch Rivals 2020 half mask",
+        "shortName": "Rivals"
+    },
+    "5bd073a586f7747e6f135799": {
+        "id": "5bd073a586f7747e6f135799",
+        "name": "Fake mustache",
+        "shortName": "Mustache"
+    },
+    "572b7fa524597762b747ce82": {
+        "id": "572b7fa524597762b747ce82",
+        "name": "Lower half-mask",
+        "shortName": "Mask"
+    },
+    "59e7715586f7742ee5789605": {
+        "id": "59e7715586f7742ee5789605",
+        "name": "Respirator",
+        "shortName": "Resp"
+    },
+    "5ab8f85d86f7745cd93a1cf5": {
+        "id": "5ab8f85d86f7745cd93a1cf5",
+        "name": "Shemagh",
+        "shortName": "Shemagh"
+    },
+    "59e8936686f77467ce798647": {
+        "id": "59e8936686f77467ce798647",
+        "name": "Balaclava_test",
+        "shortName": "Balaclava_test"
+    },
+    "5bd06f5d86f77427101ad47c": {
+        "id": "5bd06f5d86f77427101ad47c",
+        "name": "Slender mask",
+        "shortName": "Mask"
+    },
+    "5e54f79686f7744022011103": {
+        "id": "5e54f79686f7744022011103",
+        "name": "Pestily plague mask",
+        "shortName": "Plague mask"
+    },
+    "5fd8d28367cb5e077335170f": {
+        "id": "5fd8d28367cb5e077335170f",
+        "name": "Smoke balaclava",
+        "shortName": "Smoke"
+    },
+    "5c091a4e0db834001d5addc8": {
+        "id": "5c091a4e0db834001d5addc8",
+        "name": "Maska 1Sch helmet",
+        "shortName": "Maska 1Sch"
+    },
+    "5c066ef40db834001966a595": {
+        "id": "5c066ef40db834001966a595",
+        "name": "Armasight NVG mask",
+        "shortName": "NVG mask"
+    },
+    "5aa7cfc0e5b5b00015693143": {
+        "id": "5aa7cfc0e5b5b00015693143",
+        "name": "6B47 Helmet with cover (flora digital)",
+        "shortName": "6B47"
+    },
+    "5aa2ba46e5b5b000137b758d": {
+        "id": "5aa2ba46e5b5b000137b758d",
+        "name": "UX PRO Beanie",
+        "shortName": "UXPRO"
+    },
+    "59e7711e86f7746cae05fbe1": {
+        "id": "59e7711e86f7746cae05fbe1",
+        "name": "Kolpak-1S riot helmet",
+        "shortName": "Kolpak"
+    },
+    "5b40e5e25acfc4001a599bea": {
+        "id": "5b40e5e25acfc4001a599bea",
+        "name": "BEAR baseball cap black",
+        "shortName": "BEAR"
+    },
+    "5b4329075acfc400153b78ff": {
+        "id": "5b4329075acfc400153b78ff",
+        "name": "Pompon hat",
+        "shortName": "Pompon"
+    },
+    "5b4329f05acfc47a86086aa1": {
+        "id": "5b4329f05acfc47a86086aa1",
+        "name": "DEVTAC Ronin ballistic helmet",
+        "shortName": "Ronin"
+    },
+    "5f60e6403b85f6263c14558c": {
+        "id": "5f60e6403b85f6263c14558c",
+        "name": "Black beret",
+        "shortName": "Beret"
+    },
+    "5bd073c986f7747f627e796c": {
+        "id": "5bd073c986f7747f627e796c",
+        "name": "Kotton beanie",
+        "shortName": "Kotton"
+    },
+    "5c06c6a80db834001b735491": {
+        "id": "5c06c6a80db834001b735491",
+        "name": "SSh-68 helmet (1968 steel helmet)",
+        "shortName": "SSh-68"
+    },
+    "5d96141523f0ea1b7f2aacab": {
+        "id": "5d96141523f0ea1b7f2aacab",
+        "name": "\"Door Kicker\" Boonie hat",
+        "shortName": "\"Door Kicker\""
+    },
+    "5b432d215acfc4771e1c6624": {
+        "id": "5b432d215acfc4771e1c6624",
+        "name": "LZSh light helmet",
+        "shortName": "LZSh"
+    },
+    "5645bc214bdc2d363b8b4571": {
+        "id": "5645bc214bdc2d363b8b4571",
+        "name": "Kiver-M Helmet",
+        "shortName": "Kiver-M"
+    },
+    "5df8a58286f77412631087ed": {
+        "id": "5df8a58286f77412631087ed",
+        "name": "Soft tank crew helmet TSH-4M-L",
+        "shortName": "Tank helmet"
+    },
+    "5c17a7ed2e2216152142459c": {
+        "id": "5c17a7ed2e2216152142459c",
+        "name": "Crye Precision Airframe Tan",
+        "shortName": "Airframe Tan"
+    },
+    "5ca20ee186f774799474abc2": {
+        "id": "5ca20ee186f774799474abc2",
+        "name": "Vulkan-5 (LShZ-5) heavy helmet",
+        "shortName": "Vulkan-5"
+    },
+    "5a7c4850e899ef00150be885": {
+        "id": "5a7c4850e899ef00150be885",
+        "name": "6B47 Ratnik-BSh Helmet",
+        "shortName": "6B47"
+    },
+    "59ef13ca86f77445fd0e2483": {
+        "id": "59ef13ca86f77445fd0e2483",
+        "name": "Jack-o'-lantern tactical pumpkin helmet",
+        "shortName": "Pumpkin"
+    },
+    "5aa7d193e5b5b000171d063f": {
+        "id": "5aa7d193e5b5b000171d063f",
+        "name": "SSSh-95 Sfera-S (Sphere-S)",
+        "shortName": "SFERA"
+    },
+    "5aa7d03ae5b5b00016327db5": {
+        "id": "5aa7d03ae5b5b00016327db5",
+        "name": "UNTAR helmet",
+        "shortName": "UNTAR"
+    },
+    "5aa7e276e5b5b000171d0647": {
+        "id": "5aa7e276e5b5b000171d0647",
+        "name": "Altyn helmet",
+        "shortName": "Altyn"
+    },
+    "5aa2b87de5b5b00016327c25": {
+        "id": "5aa2b87de5b5b00016327c25",
+        "name": "BEAR baseball cap",
+        "shortName": "BEAR"
+    },
+    "5c08f87c0db8340019124324": {
+        "id": "5c08f87c0db8340019124324",
+        "name": "SHPM Firefighter's helmet",
+        "shortName": "SHPM"
+    },
+    "5aa2a7e8e5b5b00016327c16": {
+        "id": "5aa2a7e8e5b5b00016327c16",
+        "name": "USEC baseball cap",
+        "shortName": "USEC"
+    },
+    "5e4bfc1586f774264f7582d3": {
+        "id": "5e4bfc1586f774264f7582d3",
+        "name": "MSA Gallet TC 800 High Cut combat helmet",
+        "shortName": "TC 800"
+    },
+    "59e770f986f7742cbe3164ef": {
+        "id": "59e770f986f7742cbe3164ef",
+        "name": "Army cap",
+        "shortName": "Cap"
+    },
+    "5a154d5cfcdbcb001a3b00da": {
+        "id": "5a154d5cfcdbcb001a3b00da",
+        "name": "Ops-Core Fast MT SUPER HIGH CUT Helmet",
+        "shortName": "Fast MT"
+    },
+    "5aa2b9ede5b5b000137b758b": {
+        "id": "5aa2b9ede5b5b000137b758b",
+        "name": "Kinda cowboy hat",
+        "shortName": "CHat"
+    },
+    "5a16bb52fcdbcb001a3b00dc": {
+        "id": "5a16bb52fcdbcb001a3b00dc",
+        "name": "Wilcox Skull Lock head mount",
+        "shortName": "SLock"
+    },
+    "5b4327aa5acfc400175496e0": {
+        "id": "5b4327aa5acfc400175496e0",
+        "name": "Miltec panama hat",
+        "shortName": "Panama"
+    },
+    "5f60b34a41e30a4ab12a6947": {
+        "id": "5f60b34a41e30a4ab12a6947",
+        "name": "Galvion Caiman Ballistic Helmet",
+        "shortName": "Caiman"
+    },
+    "5a43943586f77416ad2f06e2": {
+        "id": "5a43943586f77416ad2f06e2",
+        "name": "Ded Moroz hat",
+        "shortName": "Hat"
+    },
+    "5f60c74e3b85f6263c145586": {
+        "id": "5f60c74e3b85f6263c145586",
+        "name": "Rys-T helmet",
+        "shortName": "Rys-T"
+    },
+    "5b43271c5acfc432ff4dce65": {
+        "id": "5b43271c5acfc432ff4dce65",
+        "name": "Bandana",
+        "shortName": "Bandana"
+    },
+    "572b7d8524597762b472f9d1": {
+        "id": "572b7d8524597762b472f9d1",
+        "name": "Baseball cap",
+        "shortName": "Cap"
+    },
+    "5aa2b89be5b5b0001569311f": {
+        "id": "5aa2b89be5b5b0001569311f",
+        "name": "EmerCom cap",
+        "shortName": "Emercom"
+    },
+    "5aa2ba19e5b5b00014028f4e": {
+        "id": "5aa2ba19e5b5b00014028f4e",
+        "name": "Tactical fleece hat",
+        "shortName": "Fleece"
+    },
+    "5aa7e454e5b5b0214e506fa2": {
+        "id": "5aa7e454e5b5b0214e506fa2",
+        "name": "ZSh-1-2M helmet",
+        "shortName": "ZSh-1-2M"
+    },
+    "572b7fa124597762b472f9d2": {
+        "id": "572b7fa124597762b472f9d2",
+        "name": "Beanie",
+        "shortName": "Beanie"
+    },
+    "59e7708286f7742cbd762753": {
+        "id": "59e7708286f7742cbd762753",
+        "name": "Ushanka ear-flap cap",
+        "shortName": "Ushanka"
+    },
+    "5ab8f20c86f7745cdb629fb2": {
+        "id": "5ab8f20c86f7745cdb629fb2",
+        "name": "Ski hat with holes for eyes",
+        "shortName": "Shmaska"
+    },
+    "5d5e7d28a4b936645d161203": {
+        "id": "5d5e7d28a4b936645d161203",
+        "name": "MSA ACH TC-2001 MICH Series Helmet",
+        "shortName": "TC-2001"
+    },
+    "5b40e1525acfc4771e1c6611": {
+        "id": "5b40e1525acfc4771e1c6611",
+        "name": "Highcom Striker ULACH IIIA black helmet",
+        "shortName": "ULACH"
+    },
+    "5aa7e4a4e5b5b000137b76f2": {
+        "id": "5aa7e4a4e5b5b000137b76f2",
+        "name": "ZSh-1-2M helmet (black)",
+        "shortName": "ZSh-1-2M"
+    },
+    "5a43957686f7742a2c2f11b0": {
+        "id": "5a43957686f7742a2c2f11b0",
+        "name": "Santa's hat",
+        "shortName": "Hat"
+    },
+    "5b40e2bc5acfc40016388216": {
+        "id": "5b40e2bc5acfc40016388216",
+        "name": "Highcom Striker ULACH IIIA tan helmet",
+        "shortName": "ULACH"
+    },
+    "5f99418230835532b445e954": {
+        "id": "5f99418230835532b445e954",
+        "name": "Rivals 2020 cap",
+        "shortName": "Rivals"
+    },
+    "5f60e7788adaa7100c3adb49": {
+        "id": "5f60e7788adaa7100c3adb49",
+        "name": "Blue beret",
+        "shortName": "Beret"
+    },
+    "5d6d3716a4b9361bc8618872": {
+        "id": "5d6d3716a4b9361bc8618872",
+        "name": "BNTI LSHZ-2DTM Helmet ",
+        "shortName": "LSHZ-2DTM"
+    },
+    "5f60e784f2bcbb675b00dac7": {
+        "id": "5f60e784f2bcbb675b00dac7",
+        "name": "Olive beret",
+        "shortName": "Beret"
+    },
+    "5ac8d6885acfc400180ae7b0": {
+        "id": "5ac8d6885acfc400180ae7b0",
+        "name": "Ops-Core Fast MT SUPER HIGH CUT Helmet Tan",
+        "shortName": "Fast MT Tan"
+    },
+    "5f994730c91ed922dd355de3": {
+        "id": "5f994730c91ed922dd355de3",
+        "name": "Rivals 2020 beanie",
+        "shortName": "Rivals"
+    },
+    "5d5e9c74a4b9364855191c40": {
+        "id": "5d5e9c74a4b9364855191c40",
+        "name": "MSA ACH TC-2002 MICH Series Helmet",
+        "shortName": "TC-2002"
+    },
+    "5ea05cf85ad9772e6624305d": {
+        "id": "5ea05cf85ad9772e6624305d",
+        "name": "Tac-Kek Fast MT Helmet (non-ballistic replica)",
+        "shortName": "TK Fast MT"
+    },
+    "5aa2b8d7e5b5b00014028f4a": {
+        "id": "5aa2b8d7e5b5b00014028f4a",
+        "name": "Police cap",
+        "shortName": "Police"
+    },
+    "5b40e61f5acfc4001a599bec": {
+        "id": "5b40e61f5acfc4001a599bec",
+        "name": "USEC baseball cap black",
+        "shortName": "USEC"
+    },
+    "5c0d2727d174af02a012cf58": {
+        "id": "5c0d2727d174af02a012cf58",
+        "name": "PSH-97 \"Djeta\" helmet",
+        "shortName": "Djeta"
+    },
+    "5b40e4035acfc47a87740943": {
+        "id": "5b40e4035acfc47a87740943",
+        "name": "Highcom Striker ACHHC IIIA olive helmet",
+        "shortName": "ACHHC"
+    },
+    "5ea17ca01412a1425304d1c0": {
+        "id": "5ea17ca01412a1425304d1c0",
+        "name": "Diamond Age Bastion Helmet",
+        "shortName": "Bastion"
+    },
+    "5c0e874186f7745dc7616606": {
+        "id": "5c0e874186f7745dc7616606",
+        "name": "Maska 1Sch helmet (Killa)",
+        "shortName": "Maska 1Sch"
+    },
+    "5b40e3f35acfc40016388218": {
+        "id": "5b40e3f35acfc40016388218",
+        "name": "Highcom Striker ACHHC IIIA black helmet",
+        "shortName": "ACHHC"
+    },
+    "5e00c1ad86f774747333222c": {
+        "id": "5e00c1ad86f774747333222c",
+        "name": "Team Wendy EXFIL Ballistic Helmet Black",
+        "shortName": "EXFIL"
+    },
+    "5e01ef6886f77445f643baa4": {
+        "id": "5e01ef6886f77445f643baa4",
+        "name": "Team Wendy EXFIL Ballistic Helmet Coyote",
+        "shortName": "EXFIL"
+    },
+    "5aa2b923e5b5b000137b7589": {
+        "id": "5aa2b923e5b5b000137b7589",
+        "name": "Round frame sunglasses",
+        "shortName": "RGlass"
+    },
+    "5aa2b986e5b5b00014028f4c": {
+        "id": "5aa2b986e5b5b00014028f4c",
+        "name": "Dundukk sport sunglasses",
+        "shortName": "Dundukk"
+    },
+    "5aa2b9aee5b5b00015693121": {
+        "id": "5aa2b9aee5b5b00015693121",
+        "name": "RayBench Hipster Reserve sunglasses",
+        "shortName": "RayBench"
+    },
+    "5b432be65acfc433000ed01f": {
+        "id": "5b432be65acfc433000ed01f",
+        "name": "6B34 Anti-fragmentation glasses",
+        "shortName": "6B34"
+    },
+    "5d6d2ef3a4b93618084f58bd": {
+        "id": "5d6d2ef3a4b93618084f58bd",
+        "name": "RayBench Aviator glasses",
+        "shortName": "Aviator"
+    },
+    "5d5fca1ea4b93635fd598c07": {
+        "id": "5d5fca1ea4b93635fd598c07",
+        "name": "Crossbow tactical glasses",
+        "shortName": "Crossbow"
+    },
+    "5d6d2e22a4b9361bd5780d05": {
+        "id": "5d6d2e22a4b9361bd5780d05",
+        "name": "Gascan glasses",
+        "shortName": "Gascan"
+    },
+    "5e71f70186f77429ee09f183": {
+        "id": "5e71f70186f77429ee09f183",
+        "name": "Twitch Rivals 2020 glasses",
+        "shortName": "Rivals"
+    },
+    "5c1a1cc52e221602b3136e3d": {
+        "id": "5c1a1cc52e221602b3136e3d",
+        "name": "SI M Frame safety glasses",
+        "shortName": "M Frame"
+    },
+    "5c0d32fcd174af02a1659c75": {
+        "id": "5c0d32fcd174af02a1659c75",
+        "name": "Pyramex Proximity safety glasses",
+        "shortName": "Proximity"
+    },
+    "5a16ba61fcdbcb098008728a": {
+        "id": "5a16ba61fcdbcb098008728a",
+        "name": "Ops-Core Fast GUNSIGHT Mandible",
+        "shortName": "Mandible"
+    },
+    "5e01f31d86f77465cf261343": {
+        "id": "5e01f31d86f77465cf261343",
+        "name": "TW EXFIL Ear Covers Coyote",
+        "shortName": "TW Ears"
+    },
+    "5f60b85bbdb8e27dee3dc985": {
+        "id": "5f60b85bbdb8e27dee3dc985",
+        "name": "Caiman Hybrid Ballistic Applique (black)",
+        "shortName": "Applique"
+    },
+    "5c0e66e2d174af02a96252f4": {
+        "id": "5c0e66e2d174af02a96252f4",
+        "name": "SLAAP armor Plate (Tan)",
+        "shortName": "SLAAP"
+    },
+    "5aa7e373e5b5b000137b76f0": {
+        "id": "5aa7e373e5b5b000137b76f0",
+        "name": "Altyn face shield",
+        "shortName": "FShield"
+    },
+    "5b46238386f7741a693bcf9c": {
+        "id": "5b46238386f7741a693bcf9c",
+        "name": "Kiver face shield",
+        "shortName": "Kiver FS"
+    },
+    "5e01f37686f774773c6f6c15": {
+        "id": "5e01f37686f774773c6f6c15",
+        "name": "TW EXFIL Ballistic helmet face shield (coyote)",
+        "shortName": "FShield"
+    },
+    "5a16b7e1fcdbcb00165aa6c9": {
+        "id": "5a16b7e1fcdbcb00165aa6c9",
+        "name": "Multi-hit ballistic face shield-visor for Ops-Core FAST helmet",
+        "shortName": "FShield"
+    },
+    "5ac4c50d5acfc40019262e87": {
+        "id": "5ac4c50d5acfc40019262e87",
+        "name": "K1S Visor",
+        "shortName": "Visor"
+    },
+    "5c0919b50db834001b7ce3b9": {
+        "id": "5c0919b50db834001b7ce3b9",
+        "name": "Maska 1Sch face shield",
+        "shortName": "1Sch FShield"
+    },
+    "5e00cdd986f7747473332240": {
+        "id": "5e00cdd986f7747473332240",
+        "name": "TW EXFIL Ballistic helmet face shield (black)",
+        "shortName": "FShield"
+    },
+    "5f60c076f2bcbb675b00dac2": {
+        "id": "5f60c076f2bcbb675b00dac2",
+        "name": "Caiman Ballistic Guard Mandible",
+        "shortName": "Mandible"
+    },
+    "5c1793902e221602b21d3de2": {
+        "id": "5c1793902e221602b21d3de2",
+        "name": "Crye Airframe Ears",
+        "shortName": "CP Ears"
+    },
+    "5ca2113f86f7740b2547e1d2": {
+        "id": "5ca2113f86f7740b2547e1d2",
+        "name": "Vulkan-5 face shield",
+        "shortName": "FShield"
+    },
+    "5a16b672fcdbcb001912fa83": {
+        "id": "5a16b672fcdbcb001912fa83",
+        "name": "Ops-Core FAST Visor",
+        "shortName": "FVisor"
+    },
+    "5f60bf4558eff926626a60f2": {
+        "id": "5f60bf4558eff926626a60f2",
+        "name": "Caiman Fixed Arm Visor",
+        "shortName": "FAV"
+    },
+    "5d6d3829a4b9361bc8618943": {
+        "id": "5d6d3829a4b9361bc8618943",
+        "name": "LSHZ-2DTM face shield",
+        "shortName": "FShield"
+    },
+    "5f60c85b58eff926626a60f7": {
+        "id": "5f60c85b58eff926626a60f7",
+        "name": "Rys-T face shield",
+        "shortName": "FShield"
+    },
+    "5ea058e01dbce517f324b3e2": {
+        "id": "5ea058e01dbce517f324b3e2",
+        "name": "Tac-Kek Heavy Trooper mask",
+        "shortName": "Heavy Trooper"
+    },
+    "5d6d3943a4b9360dbc46d0cc": {
+        "id": "5d6d3943a4b9360dbc46d0cc",
+        "name": "LSHZ-2DTM Cover",
+        "shortName": "Cover"
+    },
+    "5d6d3be5a4b9361bc73bc763": {
+        "id": "5d6d3be5a4b9361bc73bc763",
+        "name": "LSHZ-2DTM Aventail",
+        "shortName": "Aventail"
+    },
+    "5a16badafcdbcb001865f72d": {
+        "id": "5a16badafcdbcb001865f72d",
+        "name": "Ops-Core Fast  Side Armor",
+        "shortName": "SArmor"
+    },
+    "5448e54d4bdc2dcc718b4568": {
+        "id": "5448e54d4bdc2dcc718b4568",
+        "name": "Armor",
+        "shortName": "Item"
+    },
+    "5a341c4686f77469e155819e": {
+        "id": "5a341c4686f77469e155819e"
+    },
+    "5a341c4086f77401f2541505": {
+        "id": "5a341c4086f77401f2541505"
+    },
+    "5ea18c84ecf1982c7712d9a2": {
+        "id": "5ea18c84ecf1982c7712d9a2",
+        "name": "Additional armor for the Bastion helmet",
+        "shortName": "Bastion"
+    },
+    "5e00cfa786f77469dc6e5685": {
+        "id": "5e00cfa786f77469dc6e5685",
+        "name": "TW EXFIL Ear Covers Black",
+        "shortName": "TW Ears"
+    },
+    "5c178a942e22164bef5ceca3": {
+        "id": "5c178a942e22164bef5ceca3",
+        "name": "Crye Airframe Chops",
+        "shortName": "Chops"
+    },
+    "5448e5724bdc2ddf718b4568": {
+        "id": "5448e5724bdc2ddf718b4568",
+        "name": "Vis. observ. device",
+        "shortName": "Item"
+    },
+    "5aa7e3abe5b5b000171d064d": {
+        "id": "5aa7e3abe5b5b000171d064d",
+        "name": "ZSh-1-2M face shield",
+        "shortName": "FShield"
+    },
+    "5c0e842486f77443a74d2976": {
+        "id": "5c0e842486f77443a74d2976",
+        "name": "Maska 1Sch face shield (Killa)",
+        "shortName": "1Sch FShield"
+    },
+    "5aa2ba71e5b5b000137b758f": {
+        "id": "5aa2ba71e5b5b000137b758f",
+        "name": "MSA Sordin Supreme PRO-X/L active headphones",
+        "shortName": "Sordin"
+    },
+    "5a16b9fffcdbcb0176308b34": {
+        "id": "5a16b9fffcdbcb0176308b34",
+        "name": "Ops-Core FAST RAC Headset",
+        "shortName": "RAC"
+    },
+    "5b432b965acfc47a8774094e": {
+        "id": "5b432b965acfc47a8774094e",
+        "name": "GSSh-01 active headset",
+        "shortName": "GSSh-01"
+    },
+    "5c165d832e2216398b5a7e36": {
+        "id": "5c165d832e2216398b5a7e36",
+        "name": "Peltor Tactical Sport headset",
+        "shortName": "Tactical Sport"
+    },
+    "5e4d34ca86f774264f758330": {
+        "id": "5e4d34ca86f774264f758330",
+        "name": "Walker's Razor Digital headset",
+        "shortName": "Razor"
+    },
+    "5f60cd6cf2bcbb675b00dac6": {
+        "id": "5f60cd6cf2bcbb675b00dac6",
+        "name": " Walker's XCEL 500BT Digital headset",
+        "shortName": "XCEL"
+    },
+    "5645bcc04bdc2d363b8b4572": {
+        "id": "5645bcc04bdc2d363b8b4572",
+        "name": "Peltor ComTac 2 headset",
+        "shortName": "ComTac2"
+    },
+    "5b3f15d486f77432d0509248": {
+        "id": "5b3f15d486f77432d0509248"
+    },
+    "5645bcb74bdc2ded0b8b4578": {
+        "id": "5645bcb74bdc2ded0b8b4578",
+        "name": "Headphones",
+        "shortName": "Item"
+    },
+    "57bef4c42459772e8d35a53b": {
+        "id": "57bef4c42459772e8d35a53b",
+        "name": "Armored equipment",
+        "shortName": "Item"
+    },
+    "566168634bdc2d144c8b456c": {
+        "id": "566168634bdc2d144c8b456c",
+        "name": "Searchable item",
+        "shortName": "Item"
+    },
+    "5795f317245977243854e041": {
+        "id": "5795f317245977243854e041",
+        "name": "Common container",
+        "shortName": "Item"
+    },
+    "5448fe124bdc2da5018b4567": {
+        "id": "5448fe124bdc2da5018b4567",
+        "name": "Weapon mod",
+        "shortName": "Item"
+    },
+    "5671435f4bdc2d96058b4569": {
+        "id": "5671435f4bdc2d96058b4569",
+        "name": "Locking container",
+        "shortName": "Item"
+    },
+    "567583764bdc2d98058b456e": {
+        "id": "567583764bdc2d98058b456e",
+        "name": "Stationary cont.",
+        "shortName": "Item"
+    },
+    "55d720f24bdc2d88028b456d": {
+        "id": "55d720f24bdc2d88028b456d",
+        "name": "Inventory",
+        "shortName": "Item"
+    },
+    "566abbb64bdc2d144c8b457d": {
+        "id": "566abbb64bdc2d144c8b457d",
+        "name": "Stash",
+        "shortName": "Item"
+    },
+    "543be5f84bdc2dd4348b456a": {
+        "id": "543be5f84bdc2dd4348b456a",
+        "name": "Equipment",
+        "shortName": "Item"
+    },
+    "5422acb9af1c889c16000029": {
+        "id": "5422acb9af1c889c16000029",
+        "name": "Weapon",
+        "shortName": "Item"
+    },
+    "5751496424597720a27126da": {
+        "id": "5751496424597720a27126da",
+        "name": "Hot Rod",
+        "shortName": "Hot Rod"
+    },
+    "5d1b376e86f774252519444e": {
+        "id": "5d1b376e86f774252519444e",
+        "name": "\"Fierce Hatchling\" moonshine",
+        "shortName": "Moonshine"
+    },
+    "5d40407c86f774318526545a": {
+        "id": "5d40407c86f774318526545a",
+        "name": "Bottle of vodka Tarkovskaya",
+        "shortName": "Vodka"
+    },
+    "5c0fa877d174af02a012e1cf": {
+        "id": "5c0fa877d174af02a012e1cf",
+        "name": "Water bottle with a filter Aquamari",
+        "shortName": "Aquamari"
+    },
+    "575062b524597720a31c09a1": {
+        "id": "575062b524597720a31c09a1",
+        "name": "Green Ice",
+        "shortName": "Green Tea"
+    },
+    "57513f07245977207e26a311": {
+        "id": "57513f07245977207e26a311",
+        "name": "Apple juice",
+        "shortName": "Apl.jc."
+    },
+    "57513f9324597720a7128161": {
+        "id": "57513f9324597720a7128161",
+        "name": "Grand juice",
+        "shortName": "Pom.juice"
+    },
+    "57513fcc24597720a31c09a6": {
+        "id": "57513fcc24597720a31c09a6",
+        "name": "Vita juice",
+        "shortName": "Vita juice"
+    },
+    "5751435d24597720a27126d1": {
+        "id": "5751435d24597720a27126d1",
+        "name": "Max energy",
+        "shortName": "NRG Drink"
+    },
+    "575146b724597720a27126d5": {
+        "id": "575146b724597720a27126d5",
+        "name": "Pack of milk",
+        "shortName": "Milk"
+    },
+    "57514643245977207f2c2d09": {
+        "id": "57514643245977207f2c2d09",
+        "name": "TarCola",
+        "shortName": "TarCola"
+    },
+    "5e8f3423fd7471236e6e3b64": {
+        "id": "5e8f3423fd7471236e6e3b64",
+        "name": "Premium Kvass \"Norvinskiy Yadreniy\" 0.6L bottle",
+        "shortName": "Kvass"
+    },
+    "5d403f9186f7743cac3f229b": {
+        "id": "5d403f9186f7743cac3f229b",
+        "name": "Bottle of Dan Jackiel Whiskey",
+        "shortName": "Whiskey"
+    },
+    "5d1b33a686f7742523398398": {
+        "id": "5d1b33a686f7742523398398",
+        "name": "Purified water",
+        "shortName": "Superwater"
+    },
+    "544fb62a4bdc2dfb738b4568": {
+        "id": "544fb62a4bdc2dfb738b4568",
+        "name": "Russian Army pineapple juice",
+        "shortName": "Pineapp.Jc."
+    },
+    "5448fee04bdc2dbc018b4567": {
+        "id": "5448fee04bdc2dbc018b4567",
+        "name": "0.6L water bottle",
+        "shortName": "Water"
+    },
+    "5bc9c29cd4351e003562b8a3": {
+        "id": "5bc9c29cd4351e003562b8a3",
+        "name": "Can of sprats",
+        "shortName": "Sprats"
+    },
+    "5734773724597737fd047c14": {
+        "id": "5734773724597737fd047c14",
+        "name": "Condensed milk",
+        "shortName": "Cond. milk"
+    },
+    "5751487e245977207e26a315": {
+        "id": "5751487e245977207e26a315",
+        "name": "Emelya rye croutons",
+        "shortName": "Emelya"
+    },
+    "5bc9b156d4351e00367fbce9": {
+        "id": "5bc9b156d4351e00367fbce9",
+        "name": "Jar of DevilDog mayo",
+        "shortName": "Mayo"
+    },
+    "57347d7224597744596b4e72": {
+        "id": "57347d7224597744596b4e72",
+        "name": "Can of beef stew",
+        "shortName": "Tushonka"
+    },
+    "57347d9c245977448b40fa85": {
+        "id": "57347d9c245977448b40fa85",
+        "name": "Can of herring",
+        "shortName": "Herring"
+    },
+    "57347d90245977448f7b7f65": {
+        "id": "57347d90245977448f7b7f65",
+        "name": "Pack of oat flakes",
+        "shortName": "Oatflakes"
+    },
+    "57347da92459774491567cf5": {
+        "id": "57347da92459774491567cf5",
+        "name": "Can of delicious beef stew",
+        "shortName": "Tushonka"
+    },
+    "544fb6cc4bdc2d34748b456e": {
+        "id": "544fb6cc4bdc2d34748b456e",
+        "name": "Slickers bar",
+        "shortName": "Slickers"
+    },
+    "57347d5f245977448b40fa81": {
+        "id": "57347d5f245977448b40fa81",
+        "name": "Humpback salmon",
+        "shortName": "Humpback"
+    },
+    "590c5f0d86f77413997acfab": {
+        "id": "590c5f0d86f77413997acfab",
+        "name": "MRE lunch box",
+        "shortName": "MRE"
+    },
+    "57505f6224597709a92585a9": {
+        "id": "57505f6224597709a92585a9",
+        "name": "Alyonka chocolate bar",
+        "shortName": "Alyonka"
+    },
+    "57347d8724597744596b4e76": {
+        "id": "57347d8724597744596b4e76",
+        "name": "Squash spread",
+        "shortName": "Squash"
+    },
+    "59e3577886f774176a362503": {
+        "id": "59e3577886f774176a362503",
+        "name": "Pack of sugar",
+        "shortName": "Sugar"
+    },
+    "57347d692459774491567cf1": {
+        "id": "57347d692459774491567cf1",
+        "name": "Can of green peas",
+        "shortName": "Peas"
+    },
+    "5673de654bdc2d180f8b456d": {
+        "id": "5673de654bdc2d180f8b456d",
+        "name": "Can of pacific saury",
+        "shortName": "Saury"
+    },
+    "5448ff904bdc2d6f028b456e": {
+        "id": "5448ff904bdc2d6f028b456e",
+        "name": "Army Crackers",
+        "shortName": "Crackers"
+    },
+    "57347d3d245977448f7b7f61": {
+        "id": "57347d3d245977448f7b7f61",
+        "name": "Rye croutons",
+        "shortName": "Croutons"
+    },
+    "590c5d4b86f774784e1b9c45": {
+        "id": "590c5d4b86f774784e1b9c45",
+        "name": "Iskra lunch box",
+        "shortName": "Lunchbox"
+    },
+    "5448e8d64bdc2dce718b4568": {
+        "id": "5448e8d64bdc2dce718b4568",
+        "name": "Drink",
+        "shortName": "Item"
+    },
+    "5448e8d04bdc2ddf718b4569": {
+        "id": "5448e8d04bdc2ddf718b4569",
+        "name": "Food",
+        "shortName": "Item"
+    },
+    "5a29357286f77409c705e025": {
+        "id": "5a29357286f77409c705e025",
+        "name": "Sliderkey Flash drive",
+        "shortName": "Flash drive"
+    },
+    "590c62a386f77412b0130255": {
+        "id": "590c62a386f77412b0130255",
+        "name": "Sliderkey Secure Flash drive",
+        "shortName": "Sliderkey"
+    },
+    "5939e9b286f77462a709572c": {
+        "id": "5939e9b286f77462a709572c",
+        "name": "Sealed letter",
+        "shortName": "Letter"
+    },
+    "591092ef86f7747bb8703422": {
+        "id": "591092ef86f7747bb8703422",
+        "name": "Secure case for documents n.0022",
+        "shortName": "Docs"
+    },
+    "591093bb86f7747caa7bb2ee": {
+        "id": "591093bb86f7747caa7bb2ee",
+        "name": "Sealed letter",
+        "shortName": "Letter"
+    },
+    "5939e5a786f77461f11c0098": {
+        "id": "5939e5a786f77461f11c0098",
+        "name": "Secure case for documents 0013",
+        "shortName": "Docs 0013"
+    },
+    "5c12301c86f77419522ba7e4": {
+        "id": "5c12301c86f77419522ba7e4",
+        "name": "False flash drive",
+        "shortName": "False FD"
+    },
+    "5a294d8486f774068638cd93": {
+        "id": "5a294d8486f774068638cd93",
+        "name": "SAS disk with drones",
+        "shortName": "SAS disk"
+    },
+    "5ac620eb86f7743a8e6e0da0": {
+        "id": "5ac620eb86f7743a8e6e0da0",
+        "name": "Package with graphics cards",
+        "shortName": "Package"
+    },
+    "5ae9a1b886f77404c8537c62": {
+        "id": "5ae9a1b886f77404c8537c62",
+        "name": "IDEA cargo manifests",
+        "shortName": "Manifests"
+    },
+    "5ae9a18586f7746e381e16a3": {
+        "id": "5ae9a18586f7746e381e16a3",
+        "name": "OLI cargo manifests",
+        "shortName": "Manifests"
+    },
+    "5ae9a3f586f7740aab00e4e6": {
+        "id": "5ae9a3f586f7740aab00e4e6",
+        "name": "Clothes design handbook Part 1",
+        "shortName": "Book p.1"
+    },
+    "5ae9a0dd86f7742e5f454a05": {
+        "id": "5ae9a0dd86f7742e5f454a05",
+        "name": "Goshan cargo manifests",
+        "shortName": "Manifests"
+    },
+    "5a294d7c86f7740651337cf9": {
+        "id": "5a294d7c86f7740651337cf9",
+        "name": "SAS disk with drones",
+        "shortName": "SAS disk "
+    },
+    "5a6860d886f77411cd3a9e47": {
+        "id": "5a6860d886f77411cd3a9e47",
+        "name": "Secure case for documents 0060",
+        "shortName": "Docs 0060"
+    },
+    "593965cf86f774087a77e1b6": {
+        "id": "593965cf86f774087a77e1b6",
+        "name": "Secure case for documents 0048",
+        "shortName": "Docs 0048"
+    },
+    "5d357d6b86f7745b606e3508": {
+        "id": "5d357d6b86f7745b606e3508",
+        "name": "photo album",
+        "shortName": "photo album"
+    },
+    "5ae9a4fc86f7746e381e1753": {
+        "id": "5ae9a4fc86f7746e381e1753",
+        "name": "Clothes design handbook Part 2",
+        "shortName": "Book p.2"
+    },
+    "5ae9a25386f7746dd946e6d9": {
+        "id": "5ae9a25386f7746dd946e6d9",
+        "name": "OLI cargo route documents",
+        "shortName": "Cargo route"
+    },
+    "5d3ec50586f774183a607442": {
+        "id": "5d3ec50586f774183a607442",
+        "name": "Encrypted message",
+        "shortName": "Encr. pack"
+    },
+    "5938878586f7741b797c562f": {
+        "id": "5938878586f7741b797c562f",
+        "name": "Secure case for documents 0052",
+        "shortName": "Docs 0052"
+    },
+    "5938188786f77474f723e87f": {
+        "id": "5938188786f77474f723e87f",
+        "name": "Secure case for documents 0031",
+        "shortName": "Docs 0031"
+    },
+    "5eff135be0d3331e9d282b7b": {
+        "id": "5eff135be0d3331e9d282b7b",
+        "name": "Marked with tape flash drive",
+        "shortName": "Flsh drv."
+    },
+    "5efdaf6de6a30218ed211a48": {
+        "id": "5efdaf6de6a30218ed211a48",
+        "name": "Marked Ophthalmoscope",
+        "shortName": "Ophthalmoscope"
+    },
+    "5efdafc1e70b5e33f86de058": {
+        "id": "5efdafc1e70b5e33f86de058",
+        "name": "Marked with a blue symbol surgical set",
+        "shortName": "Surgical set"
+    },
+    "590c621186f774138d11ea29": {
+        "id": "590c621186f774138d11ea29",
+        "name": "Secure Flash drive",
+        "shortName": "Flash drive"
+    },
+    "5c12613b86f7743bbe2c3f76": {
+        "id": "5c12613b86f7743bbe2c3f76",
+        "name": "Folder with intelligence",
+        "shortName": "Intelligence"
+    },
+    "590c639286f774151567fa95": {
+        "id": "590c639286f774151567fa95",
+        "name": "Technical documentation",
+        "shortName": "Manual"
+    },
+    "590c645c86f77412b01304d9": {
+        "id": "590c645c86f77412b01304d9",
+        "name": "Diary",
+        "shortName": "Diary"
+    },
+    "590c651286f7741e566b6461": {
+        "id": "590c651286f7741e566b6461",
+        "name": "Slim diary",
+        "shortName": "Diary"
+    },
+    "590c392f86f77444754deb29": {
+        "id": "590c392f86f77444754deb29",
+        "name": "SSD drive",
+        "shortName": "SSD"
+    },
+    "590c37d286f77443be3d7827": {
+        "id": "590c37d286f77443be3d7827",
+        "name": "SAS drive",
+        "shortName": "SAS"
+    },
+    "5c1d0c5f86f7744bb2683cf0": {
+        "id": "5c1d0c5f86f7744bb2683cf0",
+        "name": "Lab. Blue keycard",
+        "shortName": "Blue"
+    },
+    "5c1d0d6d86f7744bb2683e1f": {
+        "id": "5c1d0d6d86f7744bb2683e1f",
+        "name": "Lab. Yellow keycard. ",
+        "shortName": "Yellow"
+    },
+    "5c1d0dc586f7744baf2e7b79": {
+        "id": "5c1d0dc586f7744baf2e7b79",
+        "name": "Lab. Green keycard ",
+        "shortName": "Green"
+    },
+    "5c1d0efb86f7744baf2e7b7b": {
+        "id": "5c1d0efb86f7744baf2e7b7b",
+        "name": "Lab. Red keycard",
+        "shortName": "Red"
+    },
+    "5c1e495a86f7743109743dfb": {
+        "id": "5c1e495a86f7743109743dfb",
+        "name": "Lab. Violet keycard",
+        "shortName": "Violet"
+    },
+    "5e42c81886f7742a01529f57": {
+        "id": "5e42c81886f7742a01529f57",
+        "name": "Object #11SR keycard",
+        "shortName": "#11SR"
+    },
+    "5e42c83786f7742a021fdf3c": {
+        "id": "5e42c83786f7742a021fdf3c",
+        "name": "Object #21WS keycard",
+        "shortName": "#21WS"
+    },
+    "5c94bbff86f7747ee735c08f": {
+        "id": "5c94bbff86f7747ee735c08f",
+        "name": "TerraGroup Labs access keycard",
+        "shortName": "Keycard"
+    },
+    "5c1d0f4986f7744bb01837fa": {
+        "id": "5c1d0f4986f7744bb01837fa",
+        "name": "Lab. Black keycard",
+        "shortName": "Black"
+    },
+    "5efde6b4f5448336730dbd61": {
+        "id": "5efde6b4f5448336730dbd61",
+        "name": "Key card with a blue marking",
+        "shortName": "Key card"
+    },
+    "5ad5ccd186f774446d5706e9": {
+        "id": "5ad5ccd186f774446d5706e9",
+        "name": "Key to OLI administrator office",
+        "shortName": "OLI Office"
+    },
+    "5ad5cfbd86f7742c825d6104": {
+        "id": "5ad5cfbd86f7742c825d6104",
+        "name": "Key to OLI logistics department office",
+        "shortName": "Log. Office"
+    },
+    "5ad5db3786f7743568421cce": {
+        "id": "5ad5db3786f7743568421cce",
+        "name": "Key to EMERCOM medical unit",
+        "shortName": "MES"
+    },
+    "5ad5d20586f77449be26d877": {
+        "id": "5ad5d20586f77449be26d877",
+        "name": "Key to utility room of OLI outlet",
+        "shortName": "OLI Ut."
+    },
+    "5ad7217186f7746744498875": {
+        "id": "5ad7217186f7746744498875",
+        "name": "Key to OLI cash register",
+        "shortName": "OLI"
+    },
+    "5addaffe86f77470b455f900": {
+        "id": "5addaffe86f77470b455f900",
+        "name": "Key to KIBA Outlet grate door",
+        "shortName": "KIBA 2"
+    },
+    "57a349b2245977762b199ec7": {
+        "id": "57a349b2245977762b199ec7",
+        "name": "Door key",
+        "shortName": "Key"
+    },
+    "5ad5d7d286f77450166e0a89": {
+        "id": "5ad5d7d286f77450166e0a89",
+        "name": "Key to KIBA store outlet",
+        "shortName": "KIBA"
+    },
+    "5d08d21286f774736e7c94c3": {
+        "id": "5d08d21286f774736e7c94c3",
+        "name": "Shturman key",
+        "shortName": "KSH"
+    },
+    "5ad5d64486f774079b080af8": {
+        "id": "5ad5d64486f774079b080af8",
+        "name": "Key to pharmacy",
+        "shortName": "Pharmacy"
+    },
+    "5ad7247386f7747487619dc3": {
+        "id": "5ad7247386f7747487619dc3",
+        "name": "Key to Goshan cash register",
+        "shortName": "Goshan"
+    },
+    "5ad7242b86f7740a6a3abd43": {
+        "id": "5ad7242b86f7740a6a3abd43",
+        "name": "Key to IDEA cash register",
+        "shortName": "IDEA "
+    },
+    "5ad5d49886f77455f9731921": {
+        "id": "5ad5d49886f77455f9731921",
+        "name": "Key to utility room of power substation",
+        "shortName": "Pow. Ut."
+    },
+    "5a0448bc86f774736f14efa8": {
+        "id": "5a0448bc86f774736f14efa8",
+        "name": "The key to the closed premises of the sanatorium",
+        "shortName": "Sanatorium"
+    },
+    "593962ca86f774068014d9af": {
+        "id": "593962ca86f774068014d9af",
+        "name": "Unknown key",
+        "shortName": "Unk. key"
+    },
+    "5448ba0b4bdc2d02308b456c": {
+        "id": "5448ba0b4bdc2d02308b456c",
+        "name": "Factory exit key",
+        "shortName": "Factory"
+    },
+    "5c1f79a086f7746ed066fb8f": {
+        "id": "5c1f79a086f7746ed066fb8f",
+        "name": "Lab. key. Arsenal storage room",
+        "shortName": "Lk.ASR"
+    },
+    "591afe0186f77431bd616a11": {
+        "id": "591afe0186f77431bd616a11",
+        "name": "Key ZB-014",
+        "shortName": "ZB-014"
+    },
+    "5c1e2a1e86f77431ea0ea84c": {
+        "id": "5c1e2a1e86f77431ea0ea84c",
+        "name": "Lab. key. Manager office",
+        "shortName": "Lk.MO"
+    },
+    "5c1e2d1f86f77431e9280bee": {
+        "id": "5c1e2d1f86f77431e9280bee",
+        "name": "Lab. key. Testing area (weap.)",
+        "shortName": "Lk.TA(w)"
+    },
+    "59148f8286f7741b951ea113": {
+        "id": "59148f8286f7741b951ea113",
+        "name": "Weapon safe key",
+        "shortName": "Safe"
+    },
+    "5913915886f774123603c392": {
+        "id": "5913915886f774123603c392",
+        "name": "Military base checkpoint key",
+        "shortName": "Checkpoint"
+    },
+    "591383f186f7744a4c5edcf3": {
+        "id": "591383f186f7744a4c5edcf3",
+        "name": "Dorm room 104 Key",
+        "shortName": "104 Key"
+    },
+    "593858c486f774253a24cb52": {
+        "id": "593858c486f774253a24cb52",
+        "name": "Door key",
+        "shortName": "Key"
+    },
+    "59136e1e86f774432f15d133": {
+        "id": "59136e1e86f774432f15d133",
+        "name": "Dorm room 110 Key",
+        "shortName": "110 Key"
+    },
+    "591382d986f774465a6413a7": {
+        "id": "591382d986f774465a6413a7",
+        "name": "Dorm room 105 Key",
+        "shortName": "105 Key"
+    },
+    "59387a4986f77401cc236e62": {
+        "id": "59387a4986f77401cc236e62",
+        "name": "Dorm room 114 Key",
+        "shortName": "114 Key"
+    },
+    "59136f6f86f774447a1ed173": {
+        "id": "59136f6f86f774447a1ed173",
+        "name": "Car key",
+        "shortName": "Key"
+    },
+    "591ae8f986f77406f854be45": {
+        "id": "591ae8f986f77406f854be45",
+        "name": "Yotota car key",
+        "shortName": "Yotota"
+    },
+    "5938603e86f77435642354f4": {
+        "id": "5938603e86f77435642354f4",
+        "name": "Dorm room 206 Key",
+        "shortName": "206 Key"
+    },
+    "5937ee6486f77408994ba448": {
+        "id": "5937ee6486f77408994ba448",
+        "name": "Machinery key",
+        "shortName": "Key"
+    },
+    "5780d07a2459777de4559324": {
+        "id": "5780d07a2459777de4559324",
+        "name": "Portable cabin key",
+        "shortName": "Cabin key"
+    },
+    "5913877a86f774432f15d444": {
+        "id": "5913877a86f774432f15d444",
+        "name": "The key to the gas station storage room",
+        "shortName": "Storage"
+    },
+    "5672c92d4bdc2d180f8b4567": {
+        "id": "5672c92d4bdc2d180f8b4567",
+        "name": "Dorm room 118 Key",
+        "shortName": "Room 118 Key"
+    },
+    "5938144586f77473c2087145": {
+        "id": "5938144586f77473c2087145",
+        "name": "Portable cabin key of customs Factory zone",
+        "shortName": "Key"
+    },
+    "5780d0652459777df90dcb74": {
+        "id": "5780d0652459777df90dcb74",
+        "name": "Cabinet key",
+        "shortName": "Gas station"
+    },
+    "5a0eb6ac86f7743124037a28": {
+        "id": "5a0eb6ac86f7743124037a28",
+        "name": "Cottage back entrance key",
+        "shortName": "Cottage"
+    },
+    "5780cf942459777df90dcb72": {
+        "id": "5780cf942459777df90dcb72",
+        "name": "Dorm room 214 Key",
+        "shortName": "Room 214 Key"
+    },
+    "5780cfa52459777dfb276eb1": {
+        "id": "5780cfa52459777dfb276eb1",
+        "name": "Dorm room 220 Key",
+        "shortName": "Room 220 Key"
+    },
+    "5780cf7f2459777de4559322": {
+        "id": "5780cf7f2459777de4559322",
+        "name": "Marked key",
+        "shortName": "Mark.Key"
+    },
+    "593aa4be86f77457f56379f8": {
+        "id": "593aa4be86f77457f56379f8",
+        "name": "Dorm room 303 Key",
+        "shortName": "303 Key"
+    },
+    "5780cf9e2459777df90dcb73": {
+        "id": "5780cf9e2459777df90dcb73",
+        "name": "Dorm room 218 Key",
+        "shortName": "Room 218 Key"
+    },
+    "5938504186f7740991483f30": {
+        "id": "5938504186f7740991483f30",
+        "name": "Dorm room 203 Key",
+        "shortName": "Room 203 Key"
+    },
+    "5780cda02459777b272ede61": {
+        "id": "5780cda02459777b272ede61",
+        "name": "Dorm room 306 Key",
+        "shortName": "306 Key"
+    },
+    "5780cf722459777a5108b9a1": {
+        "id": "5780cf722459777a5108b9a1",
+        "name": "Dorm room 308 Key",
+        "shortName": "308 Key"
+    },
+    "5780cf692459777de4559321": {
+        "id": "5780cf692459777de4559321",
+        "name": "Dorm room 315 Key",
+        "shortName": "315 Key"
+    },
+    "5a144bdb86f7741d374bbde0": {
+        "id": "5a144bdb86f7741d374bbde0",
+        "name": "East wing room 205 key",
+        "shortName": "San.205 "
+    },
+    "5a0ea69f86f7741cd5406619": {
+        "id": "5a0ea69f86f7741cd5406619",
+        "name": "Office 108 East wing key",
+        "shortName": "San.108"
+    },
+    "5a0ea64786f7741707720468": {
+        "id": "5a0ea64786f7741707720468",
+        "name": "Office 107 East wing key",
+        "shortName": "San.107"
+    },
+    "5a0dc95c86f77452440fc675": {
+        "id": "5a0dc95c86f77452440fc675",
+        "name": "Office 112 West wing key",
+        "shortName": "San. 112"
+    },
+    "5a0dc45586f7742f6b0b73e3": {
+        "id": "5a0dc45586f7742f6b0b73e3",
+        "name": "Office 104 West wing key",
+        "shortName": "San.104"
+    },
+    "5a0ee72c86f77436955d3435": {
+        "id": "5a0ee72c86f77436955d3435",
+        "name": "East wing room 213 key",
+        "shortName": "San.213"
+    },
+    "5a0ee62286f774369454a7ac": {
+        "id": "5a0ee62286f774369454a7ac",
+        "name": "East wing room 209 key",
+        "shortName": "San.209 "
+    },
+    "5780d0532459777a5108b9a2": {
+        "id": "5780d0532459777a5108b9a2",
+        "name": "Customs office key",
+        "shortName": "Customs key"
+    },
+    "5a144dfd86f77445cb5a0982": {
+        "id": "5a144dfd86f77445cb5a0982",
+        "name": "West wing room 203 key",
+        "shortName": "San.203 "
+    },
+    "5a0ec6d286f7742c0b518fb5": {
+        "id": "5a0ec6d286f7742c0b518fb5",
+        "name": "West wing room 205 key",
+        "shortName": "San.205"
+    },
+    "5a13ef0686f7746e5a411744": {
+        "id": "5a13ef0686f7746e5a411744",
+        "name": "West wing room 219 key",
+        "shortName": "San.219  "
+    },
+    "5a0ee76686f7743698200d5c": {
+        "id": "5a0ee76686f7743698200d5c",
+        "name": "East wing room 216 key",
+        "shortName": "San.216"
+    },
+    "5a0ec70e86f7742c0b518fba": {
+        "id": "5a0ec70e86f7742c0b518fba",
+        "name": "West wing room 207 key",
+        "shortName": "San.207"
+    },
+    "5a0ee4b586f7743698200d22": {
+        "id": "5a0ee4b586f7743698200d22",
+        "name": "East wing room 206 key",
+        "shortName": "San.206 "
+    },
+    "5a0ee34586f774023b6ee092": {
+        "id": "5a0ee34586f774023b6ee092",
+        "name": "West wing room 220 key",
+        "shortName": "San.220"
+    },
+    "5a0ee30786f774023b6ee08f": {
+        "id": "5a0ee30786f774023b6ee08f",
+        "name": "West wing room 216 key",
+        "shortName": "San.216"
+    },
+    "5a1452ee86f7746f33111763": {
+        "id": "5a1452ee86f7746f33111763",
+        "name": "West wing room 222 key",
+        "shortName": "San.222 "
+    },
+    "5a13f24186f77410e57c5626": {
+        "id": "5a13f24186f77410e57c5626",
+        "name": "East wing room 222 key",
+        "shortName": "San.222 "
+    },
+    "5a0ee37f86f774023657a86f": {
+        "id": "5a0ee37f86f774023657a86f",
+        "name": "West wing room 221 key",
+        "shortName": "San.221"
+    },
+    "5a0eeb1a86f774688b70aa5c": {
+        "id": "5a0eeb1a86f774688b70aa5c",
+        "name": "West wing room 303 key",
+        "shortName": "San.303  "
+    },
+    "5a13ef7e86f7741290491063": {
+        "id": "5a13ef7e86f7741290491063",
+        "name": "West wing room 301 key",
+        "shortName": "San.301 "
+    },
+    "5a13eebd86f7746fd639aa93": {
+        "id": "5a13eebd86f7746fd639aa93",
+        "name": "West wing room 218 key",
+        "shortName": "San.218 "
+    },
+    "5a13f35286f77413ef1436b0": {
+        "id": "5a13f35286f77413ef1436b0",
+        "name": "East wing room 226 key",
+        "shortName": "San.226 "
+    },
+    "5a145d4786f7744cbb6f4a12": {
+        "id": "5a145d4786f7744cbb6f4a12",
+        "name": "East wing room 306 key",
+        "shortName": "San.306 "
+    },
+    "5a145d7b86f7744cbb6f4a13": {
+        "id": "5a145d7b86f7744cbb6f4a13",
+        "name": "East wing room 308 key",
+        "shortName": "San.308 "
+    },
+    "5a13f46386f7741dd7384b04": {
+        "id": "5a13f46386f7741dd7384b04",
+        "name": "West wing room 306 key",
+        "shortName": "San.306 "
+    },
+    "5a0eb38b86f774153b320eb0": {
+        "id": "5a0eb38b86f774153b320eb0",
+        "name": "SMW car key",
+        "shortName": "SMW"
+    },
+    "5a0eec9686f77402ac5c39f2": {
+        "id": "5a0eec9686f77402ac5c39f2",
+        "name": "East wing room 310 key",
+        "shortName": "San.310 "
+    },
+    "5a0eecf686f7740350630097": {
+        "id": "5a0eecf686f7740350630097",
+        "name": "East wing room 313 key",
+        "shortName": "San. 313 "
+    },
+    "5a13ee1986f774794d4c14cd": {
+        "id": "5a13ee1986f774794d4c14cd",
+        "name": "West wing room 323 key",
+        "shortName": "San.323"
+    },
+    "5a0eed4386f77405112912aa": {
+        "id": "5a0eed4386f77405112912aa",
+        "name": "East wing room 314 key",
+        "shortName": "San.314"
+    },
+    "5a0eeb8e86f77461257ed71a": {
+        "id": "5a0eeb8e86f77461257ed71a",
+        "name": "West wing room 309 key",
+        "shortName": "San.309 "
+    },
+    "5a145ebb86f77458f1796f05": {
+        "id": "5a145ebb86f77458f1796f05",
+        "name": "East wing room 316 key",
+        "shortName": "San.316 "
+    },
+    "5a0eedb386f77403506300be": {
+        "id": "5a0eedb386f77403506300be",
+        "name": "East wing room 322 key",
+        "shortName": "San.322 "
+    },
+    "5a0eebed86f77461230ddb3d": {
+        "id": "5a0eebed86f77461230ddb3d",
+        "name": "West wing room 325 key",
+        "shortName": "San.325 "
+    },
+    "5a0f045e86f7745b0f0d0e42": {
+        "id": "5a0f045e86f7745b0f0d0e42",
+        "name": "Gas station safe key",
+        "shortName": "Safe "
+    },
+    "5a0ea79b86f7741d4a35298e": {
+        "id": "5a0ea79b86f7741d4a35298e",
+        "name": "Health resort utility room key",
+        "shortName": "Storeroom"
+    },
+    "5a0f0f5886f7741c4e32a472": {
+        "id": "5a0f0f5886f7741c4e32a472",
+        "name": "Health resort warehouse safe key",
+        "shortName": "Safe "
+    },
+    "5a0eee1486f77402aa773226": {
+        "id": "5a0eee1486f77402aa773226",
+        "name": "East wing room 328 key",
+        "shortName": "San.328 "
+    },
+    "5a0eff2986f7741fd654e684": {
+        "id": "5a0eff2986f7741fd654e684",
+        "name": "Health resort room 321 safe key",
+        "shortName": "Safe 321 "
+    },
+    "5a0f068686f7745b0d4ea242": {
+        "id": "5a0f068686f7745b0d4ea242",
+        "name": "Cottage safe key",
+        "shortName": "Safe "
+    },
+    "5d80c88d86f77440556dbf07": {
+        "id": "5d80c88d86f77440556dbf07",
+        "name": "RB-AM key",
+        "shortName": "RB-AM"
+    },
+    "59148c8a86f774197930e983": {
+        "id": "59148c8a86f774197930e983",
+        "name": "Dorm room 204 Key",
+        "shortName": "Room 204 Key"
+    },
+    "5938994586f774523a425196": {
+        "id": "5938994586f774523a425196",
+        "name": "Dorm room 103 Key",
+        "shortName": "103 Key"
+    },
+    "5914578086f774123569ffa4": {
+        "id": "5914578086f774123569ffa4",
+        "name": "Dorm room 108 Key",
+        "shortName": "108 Key"
+    },
+    "5d80c6c586f77440351beef1": {
+        "id": "5d80c6c586f77440351beef1",
+        "name": "RB-OB key",
+        "shortName": "RB-OB"
+    },
+    "5d80c78786f774403a401e3e": {
+        "id": "5d80c78786f774403a401e3e",
+        "name": "RB-AK key",
+        "shortName": "RB-AK"
+    },
+    "5da743f586f7744014504f72": {
+        "id": "5da743f586f7744014504f72",
+        "name": "USEC stash on Customs key",
+        "shortName": "USEC key"
+    },
+    "5d80c6fc86f774403a401e3c": {
+        "id": "5d80c6fc86f774403a401e3c",
+        "name": "RB-TB key",
+        "shortName": "RB-TB"
+    },
+    "5d80cd1a86f77402aa362f42": {
+        "id": "5d80cd1a86f77402aa362f42",
+        "name": "RB-ORB3 key",
+        "shortName": "RB-ORB3"
+    },
+    "5d8e3ecc86f774414c78d05e": {
+        "id": "5d8e3ecc86f774414c78d05e",
+        "name": "RB-GN key",
+        "shortName": "RB-GN"
+    },
+    "5d80c60f86f77440373c4ece": {
+        "id": "5d80c60f86f77440373c4ece",
+        "name": "RB-BK key",
+        "shortName": "RB-BK"
+    },
+    "5d80c62a86f7744036212b3f": {
+        "id": "5d80c62a86f7744036212b3f",
+        "name": "RB-VO key",
+        "shortName": "RB-VO"
+    },
+    "5d947d3886f774447b415893": {
+        "id": "5d947d3886f774447b415893",
+        "name": "RB-SMP key",
+        "shortName": "RB-SMP"
+    },
+    "5d80c93086f7744036212b41": {
+        "id": "5d80c93086f7744036212b41",
+        "name": "RB-MP11 key",
+        "shortName": "RB-MP11"
+    },
+    "5d947d4e86f774447b415895": {
+        "id": "5d947d4e86f774447b415895",
+        "name": "RB-KSM key",
+        "shortName": "RB-KSM"
+    },
+    "5d80cab086f77440535be201": {
+        "id": "5d80cab086f77440535be201",
+        "name": "RB-MP22 key",
+        "shortName": "RB-MP22"
+    },
+    "5d8e0e0e86f774321140eb56": {
+        "id": "5d8e0e0e86f774321140eb56",
+        "name": "RB-KPRL key",
+        "shortName": "RB-KPRL"
+    },
+    "5d80ccdd86f77474f7575e02": {
+        "id": "5d80ccdd86f77474f7575e02",
+        "name": "RB-ORB2 key",
+        "shortName": "RB-ORB2"
+    },
+    "5d80cbd886f77470855c26c2": {
+        "id": "5d80cbd886f77470855c26c2",
+        "name": "RB-MP13 key",
+        "shortName": "RB-MP13"
+    },
+    "5d80ca9086f774403a401e40": {
+        "id": "5d80ca9086f774403a401e40",
+        "name": "RB-MP21 key",
+        "shortName": "RB-MP21"
+    },
+    "5d80c95986f77440351beef3": {
+        "id": "5d80c95986f77440351beef3",
+        "name": "RB-MP12 key",
+        "shortName": "RB-MP12"
+    },
+    "5d80ccac86f77470841ff452": {
+        "id": "5d80ccac86f77470841ff452",
+        "name": "RB-ORB1 key",
+        "shortName": "RB-ORB1"
+    },
+    "5da46e3886f774653b7a83fe": {
+        "id": "5da46e3886f774653b7a83fe",
+        "name": "RB-RS key",
+        "shortName": "RB-RS"
+    },
+    "5d80cb3886f77440556dbf09": {
+        "id": "5d80cb3886f77440556dbf09",
+        "name": "RB-PSP1 key",
+        "shortName": "RB-PSP1"
+    },
+    "5d80c8f586f77440373c4ed0": {
+        "id": "5d80c8f586f77440373c4ed0",
+        "name": "RB-OP key",
+        "shortName": "RB-OP"
+    },
+    "5da5cdcd86f774529238fb9b": {
+        "id": "5da5cdcd86f774529238fb9b",
+        "name": "RB-RH key",
+        "shortName": "RB-RH"
+    },
+    "5d95d6fa86f77424484aa5e9": {
+        "id": "5d95d6fa86f77424484aa5e9",
+        "name": "Key RB-PSP2",
+        "shortName": "RB-PSP2"
+    },
+    "5d8e0db586f7744450412a42": {
+        "id": "5d8e0db586f7744450412a42",
+        "name": "RB-KORL key",
+        "shortName": "RB-KORL"
+    },
+    "5d95d6be86f77424444eb3a7": {
+        "id": "5d95d6be86f77424444eb3a7",
+        "name": "RB-PS82 key",
+        "shortName": "RB-PS82"
+    },
+    "5d80cb5686f77440545d1286": {
+        "id": "5d80cb5686f77440545d1286",
+        "name": "RB-PS81 key",
+        "shortName": "RB-PS81"
+    },
+    "5d80cb8786f774405611c7d9": {
+        "id": "5d80cb8786f774405611c7d9",
+        "name": "RB-PP key",
+        "shortName": "RB-PP"
+    },
+    "5d8e15b686f774445103b190": {
+        "id": "5d8e15b686f774445103b190",
+        "name": "Key to HEP station storage",
+        "shortName": "HEPS"
+    },
+    "5d9f1fa686f774726974a992": {
+        "id": "5d9f1fa686f774726974a992",
+        "name": "RB-ST key",
+        "shortName": "RB-ST"
+    },
+    "5a0f08bc86f77478f33b84c2": {
+        "id": "5a0f08bc86f77478f33b84c2",
+        "name": "Health resort management office safe key",
+        "shortName": "Safe "
+    },
+    "5d80c66d86f774405611c7d6": {
+        "id": "5d80c66d86f774405611c7d6",
+        "name": "RB-AO key",
+        "shortName": "RB-AO"
+    },
+    "5a0f006986f7741ffd2fe484": {
+        "id": "5a0f006986f7741ffd2fe484",
+        "name": "Weather station safe key",
+        "shortName": "Safe "
+    },
+    "59136a4486f774447a1ed172": {
+        "id": "59136a4486f774447a1ed172",
+        "name": "Dorm guard desk key",
+        "shortName": "Gdesk"
+    },
+    "5a0f075686f7745bcc42ee12": {
+        "id": "5a0f075686f7745bcc42ee12",
+        "name": "Key to store safe",
+        "shortName": "Safe "
+    },
+    "5913651986f774432f15d132": {
+        "id": "5913651986f774432f15d132",
+        "name": "VAZ key",
+        "shortName": "Sixpack"
+    },
+    "5e42c71586f7747f245e1343": {
+        "id": "5e42c71586f7747f245e1343",
+        "name": "ULTRA medical storage key",
+        "shortName": "Med.St."
+    },
+    "5913611c86f77479e0084092": {
+        "id": "5913611c86f77479e0084092",
+        "name": "Trailer park cabin key",
+        "shortName": "Cabin key"
+    },
+    "5ede7a8229445733cb4c18e2": {
+        "id": "5ede7a8229445733cb4c18e2",
+        "name": "RB-PKPM key",
+        "shortName": "RB-PKPM"
+    },
+    "5ede7b0c6d23e5473e6e8c66": {
+        "id": "5ede7b0c6d23e5473e6e8c66",
+        "name": "RB-RLSSA key",
+        "shortName": "RB-RLSA"
+    },
+    "5eff09cd30a7dc22fd1ddfed": {
+        "id": "5eff09cd30a7dc22fd1ddfed",
+        "name": "Key with tape",
+        "shortName": "Tape key"
+    },
+    "5c99f98d86f7745c314214b3": {
+        "id": "5c99f98d86f7745c314214b3"
+    },
+    "5c164d2286f774194c5e69fa": {
+        "id": "5c164d2286f774194c5e69fa"
+    },
+    "54491bb74bdc2d09088b4567": {
+        "id": "54491bb74bdc2d09088b4567",
+        "name": "ER Fulcrum Bayonet",
+        "shortName": "ER Bayonet"
+    },
+    "5bffe7930db834001b734a39": {
+        "id": "5bffe7930db834001b734a39",
+        "name": "Crash Axe",
+        "shortName": "SCA"
+    },
+    "5c07df7f0db834001b73588a": {
+        "id": "5c07df7f0db834001b73588a",
+        "name": "Freeman crowbar",
+        "shortName": "Crowbar"
+    },
+    "5c0126f40db834002a125382": {
+        "id": "5c0126f40db834002a125382",
+        "name": "Red Rebel Ice pick",
+        "shortName": "RR"
+    },
+    "57e26fc7245977162a14b800": {
+        "id": "57e26fc7245977162a14b800",
+        "name": "Bars A-2607- 95x18",
+        "shortName": "A-2607"
+    },
+    "57e26ea924597715ca604a09": {
+        "id": "57e26ea924597715ca604a09",
+        "name": "Bars A-2607- Damascus",
+        "shortName": "A-2607"
+    },
+    "5bffdd7e0db834001b734a1a": {
+        "id": "5bffdd7e0db834001b734a1a",
+        "name": "Miller Bros. Blades M-2 Tactical Sword ",
+        "shortName": "M-2"
+    },
+    "5c010e350db83400232feec7": {
+        "id": "5c010e350db83400232feec7",
+        "name": "SP-8 Survival Machete",
+        "shortName": "SP-8"
+    },
+    "5c012ffc0db834001d23f03f": {
+        "id": "5c012ffc0db834001d23f03f",
+        "name": "Camper axe",
+        "shortName": "Camper"
+    },
+    "5bc9c1e2d4351e00367fbcf0": {
+        "id": "5bc9c1e2d4351e00367fbcf0",
+        "name": "Antique axe",
+        "shortName": "Axe"
+    },
+    "57cd379a24597778e7682ecf": {
+        "id": "57cd379a24597778e7682ecf",
+        "name": "Kiba Arms Tactical Tomahawk",
+        "shortName": "KATT"
+    },
+    "5bead2e00db834001c062938": {
+        "id": "5bead2e00db834001c062938",
+        "name": "MPL-50 entrenching tool",
+        "shortName": "MPL-50"
+    },
+    "5fc64ea372b0dd78d51159dc": {
+        "id": "5fc64ea372b0dd78d51159dc",
+        "name": "Cultist's knife",
+        "shortName": "Knife"
+    },
+    "5bffdc370db834001d23eca8": {
+        "id": "5bffdc370db834001d23eca8",
+        "name": "6h5 Bayonet",
+        "shortName": "6h5"
+    },
+    "5798a2832459774b53341029": {
+        "id": "5798a2832459774b53341029",
+        "name": "Customs plan",
+        "shortName": "Customs"
+    },
+    "574eb85c245977648157eec3": {
+        "id": "574eb85c245977648157eec3",
+        "name": "Factory Plan",
+        "shortName": "Factory"
+    },
+    "5a80a29286f7742b25692012": {
+        "id": "5a80a29286f7742b25692012",
+        "name": "Shoreline resort plan",
+        "shortName": "Resort"
+    },
+    "5900b89686f7744e704a8747": {
+        "id": "5900b89686f7744e704a8747",
+        "name": "Woods Plan",
+        "shortName": "Woods"
+    },
+    "5a8036fb86f77407252ddc02": {
+        "id": "5a8036fb86f77407252ddc02",
+        "name": "Shoreline paper map",
+        "shortName": "Shoreline"
+    },
+    "5be4038986f774527d3fae60": {
+        "id": "5be4038986f774527d3fae60",
+        "name": "Interchange paper map",
+        "shortName": "Interchange"
+    },
+    "590c695186f7741e566b64a2": {
+        "id": "590c695186f7741e566b64a2",
+        "name": "Augmentin antibiotic pills",
+        "shortName": "Augmentin"
+    },
+    "5751a89d24597722aa0e8db0": {
+        "id": "5751a89d24597722aa0e8db0",
+        "name": "Golden Star Balm",
+        "shortName": "GoldenStar"
+    },
+    "5af0548586f7743a532b7e99": {
+        "id": "5af0548586f7743a532b7e99",
+        "name": "Ibuprofen painkillers",
+        "shortName": "Ibuprofen"
+    },
+    "544fb3f34bdc2d03748b456a": {
+        "id": "544fb3f34bdc2d03748b456a",
+        "name": "Morphine injector",
+        "shortName": "Morphine"
+    },
+    "544fb37f4bdc2dee738b4567": {
+        "id": "544fb37f4bdc2dee738b4567",
+        "name": "Analgin painkillers",
+        "shortName": "Painkillers"
+    },
+    "5755383e24597772cb798966": {
+        "id": "5755383e24597772cb798966",
+        "name": "Vaseline",
+        "shortName": "Vaseline"
+    },
+    "590c661e86f7741e566b646a": {
+        "id": "590c661e86f7741e566b646a",
+        "name": "Car first aid kit",
+        "shortName": "Car"
+    },
+    "5755356824597772cb798962": {
+        "id": "5755356824597772cb798962",
+        "name": "AI-2 medikit",
+        "shortName": "AI-2"
+    },
+    "5e99711486f7744bfc4af328": {
+        "id": "5e99711486f7744bfc4af328",
+        "name": "Sanitar first aid kit",
+        "shortName": "Sanitar"
+    },
+    "590c657e86f77412b013051d": {
+        "id": "590c657e86f77412b013051d",
+        "name": "Grizzly First Aid Kit",
+        "shortName": "Grizzly"
+    },
+    "544fb45d4bdc2dee738b4568": {
+        "id": "544fb45d4bdc2dee738b4568",
+        "name": "Salewa FIRST AID KIT",
+        "shortName": "Salewa"
+    },
+    "590c678286f77426c9660122": {
+        "id": "590c678286f77426c9660122",
+        "name": "IFAK personal tactical first aid kit",
+        "shortName": "IFAK"
+    },
+    "544fb3364bdc2d34748b456a": {
+        "id": "544fb3364bdc2d34748b456a",
+        "name": "Immobilizing splint",
+        "shortName": "Splint"
+    },
+    "544fb25a4bdc2dfb738b4567": {
+        "id": "544fb25a4bdc2dfb738b4567",
+        "name": "Aseptic bandage",
+        "shortName": "Bandage"
+    },
+    "5751a25924597722c463c472": {
+        "id": "5751a25924597722c463c472",
+        "name": "Army bandage",
+        "shortName": "Bandage"
+    },
+    "5d02778e86f774203e7dedbe": {
+        "id": "5d02778e86f774203e7dedbe",
+        "name": "CMS kit",
+        "shortName": "CMS"
+    },
+    "5af0454c86f7746bf20992e8": {
+        "id": "5af0454c86f7746bf20992e8",
+        "name": "Immobilizing splint",
+        "shortName": "Alu Splint"
+    },
+    "5e8488fa988a8701445df1e4": {
+        "id": "5e8488fa988a8701445df1e4",
+        "name": "CALOK-B Hemostatic",
+        "shortName": "Hemostat"
+    },
+    "5e99735686f7744bfc4af32c": {
+        "id": "5e99735686f7744bfc4af32c",
+        "name": "Sanitar kit",
+        "shortName": "Sanitar kit"
+    },
+    "5d02797c86f774203f38e30a": {
+        "id": "5d02797c86f774203f38e30a",
+        "name": "Surv12 field surgical kit",
+        "shortName": "Surv12"
+    },
+    "5e831507ea0a7c419c2f9bd9": {
+        "id": "5e831507ea0a7c419c2f9bd9",
+        "name": "Esmarch tourniquet",
+        "shortName": "Esmarch"
+    },
+    "5ed515c8d380ab312177c0fa": {
+        "id": "5ed515c8d380ab312177c0fa",
+        "name": "3-(b-TG)",
+        "shortName": "3-(b-TG)"
+    },
+    "5ed515f6915ec335206e4152": {
+        "id": "5ed515f6915ec335206e4152",
+        "name": "AHF1-M",
+        "shortName": "AHF1-M"
+    },
+    "5ed515e03a40a50460332579": {
+        "id": "5ed515e03a40a50460332579",
+        "name": "L1 (Norepinephrine)",
+        "shortName": "L1"
+    },
+    "5ed51652f6c34d2cc26336a1": {
+        "id": "5ed51652f6c34d2cc26336a1",
+        "name": "M.U.L.E. stimulator",
+        "shortName": "M.U.L.E"
+    },
+    "5ed5160a87bb8443d10680b5": {
+        "id": "5ed5160a87bb8443d10680b5",
+        "name": "Meldonin",
+        "shortName": "Meldonin"
+    },
+    "5ed5166ad380ab312177c100": {
+        "id": "5ed5166ad380ab312177c100",
+        "name": "Cocktail \"Obdolbos\"",
+        "shortName": "Obdolbos"
+    },
+    "5ed515ece452db0eb56fc028": {
+        "id": "5ed515ece452db0eb56fc028",
+        "name": "P22",
+        "shortName": "P22"
+    },
+    "5c0e531286f7747fa54205c2": {
+        "id": "5c0e531286f7747fa54205c2",
+        "name": "Combat stimulant injector SJ1 TGLabs",
+        "shortName": "SJ1 TGLabs"
+    },
+    "5c10c8fd86f7743d7d706df3": {
+        "id": "5c10c8fd86f7743d7d706df3",
+        "name": "Adrenaline injector",
+        "shortName": "Adrenaline"
+    },
+    "5c0e530286f7747fa1419862": {
+        "id": "5c0e530286f7747fa1419862",
+        "name": "Propital",
+        "shortName": "Propital"
+    },
+    "5c0e531d86f7747fa23f4d42": {
+        "id": "5c0e531d86f7747fa23f4d42",
+        "name": "Combat stimulant injector SJ6 TGLabs",
+        "shortName": "SJ6 TGLabs"
+    },
+    "5fca13ca637ee0341a484f46": {
+        "id": "5fca13ca637ee0341a484f46",
+        "name": "Combat stimulant injector SJ9 TGLabs",
+        "shortName": "SJ9 TGLabs"
+    },
+    "5c0e533786f7747fa23f4d47": {
+        "id": "5c0e533786f7747fa23f4d47",
+        "name": "Hemostatic drug Zagustin",
+        "shortName": "Zagustin"
+    },
+    "5c0e534186f7747fa1419867": {
+        "id": "5c0e534186f7747fa1419867",
+        "name": "Regenerative stimulant injector eTG-change",
+        "shortName": "eTG-c"
+    },
+    "5fca138c2a7b221b2852a5c6": {
+        "id": "5fca138c2a7b221b2852a5c6",
+        "name": "Antidote xTG-12",
+        "shortName": "xTG-12"
+    },
+    "5448f3a64bdc2d60728b456a": {
+        "id": "5448f3a64bdc2d60728b456a",
+        "name": "Stimulator",
+        "shortName": "Item"
+    },
+    "5448f3ac4bdc2dce718b4569": {
+        "id": "5448f3ac4bdc2dce718b4569",
+        "name": "Medical item",
+        "shortName": "Item"
+    },
+    "5448f39d4bdc2d0a728b4568": {
+        "id": "5448f39d4bdc2d0a728b4568",
+        "name": "Medikit",
+        "shortName": "Item"
+    },
+    "5448f3a14bdc2d27728b4569": {
+        "id": "5448f3a14bdc2d27728b4569",
+        "name": "Drug",
+        "shortName": "Item"
+    },
+    "5f4f9eb969cdc30ff33f09db": {
+        "id": "5f4f9eb969cdc30ff33f09db",
+        "name": "EYE MK.2 professional hand-held compass",
+        "shortName": "Compass"
+    },
+    "591094e086f7747caa7bb2ef": {
+        "id": "591094e086f7747caa7bb2ef",
+        "name": "Body armor repair kit",
+        "shortName": "Repair Kit"
+    },
+    "5910968f86f77425cf569c32": {
+        "id": "5910968f86f77425cf569c32",
+        "name": "Weapons repair kit",
+        "shortName": "Repair Kit"
+    },
+    "5991b51486f77447b112d44f": {
+        "id": "5991b51486f77447b112d44f",
+        "name": "MS2000 Marker",
+        "shortName": "MS2000"
+    },
+    "5b4391a586f7745321235ab2": {
+        "id": "5b4391a586f7745321235ab2",
+        "name": "WIFI Camera",
+        "shortName": "Camera"
+    },
+    "5910959486f7747d96753485": {
+        "id": "5910959486f7747d96753485",
+        "name": "Knife repair and sharpening kit",
+        "shortName": "Repair Kit"
+    },
+    "544fb5454bdc2df8738b456a": {
+        "id": "544fb5454bdc2df8738b456a",
+        "name": "Leatherman Multitool",
+        "shortName": "Tool"
+    },
+    "5ac78a9b86f7741cca0bbd8d": {
+        "id": "5ac78a9b86f7741cca0bbd8d",
+        "name": "Signal Jammer",
+        "shortName": "Jammer"
+    },
+    "5f4fbaaca5573a5ac31db429": {
+        "id": "5f4fbaaca5573a5ac31db429"
+    },
+    "573720e02459776143012541": {
+        "id": "573720e02459776143012541",
+        "name": "9x18mm PM RG028 gzh",
+        "shortName": "RG028 gzh"
+    },
+    "57371f2b24597761224311f1": {
+        "id": "57371f2b24597761224311f1",
+        "name": "9x18 mm PM PS gs PPO",
+        "shortName": "PS gs PPO"
+    },
+    "5a608bf24f39f98ffc77720e": {
+        "id": "5a608bf24f39f98ffc77720e",
+        "name": "7.62x51 mm M62",
+        "shortName": "M62"
+    },
+    "573718ba2459775a75491131": {
+        "id": "573718ba2459775a75491131",
+        "name": "9x18 mm PM 9 BZT gzh",
+        "shortName": "9 BZT gzh"
+    },
+    "57371aab2459775a77142f22": {
+        "id": "57371aab2459775a77142f22",
+        "name": "9x18 mm PM PMM",
+        "shortName": "PMM"
+    },
+    "5737218f245977612125ba51": {
+        "id": "5737218f245977612125ba51",
+        "name": "9x18 mm PM SP8 gzh",
+        "shortName": "SP8 gzh"
+    },
+    "573719762459775a626ccbc1": {
+        "id": "573719762459775a626ccbc1",
+        "name": "9x18 mm PM 9 P gzh",
+        "shortName": "9 P gzh"
+    },
+    "5737207f24597760ff7b25f2": {
+        "id": "5737207f24597760ff7b25f2",
+        "name": "9x18 mm PM PSV",
+        "shortName": "PSV"
+    },
+    "5737201124597760fc4431f1": {
+        "id": "5737201124597760fc4431f1",
+        "name": "9x18 mm PM Pst gzh",
+        "shortName": "Pst gzh"
+    },
+    "5735ff5c245977640e39ba7e": {
+        "id": "5735ff5c245977640e39ba7e",
+        "name": "7.62x25mm TT FMJ43",
+        "shortName": "FMJ43"
+    },
+    "57371f8d24597761006c6a81": {
+        "id": "57371f8d24597761006c6a81",
+        "name": "9x18 mm PM PSO gzh",
+        "shortName": "PSO gzh"
+    },
+    "56d59d3ad2720bdb418b4577": {
+        "id": "56d59d3ad2720bdb418b4577",
+        "name": "9x19 mm Pst gzh",
+        "shortName": "Pst gzh"
+    },
+    "59e68f6f86f7746c9f75e846": {
+        "id": "59e68f6f86f7746c9f75e846",
+        "name": "5.56x45 mm M856",
+        "shortName": "M856"
+    },
+    "57372140245977611f70ee91": {
+        "id": "57372140245977611f70ee91",
+        "name": "9x18 mm PM SP7 gzh",
+        "shortName": "SP7 gzh"
+    },
+    "59e690b686f7746c9f75e848": {
+        "id": "59e690b686f7746c9f75e848",
+        "name": "5.56x45 mm M995",
+        "shortName": "M995"
+    },
+    "59e6906286f7746c9f75e847": {
+        "id": "59e6906286f7746c9f75e847",
+        "name": "5.56x45 mm M856A1",
+        "shortName": "M856A1"
+    },
+    "54527ac44bdc2d36668b4567": {
+        "id": "54527ac44bdc2d36668b4567",
+        "name": "5.56x45 mm M855A1",
+        "shortName": "M855A1"
+    },
+    "573719df2459775a626ccbc2": {
+        "id": "573719df2459775a626ccbc2",
+        "name": "9x18 mm PM PBM",
+        "shortName": "PBM"
+    },
+    "56dff3afd2720bba668b4567": {
+        "id": "56dff3afd2720bba668b4567",
+        "name": "5.45x39 mm PS",
+        "shortName": "PS"
+    },
+    "560d61e84bdc2da74d8b4571": {
+        "id": "560d61e84bdc2da74d8b4571",
+        "name": "7.62x54R SNB",
+        "shortName": "SNB"
+    },
+    "57371eb62459776125652ac1": {
+        "id": "57371eb62459776125652ac1",
+        "name": "9x18 mm PM PRS gs",
+        "shortName": "PRS gs"
+    },
+    "58864a4f2459770fcc257101": {
+        "id": "58864a4f2459770fcc257101",
+        "name": "9x19 mm PSO gzh",
+        "shortName": "PSO gzh"
+    },
+    "58dd3ad986f77403051cba8f": {
+        "id": "58dd3ad986f77403051cba8f",
+        "name": "7.62x51 mm M80",
+        "shortName": "M80"
+    },
+    "59e6918f86f7746c9f75e849": {
+        "id": "59e6918f86f7746c9f75e849",
+        "name": "5.56x45 mm Mk 255 Mod 0",
+        "shortName": "Mk255 Mod0"
+    },
+    "5887431f2459777e1612938f": {
+        "id": "5887431f2459777e1612938f",
+        "name": "7.62x54R LPS Gzh",
+        "shortName": "LPS Gzh"
+    },
+    "56dff338d2720bbd668b4569": {
+        "id": "56dff338d2720bbd668b4569",
+        "name": "5.45x39 mm PRS",
+        "shortName": "PRS"
+    },
+    "56dff061d2720bb5668b4567": {
+        "id": "56dff061d2720bb5668b4567",
+        "name": "5.45x39 mm BT",
+        "shortName": "BT"
+    },
+    "5ba26835d4351e0035628ff5": {
+        "id": "5ba26835d4351e0035628ff5",
+        "name": "4.6x30mm AP SX",
+        "shortName": "AP SX"
+    },
+    "573601b42459776410737435": {
+        "id": "573601b42459776410737435",
+        "name": "7.62x25mm TT LRN",
+        "shortName": "LRN"
+    },
+    "56dff421d2720b5f5a8b4567": {
+        "id": "56dff421d2720b5f5a8b4567",
+        "name": "5.45x39 mm SP",
+        "shortName": "SP"
+    },
+    "59e6927d86f77411da468256": {
+        "id": "59e6927d86f77411da468256",
+        "name": "5.56x45 mm 55 HP",
+        "shortName": "55 HP"
+    },
+    "57371e4124597760ff7b25f1": {
+        "id": "57371e4124597760ff7b25f1",
+        "name": "9x18 mm PM PPT gzh",
+        "shortName": "PPT gzh"
+    },
+    "56dff216d2720bbd668b4568": {
+        "id": "56dff216d2720bbd668b4568",
+        "name": "5.45x39 mm HP",
+        "shortName": "HP"
+    },
+    "54527a984bdc2d4e668b4567": {
+        "id": "54527a984bdc2d4e668b4567",
+        "name": "5.56x45 mm M855",
+        "shortName": "M855"
+    },
+    "5c0d5e4486f77478390952fe": {
+        "id": "5c0d5e4486f77478390952fe",
+        "name": "5.45x39 mm 7N39 \"Igolnik\"",
+        "shortName": "7N39"
+    },
+    "59e6658b86f77411d949b250": {
+        "id": "59e6658b86f77411d949b250",
+        "name": ".366 ТКМ Geksa",
+        "shortName": "Geksa"
+    },
+    "59e6542b86f77411dc52a77a": {
+        "id": "59e6542b86f77411dc52a77a",
+        "name": ".366 ТКМ FMJ",
+        "shortName": "FMJ"
+    },
+    "5c3df7d588a4501f290594e5": {
+        "id": "5c3df7d588a4501f290594e5",
+        "name": "9x19 mm Green Tracer",
+        "shortName": "GT"
+    },
+    "5ba26812d4351e003201fef1": {
+        "id": "5ba26812d4351e003201fef1",
+        "name": "4.6x30mm Action SX",
+        "shortName": "Action SX"
+    },
+    "573603562459776430731618": {
+        "id": "573603562459776430731618",
+        "name": "7.62x25mm TT Pst gzh",
+        "shortName": "Pst gzh"
+    },
+    "5736026a245977644601dc61": {
+        "id": "5736026a245977644601dc61",
+        "name": "7.62x25mm TT P gl",
+        "shortName": "P gl"
+    },
+    "5a38ebd9c4a282000d722a5b": {
+        "id": "5a38ebd9c4a282000d722a5b",
+        "name": "20x70 7.5mm Buckshot",
+        "shortName": "7.5 20c"
+    },
+    "59e655cb86f77411dc52a77b": {
+        "id": "59e655cb86f77411dc52a77b",
+        "name": ".366 ТКМ EKO",
+        "shortName": "EKO"
+    },
+    "573602322459776445391df1": {
+        "id": "573602322459776445391df1",
+        "name": "7.62x25mm TT LRNPC",
+        "shortName": "LRNPC"
+    },
+    "5656d7c34bdc2d9d198b4587": {
+        "id": "5656d7c34bdc2d9d198b4587",
+        "name": "7.62x39 mm PS",
+        "shortName": "PS"
+    },
+    "56dff4ecd2720b5f5a8b4568": {
+        "id": "56dff4ecd2720b5f5a8b4568",
+        "name": "5.45x39 mm US",
+        "shortName": "US"
+    },
+    "5735fdcd2459776445391d61": {
+        "id": "5735fdcd2459776445391d61",
+        "name": "7.62x25mm TT AKBS",
+        "shortName": "AKBS"
+    },
+    "59e4d3d286f774176a36250a": {
+        "id": "59e4d3d286f774176a36250a",
+        "name": "7.62x39 mm HP",
+        "shortName": "HP"
+    },
+    "59e6920f86f77411d82aa167": {
+        "id": "59e6920f86f77411d82aa167",
+        "name": "5.56x45 mm 55 FMJ",
+        "shortName": "55 FMJ"
+    },
+    "5ba2678ad4351e44f824b344": {
+        "id": "5ba2678ad4351e44f824b344",
+        "name": "4.6x30mm FMJ SX",
+        "shortName": "FMJ SX"
+    },
+    "56dfef82d2720bbd668b4567": {
+        "id": "56dfef82d2720bbd668b4567",
+        "name": "5.45x39 mm BP",
+        "shortName": "BP"
+    },
+    "56dff026d2720bb8668b4567": {
+        "id": "56dff026d2720bb8668b4567",
+        "name": "5.45x39 mm BS",
+        "shortName": "BS"
+    },
+    "59e4d24686f7741776641ac7": {
+        "id": "59e4d24686f7741776641ac7",
+        "name": "7.62x39 mm US",
+        "shortName": "US"
+    },
+    "59e4cf5286f7741778269d8a": {
+        "id": "59e4cf5286f7741778269d8a",
+        "name": "7.62x39 mm T45M",
+        "shortName": "T45M"
+    },
+    "5d6e6a05a4b93618084f58d0": {
+        "id": "5d6e6a05a4b93618084f58d0",
+        "name": "20/70 Star Slug",
+        "shortName": "20/70 Slug"
+    },
+    "56dff4a2d2720bbd668b456a": {
+        "id": "56dff4a2d2720bbd668b456a",
+        "name": "5.45x39 mm T",
+        "shortName": "T"
+    },
+    "59e0d99486f7744a32234762": {
+        "id": "59e0d99486f7744a32234762",
+        "name": "7.62x39 mm BP",
+        "shortName": "BP"
+    },
+    "573603c924597764442bd9cb": {
+        "id": "573603c924597764442bd9cb",
+        "name": "7.62x25mm TT PT gzh",
+        "shortName": "PT gzh"
+    },
+    "5a6086ea4f39f99cd479502f": {
+        "id": "5a6086ea4f39f99cd479502f",
+        "name": "7.62x51 mm M61",
+        "shortName": "M61"
+    },
+    "57371b192459775a9f58a5e0": {
+        "id": "57371b192459775a9f58a5e0",
+        "name": "9x18 mm PM PPe gzh",
+        "shortName": "PPe gzh"
+    },
+    "59e77a2386f7742ee578960a": {
+        "id": "59e77a2386f7742ee578960a",
+        "name": "7.62x54R 7N1 Sniper cartridge",
+        "shortName": "7N1"
+    },
+    "5ba26844d4351e00334c9475": {
+        "id": "5ba26844d4351e00334c9475",
+        "name": "4.6x30mm Subsonic SX",
+        "shortName": "Subsonic SX"
+    },
+    "56dff0bed2720bb0668b4567": {
+        "id": "56dff0bed2720bb0668b4567",
+        "name": "5.45x39 mm FMJ",
+        "shortName": "FMJ"
+    },
+    "5c0d5ae286f7741e46554302": {
+        "id": "5c0d5ae286f7741e46554302",
+        "name": "5.56x45mm Warmage",
+        "shortName": "WG"
+    },
+    "56dff2ced2720bb4668b4567": {
+        "id": "56dff2ced2720bb4668b4567",
+        "name": "5.45x39 mm PP",
+        "shortName": "PP"
+    },
+    "5cde8864d7f00c0010373be1": {
+        "id": "5cde8864d7f00c0010373be1",
+        "name": "12.7x108 mm B-32",
+        "shortName": "B-32"
+    },
+    "5d70e500a4b9364de70d38ce": {
+        "id": "5d70e500a4b9364de70d38ce",
+        "name": "30x29 mm VOG-30",
+        "shortName": "VOG-30"
+    },
+    "5a269f97c4a282000b151807": {
+        "id": "5a269f97c4a282000b151807",
+        "name": "9x21 mm SP10",
+        "shortName": "SP10"
+    },
+    "5a26abfac4a28232980eabff": {
+        "id": "5a26abfac4a28232980eabff",
+        "name": "9x21 mm SP11",
+        "shortName": "SP11"
+    },
+    "5c0d56a986f774449d5de529": {
+        "id": "5c0d56a986f774449d5de529",
+        "name": "9x19 mm RIP",
+        "shortName": "RIP"
+    },
+    "5c925fa22e221601da359b7b": {
+        "id": "5c925fa22e221601da359b7b",
+        "name": "9x19 mm AP 6.3",
+        "shortName": "AP 6.3"
+    },
+    "5a3c16fe86f77452b62de32a": {
+        "id": "5a3c16fe86f77452b62de32a",
+        "name": "9x19 mm Luger CCI",
+        "shortName": "Luger CCI"
+    },
+    "5656eb674bdc2d35148b457c": {
+        "id": "5656eb674bdc2d35148b457c",
+        "name": "40 mm VOG-25",
+        "shortName": "40mm"
+    },
+    "5c0d688c86f77413ae3407b2": {
+        "id": "5c0d688c86f77413ae3407b2",
+        "name": "9x39 mm 7N12 BP",
+        "shortName": "BP"
+    },
+    "5a26ac06c4a282000c5a90a8": {
+        "id": "5a26ac06c4a282000c5a90a8",
+        "name": "9x21 mm SP12",
+        "shortName": "SP12"
+    },
+    "5996f6d686f77467977ba6cc": {
+        "id": "5996f6d686f77467977ba6cc",
+        "name": "F1 Shrapnel",
+        "shortName": "F1 Shrapnel"
+    },
+    "5c0d668f86f7747ccb7f13b2": {
+        "id": "5c0d668f86f7747ccb7f13b2",
+        "name": "9x39 mm 7N9 SPP",
+        "shortName": "SPP"
+    },
+    "57a0dfb82459774d3078b56c": {
+        "id": "57a0dfb82459774d3078b56c",
+        "name": "9x39 mm SP-5",
+        "shortName": "SP-5"
+    },
+    "5996f6fc86f7745e585b4de3": {
+        "id": "5996f6fc86f7745e585b4de3",
+        "name": "M67 Shrapnel",
+        "shortName": "M67 Shrapnel"
+    },
+    "57a0e5022459774d1673f889": {
+        "id": "57a0e5022459774d1673f889",
+        "name": "9x39 mm SP-6",
+        "shortName": "SP-6"
+    },
+    "5a26ac0ec4a28200741e1e18": {
+        "id": "5a26ac0ec4a28200741e1e18",
+        "name": "9x21 mm SP13",
+        "shortName": "SP13"
+    },
+    "5943d9c186f7745a13413ac9": {
+        "id": "5943d9c186f7745a13413ac9",
+        "name": "Shrapnel",
+        "shortName": "Shrapnel"
+    },
+    "5996f6cb86f774678763a6ca": {
+        "id": "5996f6cb86f774678763a6ca",
+        "name": "RGD-5 Shrapnel",
+        "shortName": "RGD-5 Shrapnel"
+    },
+    "5cadf6ddae9215051e1c23b2": {
+        "id": "5cadf6ddae9215051e1c23b2",
+        "name": "12.7x55 mm PS12",
+        "shortName": "PS12"
+    },
+    "5d2f2ab648f03550091993ca": {
+        "id": "5d2f2ab648f03550091993ca",
+        "name": "12.7x108 mm BZT-44M",
+        "shortName": "BZT-44M"
+    },
+    "5cadf6e5ae921500113bb973": {
+        "id": "5cadf6e5ae921500113bb973",
+        "name": "12.7x55 mm PS12A",
+        "shortName": "PS12A"
+    },
+    "5d6e6806a4b936088465b17e": {
+        "id": "5d6e6806a4b936088465b17e",
+        "name": "12/70 8.5 mm \"Magnum\" Buckshot",
+        "shortName": "8.5 12c"
+    },
+    "560d5e524bdc2d25448b4571": {
+        "id": "560d5e524bdc2d25448b4571",
+        "name": "12x70 7mm Buckshot",
+        "shortName": "7mm 12c"
+    },
+    "5d6e6772a4b936088465b17c": {
+        "id": "5d6e6772a4b936088465b17c",
+        "name": "12/70 5.25mm Buckshot",
+        "shortName": "5.25 12c"
+    },
+    "5cadf6eeae921500134b2799": {
+        "id": "5cadf6eeae921500134b2799",
+        "name": "12.7x55 mm PS12B",
+        "shortName": "PS12B"
+    },
+    "5d6e67fba4b9361bc73bc779": {
+        "id": "5d6e67fba4b9361bc73bc779",
+        "name": "12x70 6.5 mm \"Express\" Buckshot",
+        "shortName": "6.5 12c"
+    },
+    "5d6e6911a4b9361bd5780d52": {
+        "id": "5d6e6911a4b9361bd5780d52",
+        "name": "12/70 Flechette",
+        "shortName": "Flech."
+    },
+    "5d6e68e6a4b9361c140bcfe0": {
+        "id": "5d6e68e6a4b9361c140bcfe0",
+        "name": "12/70 FTX Custom LIte Slug",
+        "shortName": "FTX"
+    },
+    "5d6e68a8a4b9360b6c0d54e2": {
+        "id": "5d6e68a8a4b9360b6c0d54e2",
+        "name": "12/70 AP-20 Slug",
+        "shortName": "AP-20"
+    },
+    "5c0d591486f7744c505b416f": {
+        "id": "5c0d591486f7744c505b416f",
+        "name": "12x70 RIP",
+        "shortName": "12x70 RIP"
+    },
+    "5d6e69c7a4b9360b6c0d54e4": {
+        "id": "5d6e69c7a4b9360b6c0d54e4",
+        "name": "20/70 7.3mm Buckshot",
+        "shortName": "7.3 20c"
+    },
+    "5d6e68dea4b9361bcc29e659": {
+        "id": "5d6e68dea4b9361bcc29e659",
+        "name": "12/70 Dual Sabot Slug",
+        "shortName": "2-Sabot"
+    },
+    "5d6e6a5fa4b93614ec501745": {
+        "id": "5d6e6a5fa4b93614ec501745",
+        "name": "20/70 Devastator Slug",
+        "shortName": "Dev."
+    },
+    "5d6e6869a4b9361c140bcfde": {
+        "id": "5d6e6869a4b9361c140bcfde",
+        "name": "12/70 Grizzly 40 Slug ",
+        "shortName": "Grizzly"
+    },
+    "5cc80f53e4a949000e1ea4f8": {
+        "id": "5cc80f53e4a949000e1ea4f8",
+        "name": "5.7x28 mm L191",
+        "shortName": "L191"
+    },
+    "5cc80f79e4a949033c7343b2": {
+        "id": "5cc80f79e4a949033c7343b2",
+        "name": "5.7x28 mm SS198LF",
+        "shortName": "SS198LF"
+    },
+    "5d6e68c4a4b9361b93413f79": {
+        "id": "5d6e68c4a4b9361b93413f79",
+        "name": "12x70 shell with .50 BMG bullet",
+        "shortName": ".50 12c"
+    },
+    "5cc80f8fe4a949033b0224a2": {
+        "id": "5cc80f8fe4a949033b0224a2",
+        "name": "5.7x28 mm SS197SR",
+        "shortName": "SS197SR"
+    },
+    "5d6e689ca4b9361bc8618956": {
+        "id": "5d6e689ca4b9361bc8618956",
+        "name": "12/70 \"Poleva-6u\" Slug",
+        "shortName": "P-6u 12c"
+    },
+    "5d6e6891a4b9361bd473feea": {
+        "id": "5d6e6891a4b9361bd473feea",
+        "name": "12/70 \"Poleva-3\" Slug",
+        "shortName": "P-3 12c"
+    },
+    "5d6e69b9a4b9361bc8618958": {
+        "id": "5d6e69b9a4b9361bc8618958",
+        "name": "20/70 6.2mm Buckshot",
+        "shortName": "6.2 20k"
+    },
+    "5d6e695fa4b936359b35d852": {
+        "id": "5d6e695fa4b936359b35d852",
+        "name": "20/70 5.6mm Buckshot",
+        "shortName": "5.6 20c"
+    },
+    "5d6e6a53a4b9361bd473feec": {
+        "id": "5d6e6a53a4b9361bd473feec",
+        "name": "20/70 Slug \"Poleva-3\"",
+        "shortName": "P-3 20c"
+    },
+    "5d6e6a42a4b9364f07165f52": {
+        "id": "5d6e6a42a4b9364f07165f52",
+        "name": "20/70 Slug Poleva-6u",
+        "shortName": "P-6u 20c"
+    },
+    "5cc80f38e4a949001152b560": {
+        "id": "5cc80f38e4a949001152b560",
+        "name": "5.7x28 mm SS190",
+        "shortName": "SS190"
+    },
+    "5e81f423763d9f754677bf2e": {
+        "id": "5e81f423763d9f754677bf2e",
+        "name": ".45 ACP FMJ",
+        "shortName": ".45 FMJ"
+    },
+    "5cc80f67e4a949035e43bbba": {
+        "id": "5cc80f67e4a949035e43bbba",
+        "name": "5.7x28 mm SB193",
+        "shortName": "SB193"
+    },
+    "5e023e53d4353e3302577c4c": {
+        "id": "5e023e53d4353e3302577c4c",
+        "name": "7.62x51 mm BPZ FMJ",
+        "shortName": "BPZ FMJ"
+    },
+    "5e023e6e34d52a55c3304f71": {
+        "id": "5e023e6e34d52a55c3304f71",
+        "name": "7.62x51 mm TPZ SP",
+        "shortName": "TPZ SP"
+    },
+    "5e023d34e8a400319a28ed44": {
+        "id": "5e023d34e8a400319a28ed44",
+        "name": "7.62x54R 7BT1",
+        "shortName": "7BT1"
+    },
+    "5e023d48186a883be655e551": {
+        "id": "5e023d48186a883be655e551",
+        "name": "7.62x54R 7N37",
+        "shortName": "7N37"
+    },
+    "5e023cf8186a883be655e54f": {
+        "id": "5e023cf8186a883be655e54f",
+        "name": "7.62x54R T-46M",
+        "shortName": "T46M"
+    },
+    "5efb0d4f4bc50b58e81710f3": {
+        "id": "5efb0d4f4bc50b58e81710f3",
+        "name": ".45 ACP Lasermatch FMJ",
+        "shortName": ".45 LM"
+    },
+    "5f0596629e22f464da6bbdd9": {
+        "id": "5f0596629e22f464da6bbdd9",
+        "name": ".366 AP",
+        "shortName": "366 AP"
+    },
+    "5efb0c1bd79ff02a1f5e68d9": {
+        "id": "5efb0c1bd79ff02a1f5e68d9",
+        "name": "7.62x51 mm M993",
+        "shortName": "M993"
+    },
+    "5efb0da7a29a85116f6ea05f": {
+        "id": "5efb0da7a29a85116f6ea05f",
+        "name": "9x19 mm 7N31",
+        "shortName": "7N31"
+    },
+    "5e85aa1a988a8701445df1f5": {
+        "id": "5e85aa1a988a8701445df1f5",
+        "name": "23x75mm \"Barricade\"",
+        "shortName": "Barr."
+    },
+    "5e85a9a6eacf8c039e4e2ac1": {
+        "id": "5e85a9a6eacf8c039e4e2ac1",
+        "name": "23x75mm Shrapnel 10",
+        "shortName": "Shrap.10"
+    },
+    "5f647f31b6238e5dd066e196": {
+        "id": "5f647f31b6238e5dd066e196",
+        "name": "23x75mm Shrapnel-25",
+        "shortName": "Shr.25"
+    },
+    "5ede474b0c226a66f5402622": {
+        "id": "5ede474b0c226a66f5402622",
+        "name": "40x46 mm M381 (HE)",
+        "shortName": " M381"
+    },
+    "5ede475b549eed7c6d5c18fb": {
+        "id": "5ede475b549eed7c6d5c18fb",
+        "name": "40x46 mm M386(HE)",
+        "shortName": "M386"
+    },
+    "5ede4739e0350d05467f73e8": {
+        "id": "5ede4739e0350d05467f73e8",
+        "name": "40x46 mm M406 (HE)",
+        "shortName": "M406"
+    },
+    "5f0c892565703e5c461894e9": {
+        "id": "5f0c892565703e5c461894e9",
+        "name": "40x46 mm M433 (HEDP)",
+        "shortName": "M433"
+    },
+    "5ede47405b097655935d7d16": {
+        "id": "5ede47405b097655935d7d16",
+        "name": "40x46 mm M441(HE)",
+        "shortName": "M441"
+    },
+    "5ede475339ee016e8c534742": {
+        "id": "5ede475339ee016e8c534742",
+        "name": "40x46 mm M576(MP-APERS)",
+        "shortName": "M576"
+    },
+    "5efb0cabfb3e451d70735af5": {
+        "id": "5efb0cabfb3e451d70735af5",
+        "name": ".45 ACP AP",
+        "shortName": ".45 AP"
+    },
+    "5efb0fc6aeb21837e749c801": {
+        "id": "5efb0fc6aeb21837e749c801",
+        "name": ".45 ACP Hydra-Shok",
+        "shortName": ".45 HS"
+    },
+    "5ea2a8e200685063ec28c05a": {
+        "id": "5ea2a8e200685063ec28c05a",
+        "name": ".45 RIP",
+        "shortName": ".45 RIP"
+    },
+    "58820d1224597753c90aeb13": {
+        "id": "58820d1224597753c90aeb13",
+        "name": "12x70 Led slug",
+        "shortName": "12x70 Slug"
+    },
+    "5d6e68b3a4b9361bca7e50b5": {
+        "id": "5d6e68b3a4b9361bca7e50b5",
+        "name": "12/70 HP Slug Copper Sabot Premier",
+        "shortName": "CSP"
+    },
+    "5d6e68d1a4b93622fe60e845": {
+        "id": "5d6e68d1a4b93622fe60e845",
+        "name": "12/70 HP Slug \"SuperFormance\"",
+        "shortName": "SF"
+    },
+    "5e85a9f4add9fe03027d9bf1": {
+        "id": "5e85a9f4add9fe03027d9bf1",
+        "name": "23x75mm \"Star\"",
+        "shortName": "Star"
+    },
+    "5cc86832d7f00c000d3a6e6c": {
+        "id": "5cc86832d7f00c000d3a6e6c",
+        "name": "5.7x28 mm R37.F",
+        "shortName": "R37.F"
+    },
+    "5cc86840d7f00c002412c56c": {
+        "id": "5cc86840d7f00c002412c56c",
+        "name": "5.7x28 mm R37.X",
+        "shortName": "R37.X"
+    },
+    "5fbe3ffdf8b6a877a729ea82": {
+        "id": "5fbe3ffdf8b6a877a729ea82",
+        "name": ".300 BPZ AAC Blackout",
+        "shortName": "BPZ"
+    },
+    "5fd20ff893a8961fc660a954": {
+        "id": "5fd20ff893a8961fc660a954",
+        "name": ".300 AAC Blackout AP",
+        "shortName": "AP"
+    },
+    "5e023e88277cce2b522ff2b1": {
+        "id": "5e023e88277cce2b522ff2b1",
+        "name": "7.62x51 mm Ultra Nosler",
+        "shortName": "Ultra Nosler"
+    },
+    "5fc382a9d724d907e2077dab": {
+        "id": "5fc382a9d724d907e2077dab",
+        "name": ".338 Lapua Magnum AP",
+        "shortName": "AP"
+    },
+    "5fc275cf85fd526b824a571a": {
+        "id": "5fc275cf85fd526b824a571a",
+        "name": ".338 Lapua Magnum FMJ",
+        "shortName": "FMJ"
+    },
+    "5fc382c1016cce60e8341b20": {
+        "id": "5fc382c1016cce60e8341b20",
+        "name": ".338 UPZ Lapua Magnum",
+        "shortName": ".338 UPZ"
+    },
+    "5fc382b6d6fa9c00c571bbc3": {
+        "id": "5fc382b6d6fa9c00c571bbc3",
+        "name": ".338 Lapua Magnum TAC-X",
+        "shortName": "TAC-X"
+    },
+    "5efb0e16aeb21837e749c7ff": {
+        "id": "5efb0e16aeb21837e749c7ff",
+        "name": "9x19 mm QuakeMaker",
+        "shortName": "QuakeMaker"
+    },
+    "5c1127d0d174af29be75cf68": {
+        "id": "5c1127d0d174af29be75cf68",
+        "name": "5 pcs. 12x70 DIPP ammo box",
+        "shortName": "12x70 DIPP"
+    },
+    "57372f5c24597769917c0131": {
+        "id": "57372f5c24597769917c0131",
+        "name": "30 pcs. 5.45x39 T gs ammo pack",
+        "shortName": "T gs"
+    },
+    "5c1262a286f7743f8a69aab2": {
+        "id": "5c1262a286f7743f8a69aab2",
+        "name": "30 pcs. 5.45x39 7N39 ammo pack",
+        "shortName": "7N39"
+    },
+    "573724b42459776125652ac2": {
+        "id": "573724b42459776125652ac2",
+        "name": "16 pcs. 9x18 PM P gzh ammo box",
+        "shortName": "P gzh"
+    },
+    "57372e4a24597768553071c2": {
+        "id": "57372e4a24597768553071c2",
+        "name": "30 pcs. 5.45x39 PRS gs ammo pack",
+        "shortName": "PRS gs"
+    },
+    "5739d41224597779c3645501": {
+        "id": "5739d41224597779c3645501",
+        "name": "16 pcs. 9x19 Pst Gzh ammo box",
+        "shortName": "Pst Gzh"
+    },
+    "57372d1b2459776862260581": {
+        "id": "57372d1b2459776862260581",
+        "name": "120 pcs. 5.45x39 PP gs ammo pack",
+        "shortName": "PP gs"
+    },
+    "5737273924597765dd374461": {
+        "id": "5737273924597765dd374461",
+        "name": "16 pcs. 9x18 PM PSO gzh ammo box",
+        "shortName": "PSO gzh"
+    },
+    "5737256c2459776125652acd": {
+        "id": "5737256c2459776125652acd",
+        "name": "16 pcs. 9x18 PM PMM ammo box",
+        "shortName": "PMM"
+    },
+    "573727c624597765cc785b5b": {
+        "id": "573727c624597765cc785b5b",
+        "name": "16 pcs. 9x18 PM Pst gzh ammo box",
+        "shortName": "Pst gzh"
+    },
+    "5737266524597761006c6a8c": {
+        "id": "5737266524597761006c6a8c",
+        "name": "16 pcs. 9x18 PM PRS gs ammo box",
+        "shortName": "PRS gzh"
+    },
+    "5737280e24597765cc785b5c": {
+        "id": "5737280e24597765cc785b5c",
+        "name": "16 pcs. 9x18 PM PSV ammo box",
+        "shortName": "PSV"
+    },
+    "5737287724597765e1625ae2": {
+        "id": "5737287724597765e1625ae2",
+        "name": "16 pcs. 9x18 PM RG028 gzh ammo box",
+        "shortName": "RG028 gzh"
+    },
+    "57372e73245977685d4159b4": {
+        "id": "57372e73245977685d4159b4",
+        "name": "120 pcs. 5.45x39 PS gs ammo pack",
+        "shortName": "PS gs"
+    },
+    "5737260b24597761224311f2": {
+        "id": "5737260b24597761224311f2",
+        "name": "16 pcs. 9x18 PM PPT gzh ammo box",
+        "shortName": "PPT gzh"
+    },
+    "5447ac644bdc2d6c208b4567": {
+        "id": "5447ac644bdc2d6c208b4567",
+        "name": "5.56x45 M193 Ball ammo",
+        "shortName": "Ball 5.56x45"
+    },
+    "57372ac324597767001bc261": {
+        "id": "57372ac324597767001bc261",
+        "name": "30 pcs. 5.45x39 BP gs ammo pack",
+        "shortName": "BP gs"
+    },
+    "5649ed104bdc2d3d1c8b458b": {
+        "id": "5649ed104bdc2d3d1c8b458b",
+        "name": "7.62x39 PS ammo package",
+        "shortName": "PS 7.62x39"
+    },
+    "5737300424597769942d5a01": {
+        "id": "5737300424597769942d5a01",
+        "name": "30 pcs. 5.45x39 US gs ammo pack",
+        "shortName": "US gs"
+    },
+    "573728f324597765e5728561": {
+        "id": "573728f324597765e5728561",
+        "name": "16 pcs. 9x18 PM SP8 gzh ammo box",
+        "shortName": "SP8 gzh"
+    },
+    "57372c89245977685d4159b1": {
+        "id": "57372c89245977685d4159b1",
+        "name": "30 pcs. 5.45x39 BT gs ammo pack",
+        "shortName": "BT gs"
+    },
+    "57372ebf2459776862260582": {
+        "id": "57372ebf2459776862260582",
+        "name": "30 pcs. 5.45x39 PS gs ammo pack",
+        "shortName": "PS gs"
+    },
+    "5737330a2459776af32363a1": {
+        "id": "5737330a2459776af32363a1",
+        "name": "30 pcs. 5.45x39 FMJ ammo box",
+        "shortName": "FMJ"
+    },
+    "57372c21245977670937c6c2": {
+        "id": "57372c21245977670937c6c2",
+        "name": "120 pcs. 5.45x39 BT gs ammo pack",
+        "shortName": "BT gs"
+    },
+    "5737339e2459776af261abeb": {
+        "id": "5737339e2459776af261abeb",
+        "name": "30 pcs. 5.45x39 HP ammo box",
+        "shortName": "HP"
+    },
+    "560d75f54bdc2da74d8b4573": {
+        "id": "560d75f54bdc2da74d8b4573",
+        "name": "7.62x54 R SNB ammo",
+        "shortName": "SNB 7.62x54 R"
+    },
+    "57372bd3245977670b7cd243": {
+        "id": "57372bd3245977670b7cd243",
+        "name": "30 pcs. 5.45x39 BS gs ammo pack",
+        "shortName": "BS gs"
+    },
+    "57372f7d245977699b53e301": {
+        "id": "57372f7d245977699b53e301",
+        "name": "120 pcs. 5.45x39 US gs ammo pack",
+        "shortName": "US gs"
+    },
+    "57372ee1245977685d4159b5": {
+        "id": "57372ee1245977685d4159b5",
+        "name": "120 pcs. 5.45x39 T gs ammo pack",
+        "shortName": "T gs"
+    },
+    "573722e82459776104581c21": {
+        "id": "573722e82459776104581c21",
+        "name": "16 pcs. 9x18 PM BZHT gzh ammo box",
+        "shortName": "BZHT gzh"
+    },
+    "5737250c2459776125652acc": {
+        "id": "5737250c2459776125652acc",
+        "name": "16 pcs. 9x18 PM PBM ammo box",
+        "shortName": "PBM"
+    },
+    "57372deb245977685d4159b3": {
+        "id": "57372deb245977685d4159b3",
+        "name": "120 pcs. 5.45x39 PRS gs ammo pack",
+        "shortName": "PRS gs"
+    },
+    "573725b0245977612125bae2": {
+        "id": "573725b0245977612125bae2",
+        "name": "16 pcs. 9x18 PM Ppe gzh ammo box",
+        "shortName": "Ppe gzh"
+    },
+    "573733c72459776b0b7b51b0": {
+        "id": "573733c72459776b0b7b51b0",
+        "name": "30 pcs. 5.45x39 SP ammo box",
+        "shortName": "SP"
+    },
+    "57372db0245977685d4159b2": {
+        "id": "57372db0245977685d4159b2",
+        "name": "30 pcs. 5.45x39 PP gs ammo pack",
+        "shortName": "PP gs"
+    },
+    "573728cc24597765cc785b5d": {
+        "id": "573728cc24597765cc785b5d",
+        "name": "16 pcs. 9x18 PM SP7 gzh ammo box",
+        "shortName": "SP7 gzh"
+    },
+    "5737292724597765e5728562": {
+        "id": "5737292724597765e5728562",
+        "name": "120 pcs. 5.45x39 BP gs ammo pack",
+        "shortName": "BP gs"
+    },
+    "57372b832459776701014e41": {
+        "id": "57372b832459776701014e41",
+        "name": "120 pcs. 5.45x39 BS gs ammo pack",
+        "shortName": "BS gs"
+    },
+    "57372a7f24597766fe0de0c1": {
+        "id": "57372a7f24597766fe0de0c1",
+        "name": "120 pcs. 5.45x39 BP gs ammo pack",
+        "shortName": "BP gs"
+    },
+    "5c1260dc86f7746b106e8748": {
+        "id": "5c1260dc86f7746b106e8748",
+        "name": "8 pcs pack of 9x39 7N12 BP ammo",
+        "shortName": "7N12"
+    },
+    "57372bad245977670b7cd242": {
+        "id": "57372bad245977670b7cd242",
+        "name": "120 pcs. 5.45x39 BS gs ammo pack",
+        "shortName": "BS gs"
+    },
+    "57372f2824597769a270a191": {
+        "id": "57372f2824597769a270a191",
+        "name": "120 pcs. 5.45x39 T gs ammo pack",
+        "shortName": "T gs"
+    },
+    "57372c56245977685e584582": {
+        "id": "57372c56245977685e584582",
+        "name": "120 pcs. 5.45x39 BT gs ammo pack",
+        "shortName": "BT gs"
+    },
+    "57372e1924597768553071c1": {
+        "id": "57372e1924597768553071c1",
+        "name": "120 pcs. 5.45x39 PRS gs ammo pack",
+        "shortName": "PRS gs"
+    },
+    "573726d824597765d96be361": {
+        "id": "573726d824597765d96be361",
+        "name": "16 pcs. 9x18 PM PS gs PPO ammo box  ",
+        "shortName": "PS gs PPO"
+    },
+    "5c11279ad174af029d64592b": {
+        "id": "5c11279ad174af029d64592b",
+        "name": "20 pcs pack 5.56x45 Warmage ammo",
+        "shortName": "Warmage"
+    },
+    "57372d4c245977685a3da2a1": {
+        "id": "57372d4c245977685a3da2a1",
+        "name": "120 pcs. 5.45x39 PP gs ammo pack",
+        "shortName": "PP gs"
+    },
+    "57372e94245977685648d3e1": {
+        "id": "57372e94245977685648d3e1",
+        "name": "120 pcs. 5.45x39 PS gs ammo pack",
+        "shortName": "PS gs"
+    },
+    "5c12619186f7743f871c8a32": {
+        "id": "5c12619186f7743f871c8a32",
+        "name": "8 pcs pack of 9x39 7N9 SPP ammo",
+        "shortName": "7N9"
+    },
+    "5c1127bdd174af44217ab8b9": {
+        "id": "5c1127bdd174af44217ab8b9",
+        "name": "20 pcs. 9x19 mm DIPP ammo box",
+        "shortName": "DIPP"
+    },
+    "57372fc52459776998772ca1": {
+        "id": "57372fc52459776998772ca1",
+        "name": "120 pcs. 5.45x39 US gs ammo pack",
+        "shortName": "US gs"
+    },
+    "5449016a4bdc2d6f028b456f": {
+        "id": "5449016a4bdc2d6f028b456f",
+        "name": "Roubles",
+        "shortName": "Roubles"
+    },
+    "5696686a4bdc2da3298b456a": {
+        "id": "5696686a4bdc2da3298b456a",
+        "name": "Dollars",
+        "shortName": "Dollars"
+    },
+    "569668774bdc2da2298b4568": {
+        "id": "569668774bdc2da2298b4568",
+        "name": "Euros",
+        "shortName": "Euros"
+    },
+    "543be5dd4bdc2deb348b4569": {
+        "id": "543be5dd4bdc2deb348b4569",
+        "name": "Money",
+        "shortName": "Item"
+    },
+    "543be5cb4bdc2deb348b4568": {
+        "id": "543be5cb4bdc2deb348b4568",
+        "name": "Ammo container",
+        "shortName": "Item"
+    },
+    "5485a8684bdc2da71d8b4567": {
+        "id": "5485a8684bdc2da71d8b4567",
+        "name": "Ammo",
+        "shortName": "Ammo"
+    },
+    "5a0c27731526d80618476ac4": {
+        "id": "5a0c27731526d80618476ac4",
+        "name": "Zarya stun grenade",
+        "shortName": "Zarya"
+    },
+    "5a2a57cfc4a2826c6e06d44a": {
+        "id": "5a2a57cfc4a2826c6e06d44a",
+        "name": "RDG-2B Smoke grenade",
+        "shortName": "RDG-2B"
+    },
+    "5e32f56fcb6d5863cc5e5ee4": {
+        "id": "5e32f56fcb6d5863cc5e5ee4",
+        "name": "VOG-17 Khattabka grenade",
+        "shortName": "VOG-17"
+    },
+    "5e340dcdcb6d5863cc5e5efb": {
+        "id": "5e340dcdcb6d5863cc5e5efb",
+        "name": "VOG-25 Khattabka grenade",
+        "shortName": "VOG-25"
+    },
+    "5710c24ad2720bc3458b45a3": {
+        "id": "5710c24ad2720bc3458b45a3",
+        "name": "F-1 Hand grenade",
+        "shortName": "F-1"
+    },
+    "58d3db5386f77426186285a0": {
+        "id": "58d3db5386f77426186285a0",
+        "name": "M67 Hand grenade",
+        "shortName": "M67"
+    },
+    "5448be9a4bdc2dfd2f8b456a": {
+        "id": "5448be9a4bdc2dfd2f8b456a",
+        "name": "RGD-5 hand grenade",
+        "shortName": "RGD-5"
+    },
+    "5661632d4bdc2d903d8b456b": {
+        "id": "5661632d4bdc2d903d8b456b",
+        "name": "Stackable item",
+        "shortName": "Item"
+    },
+    "5447e0e74bdc2d3c308b4567": {
+        "id": "5447e0e74bdc2d3c308b4567",
+        "name": "Special item",
+        "shortName": "Item"
+    },
+    "566162e44bdc2d3f298b4573": {
+        "id": "566162e44bdc2d3f298b4573",
+        "name": "Compound item",
+        "shortName": "Item"
+    },
+    "567849dd4bdc2d150f8b456e": {
+        "id": "567849dd4bdc2d150f8b456e",
+        "name": "Map",
+        "shortName": "Item"
+    },
+    "5448eb774bdc2d0a728b4567": {
+        "id": "5448eb774bdc2d0a728b4567",
+        "name": "Barter item",
+        "shortName": "Item"
+    },
+    "5448ecbe4bdc2d60728b4568": {
+        "id": "5448ecbe4bdc2d60728b4568",
+        "name": "Info",
+        "shortName": "Item"
+    },
+    "543be5e94bdc2df1348b4568": {
+        "id": "543be5e94bdc2df1348b4568",
+        "name": "Key",
+        "shortName": "Item"
+    },
+    "543be6674bdc2df1348b4569": {
+        "id": "543be6674bdc2df1348b4569",
+        "name": "Food and drink",
+        "shortName": "Item"
+    },
+    "543be5664bdc2dd4348b4569": {
+        "id": "543be5664bdc2dd4348b4569",
+        "name": "Meds",
+        "shortName": "Item"
+    },
+    "543be6564bdc2df4348b4568": {
+        "id": "543be6564bdc2df4348b4568",
+        "name": "Throwable weapon",
+        "shortName": "Item"
+    },
+    "5447e1d04bdc2dff2f8b4567": {
+        "id": "5447e1d04bdc2dff2f8b4567",
+        "name": "Knife",
+        "shortName": "Item"
+    },
+    "557ff21e4bdc2d89578b4586": {
+        "id": "557ff21e4bdc2d89578b4586",
+        "name": "Tactical glasses",
+        "shortName": "TGlass"
+    },
+    "59e770b986f7742cbd762754": {
+        "id": "59e770b986f7742cbd762754",
+        "name": "Anti-fragmentation glasses",
+        "shortName": "AFGlass"
+    }
+}

--- a/quests.json
+++ b/quests.json
@@ -32,7 +32,8 @@
                 "target": "MP-133 12ga shotgun",
                 "number": 2,
                 "location": "Any",
-                "id": "54491c4f4bdc2db1078b4568"
+                "id": 1,
+                "bsgId": "54491c4f4bdc2db1078b4568"
             }
         ]
     },
@@ -280,7 +281,8 @@
                 "number": 3,
                 "location": "Any",
                 "have": 0,
-                "id": "55d482194bdc2d1d4e8b456b"
+                "id": 12,
+                "bsgId": "55d482194bdc2d1d4e8b456b"
             }
         ]
     },
@@ -590,7 +592,8 @@
                 "target": "Lower half-mask",
                 "number": 7,
                 "location": "Any",
-                "id": "572b7fa524597762b747ce82"
+                "id": 27,
+                "bsgId": "572b7fa524597762b747ce82"
             }
         ]
     },
@@ -684,7 +687,8 @@
                 "target": "Bars A-2607- 95x18",
                 "number": 5,
                 "location": "Any",
-                "id": "57e26fc7245977162a14b800"
+                "id": 31,
+                "bsgId": "57e26fc7245977162a14b800"
             }
         ]
     },
@@ -727,21 +731,24 @@
                 "target": "AK-74N 5.45x39 assault rifle",
                 "number": 1,
                 "location": "Any",
-                "id": "5644bd2b4bdc2d3b4c8b4572"
+                "id": 33,
+                "bsgId": "5644bd2b4bdc2d3b4c8b4572"
             },
             {
                 "type": "find",
                 "target": "Colt M4A1 5.56x45 Assault Rifle",
                 "number": 1,
                 "location": "Any",
-                "id": "5447a9cd4bdc2dbd208b4567"
+                "id": 34,
+                "bsgId": "5447a9cd4bdc2dbd208b4567"
             },
             {
                 "type": "find",
                 "target": "PM 9x18PM pistol",
                 "number": 2,
                 "location": "Any",
-                "id": "5448bd6b4bdc2dfc2f8b4569"
+                "id": 35,
+                "bsgId": "5448bd6b4bdc2dfc2f8b4569"
             }
         ]
     },
@@ -789,14 +796,16 @@
                 "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
-                "id": "59f32c3b86f77472a31742f0"
+                "id": 37,
+                "bsgId": "59f32c3b86f77472a31742f0"
             },
             {
                 "type": "collect",
                 "target": "Dogtag BEAR",
                 "number": 7,
                 "location": "Any",
-                "id": "59f32bb586f774757e1e8442"
+                "id": 38,
+                "bsgId": "59f32bb586f774757e1e8442"
             }
         ]
     },
@@ -824,7 +833,8 @@
                 "target": "Salewa First Aid Kit",
                 "number": 3,
                 "location": "Any",
-                "id": "544fb45d4bdc2dee738b4568"
+                "id": 39,
+                "bsgId": "544fb45d4bdc2dee738b4568"
             }
         ]
     },
@@ -856,7 +866,8 @@
                 "target": "Gas analyzer",
                 "number": 1,
                 "location": "Any",
-                "id": "590a3efd86f77437d351a25b"
+                "id": 40,
+                "bsgId": "590a3efd86f77437d351a25b"
             }
         ]
     },
@@ -886,7 +897,8 @@
                 "target": "Gas analyzer",
                 "number": 2,
                 "location": "Any",
-                "id": "590a3efd86f77437d351a25b"
+                "id": 41,
+                "bsgId": "590a3efd86f77437d351a25b"
             }
         ]
     },
@@ -917,7 +929,8 @@
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": "544fb3f34bdc2d03748b456a"
+                "id": 42,
+                "bsgId": "544fb3f34bdc2d03748b456a"
             }
         ]
     },
@@ -1060,7 +1073,8 @@
                 "target": "Can of beef stew",
                 "number": 15,
                 "location": "Any",
-                "id": "57347d7224597744596b4e72"
+                "id": 47,
+                "bsgId": "57347d7224597744596b4e72"
             }
         ]
     },
@@ -1091,7 +1105,8 @@
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": "5733279d245977289b77ec24"
+                "id": 48,
+                "bsgId": "5733279d245977289b77ec24"
             },
             {
                 "type": "find",
@@ -1099,7 +1114,8 @@
                 "number": 8,
                 "location": "Any",
                 "have": 0,
-                "id": "590a3c0a86f774385a33c450"
+                "id": 49,
+                "bsgId": "590a3c0a86f774385a33c450"
             }
         ]
     },
@@ -1345,14 +1361,16 @@
                 "target": "Ophthalmoscope",
                 "number": 1,
                 "location": "Any",
-                "id": "5af0534a86f7743b6f354284"
+                "id": 59,
+                "bsgId": "5af0534a86f7743b6f354284"
             },
             {
                 "type": "find",
                 "target": "LEDX Skin Transilluminator",
                 "number": 1,
                 "location": "Any",
-                "id": "5c0530ee86f774697952d952"
+                "id": 60,
+                "bsgId": "5c0530ee86f774697952d952"
             }
         ]
     },
@@ -1414,14 +1432,16 @@
                 "target": "Module-3M bodyarmor",
                 "number": 1,
                 "location": "Any",
-                "id": "59e7635f86f7742cbf2c1095"
+                "id": 62,
+                "bsgId": "59e7635f86f7742cbf2c1095"
             },
             {
                 "type": "find",
                 "target": "TOZ-106 bolt-action shotgun",
                 "number": 1,
                 "location": "Any",
-                "id": "5a38e6bac4a2826c6e06d79b"
+                "id": 63,
+                "bsgId": "5a38e6bac4a2826c6e06d79b"
             }
         ]
     },
@@ -1492,7 +1512,8 @@
                 "target": "Secure Flash drive",
                 "number": 2,
                 "location": "Any",
-                "id": "590c621186f774138d11ea29"
+                "id": 66,
+                "bsgId": "590c621186f774138d11ea29"
             }
         ]
     },
@@ -1805,14 +1826,16 @@
                 "target": "Respirator",
                 "number": 4,
                 "location": "Any",
-                "id": "59e7715586f7742ee5789605"
+                "id": 83,
+                "bsgId": "59e7715586f7742ee5789605"
             },
             {
                 "type": "find",
                 "target": "Medical bloodset",
                 "number": 3,
                 "location": "Any",
-                "id": "5b4335ba86f7744d2837a264"
+                "id": 84,
+                "bsgId": "5b4335ba86f7744d2837a264"
             }
         ]
     },
@@ -1852,7 +1875,8 @@
                 "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
-                "id": "59f32c3b86f77472a31742f0"
+                "id": 85,
+                "bsgId": "59f32c3b86f77472a31742f0"
             }
         ]
     },
@@ -1882,7 +1906,8 @@
                 "target": "Dollars",
                 "number": 6000,
                 "location": "Any",
-                "id": "5696686a4bdc2da3298b456a"
+                "id": 87,
+                "bsgId": "5696686a4bdc2da3298b456a"
             }
         ]
     },
@@ -1989,14 +2014,16 @@
                 "target": "Virtex programmable processor",
                 "number": 2,
                 "location": "Any",
-                "id": "5c05308086f7746b2101e90b"
+                "id": 95,
+                "bsgId": "5c05308086f7746b2101e90b"
             },
             {
                 "type": "find",
                 "target": "Military COFDM wireless Signal Transmitter",
                 "number": 1,
                 "location": "Any",
-                "id": "5c052f6886f7746b1e3db148"
+                "id": 96,
+                "bsgId": "5c052f6886f7746b1e3db148"
             }
         ]
     },
@@ -2577,7 +2604,8 @@
                 "target": "MRE lunch box",
                 "number": 5,
                 "location": "Any",
-                "id": "590c5f0d86f77413997acfab"
+                "id": 128,
+                "bsgId": "590c5f0d86f77413997acfab"
             },
             {
                 "type": "kill",
@@ -2786,28 +2814,32 @@
                 "target": "WD-40 100ml.",
                 "number": 1,
                 "location": "Any",
-                "id": "590c5bbd86f774785762df04"
+                "id": 138,
+                "bsgId": "590c5bbd86f774785762df04"
             },
             {
                 "type": "find",
                 "target": "Clin wiper",
                 "number": 2,
                 "location": "Any",
-                "id": "59e358a886f7741776641ac3"
+                "id": 139,
+                "bsgId": "59e358a886f7741776641ac3"
             },
             {
                 "type": "find",
                 "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
-                "id": "59e35cbb86f7741778269d83"
+                "id": 140,
+                "bsgId": "59e35cbb86f7741778269d83"
             },
             {
                 "type": "find",
                 "target": "Ox bleach",
                 "number": 2,
                 "location": "Any",
-                "id": "59e3556c86f7741776641ac2"
+                "id": 141,
+                "bsgId": "59e3556c86f7741776641ac2"
             }
         ]
     },
@@ -2911,7 +2943,8 @@
                 "target": "Dollars",
                 "number": 8000,
                 "location": "Any",
-                "id": "5696686a4bdc2da3298b456a"
+                "id": 146,
+                "bsgId": "5696686a4bdc2da3298b456a"
             }
         ]
     },
@@ -2945,28 +2978,32 @@
                 "target": "Morphine injector",
                 "number": 4,
                 "location": "Any",
-                "id": "544fb3f34bdc2d03748b456a"
+                "id": 147,
+                "bsgId": "544fb3f34bdc2d03748b456a"
             },
             {
                 "type": "find",
                 "target": "Heat-exchange alkali surface washer",
                 "number": 2,
                 "location": "Any",
-                "id": "59faf98186f774067b6be103"
+                "id": 148,
+                "bsgId": "59faf98186f774067b6be103"
             },
             {
                 "type": "find",
                 "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
-                "id": "59e35cbb86f7741778269d83"
+                "id": 149,
+                "bsgId": "59e35cbb86f7741778269d83"
             },
             {
                 "type": "find",
                 "target": "5L propane tank",
                 "number": 2,
                 "location": "Any",
-                "id": "59fafb5d86f774067a6f2084"
+                "id": 150,
+                "bsgId": "59fafb5d86f774067a6f2084"
             }
         ]
     },
@@ -3736,28 +3773,32 @@
                 "target": "PC CPU",
                 "number": 3,
                 "location": "Any",
-                "id": "573477e124597737dd42e191"
+                "id": 165,
+                "bsgId": "573477e124597737dd42e191"
             },
             {
                 "type": "find",
                 "target": "Rechargeable battery",
                 "number": 3,
                 "location": "Any",
-                "id": "590a358486f77429692b2790"
+                "id": 166,
+                "bsgId": "590a358486f77429692b2790"
             },
             {
                 "type": "find",
                 "target": "Printed circuit board",
                 "number": 3,
                 "location": "Any",
-                "id": "590a3b0486f7743954552bdb"
+                "id": 167,
+                "bsgId": "590a3b0486f7743954552bdb"
             },
             {
                 "type": "find",
                 "target": "Broken GPhone",
                 "number": 3,
                 "location": "Any",
-                "id": "56742c324bdc2d150f8b456d"
+                "id": 168,
+                "bsgId": "56742c324bdc2d150f8b456d"
             }
         ]
     },
@@ -3984,21 +4025,24 @@
                 "target": "Powercord",
                 "number": 2,
                 "location": "Any",
-                "id": "59e36c6f86f774176c10a2a7"
+                "id": 179,
+                "bsgId": "59e36c6f86f774176c10a2a7"
             },
             {
                 "type": "find",
                 "target": "T-Shaped Plug",
                 "number": 4,
                 "location": "Any",
-                "id": "57347cd0245977445a2d6ff1"
+                "id": 180,
+                "bsgId": "57347cd0245977445a2d6ff1"
             },
             {
                 "type": "find",
                 "target": "Printed circuit board",
                 "number": 2,
                 "location": "Any",
-                "id": "590a3b0486f7743954552bdb"
+                "id": 181,
+                "bsgId": "590a3b0486f7743954552bdb"
             }
         ]
     },
@@ -4065,14 +4109,16 @@
                 "target": "Graphics card",
                 "number": 3,
                 "location": "Any",
-                "id": "57347ca924597744596b4e71"
+                "id": 184,
+                "bsgId": "57347ca924597744596b4e71"
             },
             {
                 "type": "find",
                 "target": "CPU Fan",
                 "number": 8,
                 "location": "Any",
-                "id": "5734779624597737e04bf329"
+                "id": 185,
+                "bsgId": "5734779624597737e04bf329"
             }
         ]
     },
@@ -4103,14 +4149,16 @@
                 "target": "UHF RFID Reader",
                 "number": 1,
                 "location": "Any",
-                "id": "5c052fb986f7746b2101e909"
+                "id": 186,
+                "bsgId": "5c052fb986f7746b2101e909"
             },
             {
                 "type": "find",
                 "target": "VPX Flash Storage Module",
                 "number": 1,
                 "location": "Any",
-                "id": "5c05300686f7746dce784e5d"
+                "id": 187,
+                "bsgId": "5c05300686f7746dce784e5d"
             }
         ]
     },
@@ -4140,14 +4188,16 @@
                 "target": "Wires",
                 "number": 5,
                 "location": "Any",
-                "id": "5c06779c86f77426e00dd782"
+                "id": 188,
+                "bsgId": "5c06779c86f77426e00dd782"
             },
             {
                 "type": "find",
                 "target": "Capacitors",
                 "number": 5,
                 "location": "Any",
-                "id": "5c06782b86f77426df5407d2"
+                "id": 189,
+                "bsgId": "5c06782b86f77426df5407d2"
             }
         ]
     },
@@ -4376,14 +4426,16 @@
                 "target": "Ushanka ear-flap cap",
                 "number": 2,
                 "location": "Any",
-                "id": "59e7708286f7742cbd762753"
+                "id": 203,
+                "bsgId": "59e7708286f7742cbd762753"
             },
             {
                 "type": "find",
                 "target": "Kinda cowboy hat",
                 "number": 2,
                 "location": "Any",
-                "id": "5aa2b9ede5b5b000137b758b"
+                "id": 204,
+                "bsgId": "5aa2b9ede5b5b000137b758b"
             }
         ]
     },
@@ -4576,7 +4628,8 @@
                 "target": "Key to Goshan cash register",
                 "number": 1,
                 "location": "Any",
-                "id": "5ad7247386f7747487619dc3"
+                "id": 214,
+                "bsgId": "5ad7247386f7747487619dc3"
             }
         ]
     },
@@ -4763,14 +4816,16 @@
                 "target": "Ski hat with holes for eyes",
                 "number": 1,
                 "location": "Any",
-                "id": "5ab8f20c86f7745cdb629fb2"
+                "id": 223,
+                "bsgId": "5ab8f20c86f7745cdb629fb2"
             },
             {
                 "type": "find",
                 "target": "Pilgrim tourist backpack",
                 "number": 1,
                 "location": "Any",
-                "id": "59e763f286f7742ee57895da"
+                "id": 224,
+                "bsgId": "59e763f286f7742ee57895da"
             }
         ]
     },
@@ -4801,7 +4856,8 @@
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": "5ab8e79e86f7742d8b372e78"
+                "id": 225,
+                "bsgId": "5ab8e79e86f7742d8b372e78"
             },
             {
                 "type": "collect",
@@ -4809,7 +4865,8 @@
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": "5ab8e79e86f7742d8b372e78"
+                "id": 226,
+                "bsgId": "5ab8e79e86f7742d8b372e78"
             }
         ]
     },
@@ -4840,7 +4897,8 @@
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": "545cdb794bdc2d3a198b456a"
+                "id": 227,
+                "bsgId": "545cdb794bdc2d3a198b456a"
             },
             {
                 "type": "collect",
@@ -4848,7 +4906,8 @@
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": "545cdb794bdc2d3a198b456a"
+                "id": 228,
+                "bsgId": "545cdb794bdc2d3a198b456a"
             }
         ]
     },
@@ -4878,14 +4937,16 @@
                 "target": "Wartech gear rig (TV-109, TV-106)",
                 "number": 2,
                 "location": "Any",
-                "id": "59e7643b86f7742cbf2c109a"
+                "id": 229,
+                "bsgId": "59e7643b86f7742cbf2c109a"
             },
             {
                 "type": "find",
                 "target": "BlackRock chest rig",
                 "number": 2,
                 "location": "Any",
-                "id": "5648a69d4bdc2ded0b8b457b"
+                "id": 230,
+                "bsgId": "5648a69d4bdc2ded0b8b457b"
             }
         ]
     },
@@ -4976,7 +5037,8 @@
                 "target": "Fuel conditioner",
                 "number": 4,
                 "location": "Any",
-                "id": "5b43575a86f77424f443fe62"
+                "id": 233,
+                "bsgId": "5b43575a86f77424f443fe62"
             }
         ]
     },
@@ -5057,28 +5119,32 @@
                 "target": "Bronze lion",
                 "number": 2,
                 "location": "Any",
-                "id": "59e3639286f7741777737013"
+                "id": 237,
+                "bsgId": "59e3639286f7741777737013"
             },
             {
                 "type": "find",
                 "target": "Horse figurine",
                 "number": 2,
                 "location": "Any",
-                "id": "573478bc24597738002c6175"
+                "id": 238,
+                "bsgId": "573478bc24597738002c6175"
             },
             {
                 "type": "find",
                 "target": "Cat figurine",
                 "number": 1,
                 "location": "Any",
-                "id": "59e3658a86f7741776641ac4"
+                "id": 239,
+                "bsgId": "59e3658a86f7741776641ac4"
             },
             {
                 "type": "find",
                 "target": "Roler submariner gold wrist watch",
                 "number": 1,
                 "location": "Any",
-                "id": "59faf7ca86f7740dbe19f6c2"
+                "id": 240,
+                "bsgId": "59faf7ca86f7740dbe19f6c2"
             }
         ]
     },
@@ -5108,14 +5174,16 @@
                 "target": "Antique teapot",
                 "number": 3,
                 "location": "Any",
-                "id": "590de71386f774347051a052"
+                "id": 241,
+                "bsgId": "590de71386f774347051a052"
             },
             {
                 "type": "find",
                 "target": "Antique vase",
                 "number": 2,
                 "location": "Any",
-                "id": "590de7e986f7741b096e5f32"
+                "id": 242,
+                "bsgId": "590de7e986f7741b096e5f32"
             }
         ]
     },
@@ -5173,21 +5241,24 @@
                 "target": "Iskra lunch box",
                 "number": 3,
                 "location": "Any",
-                "id": "590c5d4b86f774784e1b9c45"
+                "id": 244,
+                "bsgId": "590c5d4b86f774784e1b9c45"
             },
             {
                 "type": "find",
                 "target": "Emelya rye croutons",
                 "number": 2,
                 "location": "Any",
-                "id": "5751487e245977207e26a315"
+                "id": 245,
+                "bsgId": "5751487e245977207e26a315"
             },
             {
                 "type": "find",
                 "target": "Can of delicious beef stew",
                 "number": 2,
                 "location": "Any",
-                "id": "57347da92459774491567cf5"
+                "id": 246,
+                "bsgId": "57347da92459774491567cf5"
             }
         ]
     },
@@ -5836,28 +5907,32 @@
                 "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515f6915ec335206e4152"
+                "id": 322,
+                "bsgId": "5ed515f6915ec335206e4152"
             },
             {
                 "type": "find",
                 "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515c8d380ab312177c0fa"
+                "id": 323,
+                "bsgId": "5ed515c8d380ab312177c0fa"
             },
             {
                 "type": "collect",
                 "target": "Lab. Blue keycard",
                 "number": 1,
                 "location": "Any",
-                "id": "5c1d0c5f86f7744bb2683cf0"
+                "id": 324,
+                "bsgId": "5c1d0c5f86f7744bb2683cf0"
             },
             {
                 "type": "collect",
                 "target": "Lab. Green keycard",
                 "number": 1,
                 "location": "Any",
-                "id": "5c1d0dc586f7744baf2e7b79"
+                "id": 325,
+                "bsgId": "5c1d0dc586f7744baf2e7b79"
             }
         ],
         "alternatives": [
@@ -5920,14 +5995,16 @@
                 "target": "CMS kit",
                 "number": 2,
                 "location": "Any",
-                "id": "5d02778e86f774203e7dedbe"
+                "id": 271,
+                "bsgId": "5d02778e86f774203e7dedbe"
             },
             {
                 "type": "find",
                 "target": "Portable defibrillator",
                 "number": 1,
                 "location": "Any",
-                "id": "5c052e6986f7746b207bc3c9"
+                "id": 272,
+                "bsgId": "5c052e6986f7746b207bc3c9"
             }
         ]
     },
@@ -6118,7 +6195,8 @@
                 "target": "TerraGroup Labs access keycard",
                 "number": 2,
                 "location": "Any",
-                "id": "5c94bbff86f7747ee735c08f"
+                "id": 278,
+                "bsgId": "5c94bbff86f7747ee735c08f"
             }
         ]
     },
@@ -6155,7 +6233,8 @@
                 "target": "TT pistol 7.62x25 TT Gold",
                 "number": 1,
                 "location": "Customs",
-                "id": "5b3b713c5acfc4330140bd8d"
+                "id": 280,
+                "bsgId": "5b3b713c5acfc4330140bd8d"
             }
         ]
     },
@@ -6226,7 +6305,8 @@
                 "target": "Maska 1Sch helmet (Killa)",
                 "number": 1,
                 "location": "Interchange",
-                "id": "5c0e874186f7745dc7616606"
+                "id": 283,
+                "bsgId": "5c0e874186f7745dc7616606"
             }
         ]
     },
@@ -6263,7 +6343,8 @@
                 "target": "Shturman key",
                 "number": 1,
                 "location": "Woods",
-                "id": "5d08d21286f774736e7c94c3"
+                "id": 285,
+                "bsgId": "5d08d21286f774736e7c94c3"
             }
         ]
     },
@@ -6497,14 +6578,16 @@
                 "target": "6-STEN-140-M military battery",
                 "number": 1,
                 "location": "Any",
-                "id": "5d03794386f77420415576f5"
+                "id": 293,
+                "bsgId": "5d03794386f77420415576f5"
             },
             {
                 "type": "find",
                 "target": "OFZ 30x160mm shell",
                 "number": 5,
                 "location": "Any",
-                "id": "5d0379a886f77420407aa271"
+                "id": 294,
+                "bsgId": "5d0379a886f77420407aa271"
             }
         ]
     },
@@ -6571,7 +6654,8 @@
                 "target": "Euros",
                 "number": 50000,
                 "location": "Any",
-                "id": "569668774bdc2da2298b4568"
+                "id": 296,
+                "bsgId": "569668774bdc2da2298b4568"
             }
         ]
     },
@@ -6601,21 +6685,24 @@
                 "target": "Malboro cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": "573476d324597737da2adc13"
+                "id": 297,
+                "bsgId": "573476d324597737da2adc13"
             },
             {
                 "type": "find",
                 "target": "Strike cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": "5734770f24597738025ee254"
+                "id": 298,
+                "bsgId": "5734770f24597738025ee254"
             },
             {
                 "type": "find",
                 "target": "Wilston cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": "573476f124597737e04bf328"
+                "id": 299,
+                "bsgId": "573476f124597737e04bf328"
             }
         ]
     },
@@ -6684,7 +6771,8 @@
                 "target": "Secure Flash drive",
                 "number": 3,
                 "location": "Any",
-                "id": "590c621186f774138d11ea29"
+                "id": 302,
+                "bsgId": "590c621186f774138d11ea29"
             }
         ]
     },
@@ -6862,21 +6950,24 @@
                 "target": "Aramid fiber cloth",
                 "number": 5,
                 "location": "Any",
-                "id": "5e2af4d286f7746d4159f07a"
+                "id": 306,
+                "bsgId": "5e2af4d286f7746d4159f07a"
             },
             {
                 "type": "find",
                 "target": "Ripstop cloth",
                 "number": 10,
                 "location": "Any",
-                "id": "5e2af4a786f7746d3f3c3400"
+                "id": 307,
+                "bsgId": "5e2af4a786f7746d3f3c3400"
             },
             {
                 "type": "find",
                 "target": "Paracord",
                 "number": 3,
                 "location": "Any",
-                "id": "5c12688486f77426843c7d32"
+                "id": 308,
+                "bsgId": "5c12688486f77426843c7d32"
             }
         ]
     },
@@ -6902,21 +6993,24 @@
                 "target": "Fleece cloth",
                 "number": 10,
                 "location": "Any",
-                "id": "5e2af47786f7746d404f3aaa"
+                "id": 309,
+                "bsgId": "5e2af47786f7746d404f3aaa"
             },
             {
                 "type": "find",
                 "target": "Polyamide fabric Cordura",
                 "number": 10,
                 "location": "Any",
-                "id": "5e2af41e86f774755a234b67"
+                "id": 310,
+                "bsgId": "5e2af41e86f774755a234b67"
             },
             {
                 "type": "find",
                 "target": "KEKTAPE duct tape",
                 "number": 5,
                 "location": "Any",
-                "id": "5e2af29386f7746d4159f077"
+                "id": 311,
+                "bsgId": "5e2af29386f7746d4159f077"
             }
         ]
     },
@@ -7131,49 +7225,56 @@
                 "target": "M.U.L.E. stimulator",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed51652f6c34d2cc26336a1"
+                "id": 331,
+                "bsgId": "5ed51652f6c34d2cc26336a1"
             },
             {
                 "type": "find",
                 "target": "Cocktail \"Obdolbos\"",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed5166ad380ab312177c100"
+                "id": 332,
+                "bsgId": "5ed5166ad380ab312177c100"
             },
             {
                 "type": "find",
                 "target": "Meldonin",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed5160a87bb8443d10680b5"
+                "id": 333,
+                "bsgId": "5ed5160a87bb8443d10680b5"
             },
             {
                 "type": "find",
                 "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515f6915ec335206e4152"
+                "id": 334,
+                "bsgId": "5ed515f6915ec335206e4152"
             },
             {
                 "type": "find",
                 "target": "P22",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515ece452db0eb56fc028"
+                "id": 335,
+                "bsgId": "5ed515ece452db0eb56fc028"
             },
             {
                 "type": "find",
                 "target": "L1 (Norepinephrine)",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515e03a40a50460332579"
+                "id": 336,
+                "bsgId": "5ed515e03a40a50460332579"
             },
             {
                 "type": "find",
                 "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
-                "id": "5ed515c8d380ab312177c0fa"
+                "id": 337,
+                "bsgId": "5ed515c8d380ab312177c0fa"
             }
         ]
     },
@@ -7530,126 +7631,144 @@
                 "target": "Old firesteel",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9c377d4351e3bac12251b"
+                "id": 353,
+                "bsgId": "5bc9c377d4351e3bac12251b"
             },
             {
                 "type": "find",
                 "target": "Antique axe",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9c1e2d4351e00367fbcf0"
+                "id": 354,
+                "bsgId": "5bc9c1e2d4351e00367fbcf0"
             },
             {
                 "type": "find",
                 "target": "Battered antique Book",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9c049d4351e44f824d360"
+                "id": 355,
+                "bsgId": "5bc9c049d4351e44f824d360"
             },
             {
                 "type": "find",
                 "target": "#FireKlean gun lube",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9b355d4351e6d1509862a"
+                "id": 356,
+                "bsgId": "5bc9b355d4351e6d1509862a"
             },
             {
                 "type": "find",
                 "target": "Golden rooster",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9bc53d4351e00367fbcee"
+                "id": 357,
+                "bsgId": "5bc9bc53d4351e00367fbcee"
             },
             {
                 "type": "find",
                 "target": "Silver Badge",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9bdb8d4351e003562b8a1"
+                "id": 358,
+                "bsgId": "5bc9bdb8d4351e003562b8a1"
             },
             {
                 "type": "find",
                 "target": "Deadlyslob's beard oil",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9b9ecd4351e3bac122519"
+                "id": 359,
+                "bsgId": "5bc9b9ecd4351e3bac122519"
             },
             {
                 "type": "find",
                 "target": "Golden 1GPhone",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9b720d4351e450201234b"
+                "id": 360,
+                "bsgId": "5bc9b720d4351e450201234b"
             },
             {
                 "type": "find",
                 "target": "Jar of DevilDog mayo",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9b156d4351e00367fbce9"
+                "id": 361,
+                "bsgId": "5bc9b156d4351e00367fbce9"
             },
             {
                 "type": "find",
                 "target": "Can of sprats",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9c29cd4351e003562b8a3"
+                "id": 362,
+                "bsgId": "5bc9c29cd4351e003562b8a3"
             },
             {
                 "type": "find",
                 "target": "Fake mustache",
                 "number": 1,
                 "location": "Any",
-                "id": "5bd073a586f7747e6f135799"
+                "id": 363,
+                "bsgId": "5bd073a586f7747e6f135799"
             },
             {
                 "type": "find",
                 "target": "Kotton beanie",
                 "number": 1,
                 "location": "Any",
-                "id": "5bd073c986f7747f627e796c"
+                "id": 364,
+                "bsgId": "5bd073c986f7747f627e796c"
             },
             {
                 "type": "find",
                 "target": "Can of Dr. Lupo's coffee beans",
                 "number": 1,
                 "location": "Any",
-                "id": "5e54f6af86f7742199090bf3"
+                "id": 365,
+                "bsgId": "5e54f6af86f7742199090bf3"
             },
             {
                 "type": "find",
                 "target": "Pestily plague mask",
                 "number": 1,
                 "location": "Any",
-                "id": "5e54f79686f7744022011103"
+                "id": 366,
+                "bsgId": "5e54f79686f7744022011103"
             },
             {
                 "type": "find",
                 "target": "Raven figurine",
                 "number": 1,
                 "location": "Any",
-                "id": "5e54f62086f774219b0f1937"
+                "id": 367,
+                "bsgId": "5e54f62086f774219b0f1937"
             },
             {
                 "type": "find",
                 "target": "Shroud half-mask",
                 "number": 1,
                 "location": "Any",
-                "id": "5e54f76986f7740366043752"
+                "id": 368,
+                "bsgId": "5e54f76986f7740366043752"
             },
             {
                 "type": "find",
                 "target": "Veritas guitar pick",
                 "number": 1,
                 "location": "Any",
-                "id": "5f745ee30acaeb0d490d8c5b"
+                "id": 369,
+                "bsgId": "5f745ee30acaeb0d490d8c5b"
             },
             {
                 "type": "find",
                 "target": "42nd Signature Blend English Tea",
                 "number": 1,
                 "location": "Any",
-                "id": "5bc9be8fd4351e00334cae6e"
+                "id": 370,
+                "bsgId": "5bc9be8fd4351e00334cae6e"
             }
         ]
     },
@@ -7673,7 +7792,7 @@
                 "target": "Rubles",
                 "number": 400000,
                 "location": "Any",
-                "id": "5449016a4bdc2d6f028b456f"
+                "id": 372
             }
         ]
     }

--- a/quests.json
+++ b/quests.json
@@ -32,7 +32,7 @@
                 "target": "MP-133 12ga shotgun",
                 "number": 2,
                 "location": "Any",
-                "id": 1
+                "id": "54491c4f4bdc2db1078b4568"
             }
         ]
     },
@@ -280,7 +280,7 @@
                 "number": 3,
                 "location": "Any",
                 "have": 0,
-                "id": 12
+                "id": "55d482194bdc2d1d4e8b456b"
             }
         ]
     },
@@ -590,7 +590,7 @@
                 "target": "Lower half-mask",
                 "number": 7,
                 "location": "Any",
-                "id": 27
+                "id": "572b7fa524597762b747ce82"
             }
         ]
     },
@@ -684,7 +684,7 @@
                 "target": "Bars A-2607- 95x18",
                 "number": 5,
                 "location": "Any",
-                "id": 31
+                "id": "57e26fc7245977162a14b800"
             }
         ]
     },
@@ -727,21 +727,21 @@
                 "target": "AK-74N 5.45x39 assault rifle",
                 "number": 1,
                 "location": "Any",
-                "id": 33
+                "id": "5644bd2b4bdc2d3b4c8b4572"
             },
             {
                 "type": "find",
                 "target": "Colt M4A1 5.56x45 Assault Rifle",
                 "number": 1,
                 "location": "Any",
-                "id": 34
+                "id": "5447a9cd4bdc2dbd208b4567"
             },
             {
                 "type": "find",
                 "target": "PM 9x18PM pistol",
                 "number": 2,
                 "location": "Any",
-                "id": 35
+                "id": "5448bd6b4bdc2dfc2f8b4569"
             }
         ]
     },
@@ -789,14 +789,14 @@
                 "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
-                "id": 37
+                "id": "59f32c3b86f77472a31742f0"
             },
             {
                 "type": "collect",
                 "target": "Dogtag BEAR",
                 "number": 7,
                 "location": "Any",
-                "id": 38
+                "id": "59f32bb586f774757e1e8442"
             }
         ]
     },
@@ -824,7 +824,7 @@
                 "target": "Salewa First Aid Kit",
                 "number": 3,
                 "location": "Any",
-                "id": 39
+                "id": "544fb45d4bdc2dee738b4568"
             }
         ]
     },
@@ -856,7 +856,7 @@
                 "target": "Gas analyzer",
                 "number": 1,
                 "location": "Any",
-                "id": 40
+                "id": "590a3efd86f77437d351a25b"
             }
         ]
     },
@@ -886,7 +886,7 @@
                 "target": "Gas analyzer",
                 "number": 2,
                 "location": "Any",
-                "id": 41
+                "id": "590a3efd86f77437d351a25b"
             }
         ]
     },
@@ -917,7 +917,7 @@
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": 42
+                "id": "544fb3f34bdc2d03748b456a"
             }
         ]
     },
@@ -1060,7 +1060,7 @@
                 "target": "Can of beef stew",
                 "number": 15,
                 "location": "Any",
-                "id": 47
+                "id": "57347d7224597744596b4e72"
             }
         ]
     },
@@ -1091,7 +1091,7 @@
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": 48
+                "id": "5733279d245977289b77ec24"
             },
             {
                 "type": "find",
@@ -1099,7 +1099,7 @@
                 "number": 8,
                 "location": "Any",
                 "have": 0,
-                "id": 49
+                "id": "590a3c0a86f774385a33c450"
             }
         ]
     },
@@ -1345,14 +1345,14 @@
                 "target": "Ophthalmoscope",
                 "number": 1,
                 "location": "Any",
-                "id": 59
+                "id": "5af0534a86f7743b6f354284"
             },
             {
                 "type": "find",
                 "target": "LEDX Skin Transilluminator",
                 "number": 1,
                 "location": "Any",
-                "id": 60
+                "id": "5c0530ee86f774697952d952"
             }
         ]
     },
@@ -1414,14 +1414,14 @@
                 "target": "Module-3M bodyarmor",
                 "number": 1,
                 "location": "Any",
-                "id": 62
+                "id": "59e7635f86f7742cbf2c1095"
             },
             {
                 "type": "find",
                 "target": "TOZ-106 bolt-action shotgun",
                 "number": 1,
                 "location": "Any",
-                "id": 63
+                "id": "5a38e6bac4a2826c6e06d79b"
             }
         ]
     },
@@ -1492,7 +1492,7 @@
                 "target": "Secure Flash drive",
                 "number": 2,
                 "location": "Any",
-                "id": 66
+                "id": "590c621186f774138d11ea29"
             }
         ]
     },
@@ -1805,14 +1805,14 @@
                 "target": "Respirator",
                 "number": 4,
                 "location": "Any",
-                "id": 83
+                "id": "59e7715586f7742ee5789605"
             },
             {
                 "type": "find",
                 "target": "Medical bloodset",
                 "number": 3,
                 "location": "Any",
-                "id": 84
+                "id": "5b4335ba86f7744d2837a264"
             }
         ]
     },
@@ -1852,7 +1852,7 @@
                 "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
-                "id": 85
+                "id": "59f32c3b86f77472a31742f0"
             }
         ]
     },
@@ -1882,7 +1882,7 @@
                 "target": "Dollars",
                 "number": 6000,
                 "location": "Any",
-                "id": 87
+                "id": "5696686a4bdc2da3298b456a"
             }
         ]
     },
@@ -1989,14 +1989,14 @@
                 "target": "Virtex programmable processor",
                 "number": 2,
                 "location": "Any",
-                "id": 95
+                "id": "5c05308086f7746b2101e90b"
             },
             {
                 "type": "find",
                 "target": "Military COFDM wireless Signal Transmitter",
                 "number": 1,
                 "location": "Any",
-                "id": 96
+                "id": "5c052f6886f7746b1e3db148"
             }
         ]
     },
@@ -2577,7 +2577,7 @@
                 "target": "MRE lunch box",
                 "number": 5,
                 "location": "Any",
-                "id": 128
+                "id": "590c5f0d86f77413997acfab"
             },
             {
                 "type": "kill",
@@ -2786,28 +2786,28 @@
                 "target": "WD-40 100ml.",
                 "number": 1,
                 "location": "Any",
-                "id": 138
+                "id": "590c5bbd86f774785762df04"
             },
             {
                 "type": "find",
                 "target": "Clin wiper",
                 "number": 2,
                 "location": "Any",
-                "id": 139
+                "id": "59e358a886f7741776641ac3"
             },
             {
                 "type": "find",
                 "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
-                "id": 140
+                "id": "59e35cbb86f7741778269d83"
             },
             {
                 "type": "find",
                 "target": "Ox bleach",
                 "number": 2,
                 "location": "Any",
-                "id": 141
+                "id": "59e3556c86f7741776641ac2"
             }
         ]
     },
@@ -2911,7 +2911,7 @@
                 "target": "Dollars",
                 "number": 8000,
                 "location": "Any",
-                "id": 146
+                "id": "5696686a4bdc2da3298b456a"
             }
         ]
     },
@@ -2945,28 +2945,28 @@
                 "target": "Morphine injector",
                 "number": 4,
                 "location": "Any",
-                "id": 147
+                "id": "544fb3f34bdc2d03748b456a"
             },
             {
                 "type": "find",
                 "target": "Heat-exchange alkali surface washer",
                 "number": 2,
                 "location": "Any",
-                "id": 148
+                "id": "59faf98186f774067b6be103"
             },
             {
                 "type": "find",
                 "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
-                "id": 149
+                "id": "59e35cbb86f7741778269d83"
             },
             {
                 "type": "find",
                 "target": "5L propane tank",
                 "number": 2,
                 "location": "Any",
-                "id": 150
+                "id": "59fafb5d86f774067a6f2084"
             }
         ]
     },
@@ -3736,28 +3736,28 @@
                 "target": "PC CPU",
                 "number": 3,
                 "location": "Any",
-                "id": 165
+                "id": "573477e124597737dd42e191"
             },
             {
                 "type": "find",
                 "target": "Rechargeable battery",
                 "number": 3,
                 "location": "Any",
-                "id": 166
+                "id": "590a358486f77429692b2790"
             },
             {
                 "type": "find",
                 "target": "Printed circuit board",
                 "number": 3,
                 "location": "Any",
-                "id": 167
+                "id": "590a3b0486f7743954552bdb"
             },
             {
                 "type": "find",
                 "target": "Broken GPhone",
                 "number": 3,
                 "location": "Any",
-                "id": 168
+                "id": "56742c324bdc2d150f8b456d"
             }
         ]
     },
@@ -3984,21 +3984,21 @@
                 "target": "Powercord",
                 "number": 2,
                 "location": "Any",
-                "id": 179
+                "id": "59e36c6f86f774176c10a2a7"
             },
             {
                 "type": "find",
                 "target": "T-Shaped Plug",
                 "number": 4,
                 "location": "Any",
-                "id": 180
+                "id": "57347cd0245977445a2d6ff1"
             },
             {
                 "type": "find",
                 "target": "Printed circuit board",
                 "number": 2,
                 "location": "Any",
-                "id": 181
+                "id": "590a3b0486f7743954552bdb"
             }
         ]
     },
@@ -4065,14 +4065,14 @@
                 "target": "Graphics card",
                 "number": 3,
                 "location": "Any",
-                "id": 184
+                "id": "57347ca924597744596b4e71"
             },
             {
                 "type": "find",
                 "target": "CPU Fan",
                 "number": 8,
                 "location": "Any",
-                "id": 185
+                "id": "5734779624597737e04bf329"
             }
         ]
     },
@@ -4103,14 +4103,14 @@
                 "target": "UHF RFID Reader",
                 "number": 1,
                 "location": "Any",
-                "id": 186
+                "id": "5c052fb986f7746b2101e909"
             },
             {
                 "type": "find",
                 "target": "VPX Flash Storage Module",
                 "number": 1,
                 "location": "Any",
-                "id": 187
+                "id": "5c05300686f7746dce784e5d"
             }
         ]
     },
@@ -4140,14 +4140,14 @@
                 "target": "Wires",
                 "number": 5,
                 "location": "Any",
-                "id": 188
+                "id": "5c06779c86f77426e00dd782"
             },
             {
                 "type": "find",
                 "target": "Capacitors",
                 "number": 5,
                 "location": "Any",
-                "id": 189
+                "id": "5c06782b86f77426df5407d2"
             }
         ]
     },
@@ -4376,14 +4376,14 @@
                 "target": "Ushanka ear-flap cap",
                 "number": 2,
                 "location": "Any",
-                "id": 203
+                "id": "59e7708286f7742cbd762753"
             },
             {
                 "type": "find",
                 "target": "Kinda cowboy hat",
                 "number": 2,
                 "location": "Any",
-                "id": 204
+                "id": "5aa2b9ede5b5b000137b758b"
             }
         ]
     },
@@ -4576,7 +4576,7 @@
                 "target": "Key to Goshan cash register",
                 "number": 1,
                 "location": "Any",
-                "id": 214
+                "id": "5ad7247386f7747487619dc3"
             }
         ]
     },
@@ -4763,14 +4763,14 @@
                 "target": "Ski hat with holes for eyes",
                 "number": 1,
                 "location": "Any",
-                "id": 223
+                "id": "5ab8f20c86f7745cdb629fb2"
             },
             {
                 "type": "find",
                 "target": "Pilgrim tourist backpack",
                 "number": 1,
                 "location": "Any",
-                "id": 224
+                "id": "59e763f286f7742ee57895da"
             }
         ]
     },
@@ -4801,7 +4801,7 @@
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 225
+                "id": "5ab8e79e86f7742d8b372e78"
             },
             {
                 "type": "collect",
@@ -4809,7 +4809,7 @@
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 226
+                "id": "5ab8e79e86f7742d8b372e78"
             }
         ]
     },
@@ -4840,7 +4840,7 @@
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 227
+                "id": "545cdb794bdc2d3a198b456a"
             },
             {
                 "type": "collect",
@@ -4848,7 +4848,7 @@
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 228
+                "id": "545cdb794bdc2d3a198b456a"
             }
         ]
     },
@@ -4878,14 +4878,14 @@
                 "target": "Wartech gear rig (TV-109, TV-106)",
                 "number": 2,
                 "location": "Any",
-                "id": 229
+                "id": "59e7643b86f7742cbf2c109a"
             },
             {
                 "type": "find",
                 "target": "BlackRock chest rig",
                 "number": 2,
                 "location": "Any",
-                "id": 230
+                "id": "5648a69d4bdc2ded0b8b457b"
             }
         ]
     },
@@ -4976,7 +4976,7 @@
                 "target": "Fuel conditioner",
                 "number": 4,
                 "location": "Any",
-                "id": 233
+                "id": "5b43575a86f77424f443fe62"
             }
         ]
     },
@@ -5057,28 +5057,28 @@
                 "target": "Bronze lion",
                 "number": 2,
                 "location": "Any",
-                "id": 237
+                "id": "59e3639286f7741777737013"
             },
             {
                 "type": "find",
                 "target": "Horse figurine",
                 "number": 2,
                 "location": "Any",
-                "id": 238
+                "id": "573478bc24597738002c6175"
             },
             {
                 "type": "find",
                 "target": "Cat figurine",
                 "number": 1,
                 "location": "Any",
-                "id": 239
+                "id": "59e3658a86f7741776641ac4"
             },
             {
                 "type": "find",
                 "target": "Roler submariner gold wrist watch",
                 "number": 1,
                 "location": "Any",
-                "id": 240
+                "id": "59faf7ca86f7740dbe19f6c2"
             }
         ]
     },
@@ -5108,14 +5108,14 @@
                 "target": "Antique teapot",
                 "number": 3,
                 "location": "Any",
-                "id": 241
+                "id": "590de71386f774347051a052"
             },
             {
                 "type": "find",
                 "target": "Antique vase",
                 "number": 2,
                 "location": "Any",
-                "id": 242
+                "id": "590de7e986f7741b096e5f32"
             }
         ]
     },
@@ -5173,21 +5173,21 @@
                 "target": "Iskra lunch box",
                 "number": 3,
                 "location": "Any",
-                "id": 244
+                "id": "590c5d4b86f774784e1b9c45"
             },
             {
                 "type": "find",
                 "target": "Emelya rye croutons",
                 "number": 2,
                 "location": "Any",
-                "id": 245
+                "id": "5751487e245977207e26a315"
             },
             {
                 "type": "find",
                 "target": "Can of delicious beef stew",
                 "number": 2,
                 "location": "Any",
-                "id": 246
+                "id": "57347da92459774491567cf5"
             }
         ]
     },
@@ -5836,28 +5836,28 @@
                 "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
-                "id": 322
+                "id": "5ed515f6915ec335206e4152"
             },
             {
                 "type": "find",
                 "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
-                "id": 323
+                "id": "5ed515c8d380ab312177c0fa"
             },
             {
                 "type": "collect",
                 "target": "Lab. Blue keycard",
                 "number": 1,
                 "location": "Any",
-                "id": 324
+                "id": "5c1d0c5f86f7744bb2683cf0"
             },
             {
                 "type": "collect",
                 "target": "Lab. Green keycard",
                 "number": 1,
                 "location": "Any",
-                "id": 325
+                "id": "5c1d0dc586f7744baf2e7b79"
             }
         ],
         "alternatives": [
@@ -5920,14 +5920,14 @@
                 "target": "CMS kit",
                 "number": 2,
                 "location": "Any",
-                "id": 271
+                "id": "5d02778e86f774203e7dedbe"
             },
             {
                 "type": "find",
                 "target": "Portable defibrillator",
                 "number": 1,
                 "location": "Any",
-                "id": 272
+                "id": "5c052e6986f7746b207bc3c9"
             }
         ]
     },
@@ -6118,7 +6118,7 @@
                 "target": "TerraGroup Labs access keycard",
                 "number": 2,
                 "location": "Any",
-                "id": 278
+                "id": "5c94bbff86f7747ee735c08f"
             }
         ]
     },
@@ -6155,7 +6155,7 @@
                 "target": "TT pistol 7.62x25 TT Gold",
                 "number": 1,
                 "location": "Customs",
-                "id": 280
+                "id": "5b3b713c5acfc4330140bd8d"
             }
         ]
     },
@@ -6226,7 +6226,7 @@
                 "target": "Maska 1Sch helmet (Killa)",
                 "number": 1,
                 "location": "Interchange",
-                "id": 283
+                "id": "5c0e874186f7745dc7616606"
             }
         ]
     },
@@ -6263,7 +6263,7 @@
                 "target": "Shturman key",
                 "number": 1,
                 "location": "Woods",
-                "id": 285
+                "id": "5d08d21286f774736e7c94c3"
             }
         ]
     },
@@ -6497,14 +6497,14 @@
                 "target": "6-STEN-140-M military battery",
                 "number": 1,
                 "location": "Any",
-                "id": 293
+                "id": "5d03794386f77420415576f5"
             },
             {
                 "type": "find",
                 "target": "OFZ 30x160mm shell",
                 "number": 5,
                 "location": "Any",
-                "id": 294
+                "id": "5d0379a886f77420407aa271"
             }
         ]
     },
@@ -6571,7 +6571,7 @@
                 "target": "Euros",
                 "number": 50000,
                 "location": "Any",
-                "id": 296
+                "id": "569668774bdc2da2298b4568"
             }
         ]
     },
@@ -6601,21 +6601,21 @@
                 "target": "Malboro cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": 297
+                "id": "573476d324597737da2adc13"
             },
             {
                 "type": "find",
                 "target": "Strike cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": 298
+                "id": "5734770f24597738025ee254"
             },
             {
                 "type": "find",
                 "target": "Wilston cigarettes",
                 "number": 5,
                 "location": "Any",
-                "id": 299
+                "id": "573476f124597737e04bf328"
             }
         ]
     },
@@ -6684,7 +6684,7 @@
                 "target": "Secure Flash drive",
                 "number": 3,
                 "location": "Any",
-                "id": 302
+                "id": "590c621186f774138d11ea29"
             }
         ]
     },
@@ -6862,21 +6862,21 @@
                 "target": "Aramid fiber cloth",
                 "number": 5,
                 "location": "Any",
-                "id": 306
+                "id": "5e2af4d286f7746d4159f07a"
             },
             {
                 "type": "find",
                 "target": "Ripstop cloth",
                 "number": 10,
                 "location": "Any",
-                "id": 307
+                "id": "5e2af4a786f7746d3f3c3400"
             },
             {
                 "type": "find",
                 "target": "Paracord",
                 "number": 3,
                 "location": "Any",
-                "id": 308
+                "id": "5c12688486f77426843c7d32"
             }
         ]
     },
@@ -6902,21 +6902,21 @@
                 "target": "Fleece cloth",
                 "number": 10,
                 "location": "Any",
-                "id": 309
+                "id": "5e2af47786f7746d404f3aaa"
             },
             {
                 "type": "find",
                 "target": "Polyamide fabric Cordura",
                 "number": 10,
                 "location": "Any",
-                "id": 310
+                "id": "5e2af41e86f774755a234b67"
             },
             {
                 "type": "find",
                 "target": "KEKTAPE duct tape",
                 "number": 5,
                 "location": "Any",
-                "id": 311
+                "id": "5e2af29386f7746d4159f077"
             }
         ]
     },
@@ -6934,8 +6934,7 @@
         "wiki": "https://escapefromtarkov.gamepedia.com/Anesthesia",
         "exp": 12600,
         "nokappa": true,
-        "unlocks": [
-        ],
+        "unlocks": [],
         "reputation": [
             {
                 "trader": "Prapor",
@@ -7132,49 +7131,49 @@
                 "target": "M.U.L.E. stimulator",
                 "number": 1,
                 "location": "Any",
-                "id": 331
+                "id": "5ed51652f6c34d2cc26336a1"
             },
             {
                 "type": "find",
                 "target": "Cocktail \"Obdolbos\"",
                 "number": 1,
                 "location": "Any",
-                "id": 332
+                "id": "5ed5166ad380ab312177c100"
             },
             {
                 "type": "find",
                 "target": "Meldonin",
                 "number": 1,
                 "location": "Any",
-                "id": 333
+                "id": "5ed5160a87bb8443d10680b5"
             },
             {
                 "type": "find",
                 "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
-                "id": 334
+                "id": "5ed515f6915ec335206e4152"
             },
             {
                 "type": "find",
                 "target": "P22",
                 "number": 1,
                 "location": "Any",
-                "id": 335
+                "id": "5ed515ece452db0eb56fc028"
             },
             {
                 "type": "find",
                 "target": "L1 (Norepinephrine)",
                 "number": 1,
                 "location": "Any",
-                "id": 336
+                "id": "5ed515e03a40a50460332579"
             },
             {
                 "type": "find",
                 "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
-                "id": 337
+                "id": "5ed515c8d380ab312177c0fa"
             }
         ]
     },
@@ -7531,126 +7530,126 @@
                 "target": "Old firesteel",
                 "number": 1,
                 "location": "Any",
-                "id": 353
+                "id": "5bc9c377d4351e3bac12251b"
             },
             {
                 "type": "find",
                 "target": "Antique axe",
                 "number": 1,
                 "location": "Any",
-                "id": 354
+                "id": "5bc9c1e2d4351e00367fbcf0"
             },
             {
                 "type": "find",
                 "target": "Battered antique Book",
                 "number": 1,
                 "location": "Any",
-                "id": 355
+                "id": "5bc9c049d4351e44f824d360"
             },
             {
                 "type": "find",
                 "target": "#FireKlean gun lube",
                 "number": 1,
                 "location": "Any",
-                "id": 356
+                "id": "5bc9b355d4351e6d1509862a"
             },
             {
                 "type": "find",
                 "target": "Golden rooster",
                 "number": 1,
                 "location": "Any",
-                "id": 357
+                "id": "5bc9bc53d4351e00367fbcee"
             },
             {
                 "type": "find",
                 "target": "Silver Badge",
                 "number": 1,
                 "location": "Any",
-                "id": 358
+                "id": "5bc9bdb8d4351e003562b8a1"
             },
             {
                 "type": "find",
                 "target": "Deadlyslob's beard oil",
                 "number": 1,
                 "location": "Any",
-                "id": 359
+                "id": "5bc9b9ecd4351e3bac122519"
             },
             {
                 "type": "find",
                 "target": "Golden 1GPhone",
                 "number": 1,
                 "location": "Any",
-                "id": 360
+                "id": "5bc9b720d4351e450201234b"
             },
             {
                 "type": "find",
                 "target": "Jar of DevilDog mayo",
                 "number": 1,
                 "location": "Any",
-                "id": 361
+                "id": "5bc9b156d4351e00367fbce9"
             },
             {
                 "type": "find",
                 "target": "Can of sprats",
                 "number": 1,
                 "location": "Any",
-                "id": 362
+                "id": "5bc9c29cd4351e003562b8a3"
             },
             {
                 "type": "find",
                 "target": "Fake mustache",
                 "number": 1,
                 "location": "Any",
-                "id": 363
+                "id": "5bd073a586f7747e6f135799"
             },
             {
                 "type": "find",
                 "target": "Kotton beanie",
                 "number": 1,
                 "location": "Any",
-                "id": 364
+                "id": "5bd073c986f7747f627e796c"
             },
             {
                 "type": "find",
                 "target": "Can of Dr. Lupo's coffee beans",
                 "number": 1,
                 "location": "Any",
-                "id": 365
+                "id": "5e54f6af86f7742199090bf3"
             },
             {
                 "type": "find",
                 "target": "Pestily plague mask",
                 "number": 1,
                 "location": "Any",
-                "id": 366
+                "id": "5e54f79686f7744022011103"
             },
             {
                 "type": "find",
                 "target": "Raven figurine",
                 "number": 1,
                 "location": "Any",
-                "id": 367
+                "id": "5e54f62086f774219b0f1937"
             },
             {
                 "type": "find",
                 "target": "Shroud half-mask",
                 "number": 1,
                 "location": "Any",
-                "id": 368
+                "id": "5e54f76986f7740366043752"
             },
             {
                 "type": "find",
                 "target": "Veritas guitar pick",
                 "number": 1,
                 "location": "Any",
-                "id": 369
+                "id": "5f745ee30acaeb0d490d8c5b"
             },
             {
                 "type": "find",
                 "target": "42nd Signature Blend English Tea",
                 "number": 1,
                 "location": "Any",
-                "id": 370
+                "id": "5bc9be8fd4351e00334cae6e"
             }
         ]
     },
@@ -7674,7 +7673,7 @@
                 "target": "Rubles",
                 "number": 400000,
                 "location": "Any",
-                "id": 372
+                "id": "5449016a4bdc2d6f028b456f"
             }
         ]
     }

--- a/quests.json
+++ b/quests.json
@@ -29,11 +29,10 @@
             },
             {
                 "type": "collect",
-                "target": "MP-133 12ga shotgun",
+                "target": "54491c4f4bdc2db1078b4568",
                 "number": 2,
                 "location": "Any",
-                "id": 1,
-                "bsgId": "54491c4f4bdc2db1078b4568"
+                "id": 1
             }
         ]
     },
@@ -277,12 +276,11 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "60-round 6L31 5.45x39 magazine for АК-74 and compatibles",
+                "target": "55d482194bdc2d1d4e8b456b",
                 "number": 3,
                 "location": "Any",
                 "have": 0,
-                "id": 12,
-                "bsgId": "55d482194bdc2d1d4e8b456b"
+                "id": 12
             }
         ]
     },
@@ -589,11 +587,10 @@
             },
             {
                 "type": "find",
-                "target": "Lower half-mask",
+                "target": "572b7fa524597762b747ce82",
                 "number": 7,
                 "location": "Any",
-                "id": 27,
-                "bsgId": "572b7fa524597762b747ce82"
+                "id": 27
             }
         ]
     },
@@ -684,11 +681,10 @@
             },
             {
                 "type": "find",
-                "target": "Bars A-2607- 95x18",
+                "target": "57e26fc7245977162a14b800",
                 "number": 5,
                 "location": "Any",
-                "id": 31,
-                "bsgId": "57e26fc7245977162a14b800"
+                "id": 31
             }
         ]
     },
@@ -728,27 +724,24 @@
             },
             {
                 "type": "find",
-                "target": "AK-74N 5.45x39 assault rifle",
+                "target": "5644bd2b4bdc2d3b4c8b4572",
                 "number": 1,
                 "location": "Any",
-                "id": 33,
-                "bsgId": "5644bd2b4bdc2d3b4c8b4572"
+                "id": 33
             },
             {
                 "type": "find",
-                "target": "Colt M4A1 5.56x45 Assault Rifle",
+                "target": "5447a9cd4bdc2dbd208b4567",
                 "number": 1,
                 "location": "Any",
-                "id": 34,
-                "bsgId": "5447a9cd4bdc2dbd208b4567"
+                "id": 34
             },
             {
                 "type": "find",
-                "target": "PM 9x18PM pistol",
+                "target": "5448bd6b4bdc2dfc2f8b4569",
                 "number": 2,
                 "location": "Any",
-                "id": 35,
-                "bsgId": "5448bd6b4bdc2dfc2f8b4569"
+                "id": 35
             }
         ]
     },
@@ -793,19 +786,17 @@
             },
             {
                 "type": "collect",
-                "target": "Dogtag USEC",
+                "target": "59f32c3b86f77472a31742f0",
                 "number": 7,
                 "location": "Any",
-                "id": 37,
-                "bsgId": "59f32c3b86f77472a31742f0"
+                "id": 37
             },
             {
                 "type": "collect",
-                "target": "Dogtag BEAR",
+                "target": "59f32bb586f774757e1e8442",
                 "number": 7,
                 "location": "Any",
-                "id": 38,
-                "bsgId": "59f32bb586f774757e1e8442"
+                "id": 38
             }
         ]
     },
@@ -830,11 +821,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Salewa First Aid Kit",
+                "target": "544fb45d4bdc2dee738b4568",
                 "number": 3,
                 "location": "Any",
-                "id": 39,
-                "bsgId": "544fb45d4bdc2dee738b4568"
+                "id": 39
             }
         ]
     },
@@ -863,11 +853,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Gas analyzer",
+                "target": "590a3efd86f77437d351a25b",
                 "number": 1,
                 "location": "Any",
-                "id": 40,
-                "bsgId": "590a3efd86f77437d351a25b"
+                "id": 40
             }
         ]
     },
@@ -894,11 +883,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Gas analyzer",
+                "target": "590a3efd86f77437d351a25b",
                 "number": 2,
                 "location": "Any",
-                "id": 41,
-                "bsgId": "590a3efd86f77437d351a25b"
+                "id": 41
             }
         ]
     },
@@ -925,12 +913,11 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Morphine injector",
+                "target": "544fb3f34bdc2d03748b456a",
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": 42,
-                "bsgId": "544fb3f34bdc2d03748b456a"
+                "id": 42
             }
         ]
     },
@@ -1070,11 +1057,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Can of beef stew",
+                "target": "57347d7224597744596b4e72",
                 "number": 15,
                 "location": "Any",
-                "id": 47,
-                "bsgId": "57347d7224597744596b4e72"
+                "id": 47
             }
         ]
     },
@@ -1101,21 +1087,19 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Car battery",
+                "target": "5733279d245977289b77ec24",
                 "number": 4,
                 "location": "Any",
                 "have": 0,
-                "id": 48,
-                "bsgId": "5733279d245977289b77ec24"
+                "id": 48
             },
             {
                 "type": "find",
-                "target": "Spark plug",
+                "target": "590a3c0a86f774385a33c450",
                 "number": 8,
                 "location": "Any",
                 "have": 0,
-                "id": 49,
-                "bsgId": "590a3c0a86f774385a33c450"
+                "id": 49
             }
         ]
     },
@@ -1358,19 +1342,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Ophthalmoscope",
+                "target": "5af0534a86f7743b6f354284",
                 "number": 1,
                 "location": "Any",
-                "id": 59,
-                "bsgId": "5af0534a86f7743b6f354284"
+                "id": 59
             },
             {
                 "type": "find",
-                "target": "LEDX Skin Transilluminator",
+                "target": "5c0530ee86f774697952d952",
                 "number": 1,
                 "location": "Any",
-                "id": 60,
-                "bsgId": "5c0530ee86f774697952d952"
+                "id": 60
             }
         ]
     },
@@ -1429,19 +1411,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Module-3M bodyarmor",
+                "target": "59e7635f86f7742cbf2c1095",
                 "number": 1,
                 "location": "Any",
-                "id": 62,
-                "bsgId": "59e7635f86f7742cbf2c1095"
+                "id": 62
             },
             {
                 "type": "find",
-                "target": "TOZ-106 bolt-action shotgun",
+                "target": "5a38e6bac4a2826c6e06d79b",
                 "number": 1,
                 "location": "Any",
-                "id": 63,
-                "bsgId": "5a38e6bac4a2826c6e06d79b"
+                "id": 63
             }
         ]
     },
@@ -1509,11 +1489,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Secure Flash drive",
+                "target": "590c621186f774138d11ea29",
                 "number": 2,
                 "location": "Any",
-                "id": 66,
-                "bsgId": "590c621186f774138d11ea29"
+                "id": 66
             }
         ]
     },
@@ -1823,19 +1802,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Respirator",
+                "target": "59e7715586f7742ee5789605",
                 "number": 4,
                 "location": "Any",
-                "id": 83,
-                "bsgId": "59e7715586f7742ee5789605"
+                "id": 83
             },
             {
                 "type": "find",
-                "target": "Medical bloodset",
+                "target": "5b4335ba86f7744d2837a264",
                 "number": 3,
                 "location": "Any",
-                "id": 84,
-                "bsgId": "5b4335ba86f7744d2837a264"
+                "id": 84
             }
         ]
     },
@@ -1872,11 +1849,10 @@
             },
             {
                 "type": "find",
-                "target": "Dogtag USEC",
+                "target": "59f32c3b86f77472a31742f0",
                 "number": 7,
                 "location": "Any",
-                "id": 85,
-                "bsgId": "59f32c3b86f77472a31742f0"
+                "id": 85
             }
         ]
     },
@@ -1903,11 +1879,10 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "Dollars",
+                "target": "5696686a4bdc2da3298b456a",
                 "number": 6000,
                 "location": "Any",
-                "id": 87,
-                "bsgId": "5696686a4bdc2da3298b456a"
+                "id": 87
             }
         ]
     },
@@ -2011,19 +1986,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Virtex programmable processor",
+                "target": "5c05308086f7746b2101e90b",
                 "number": 2,
                 "location": "Any",
-                "id": 95,
-                "bsgId": "5c05308086f7746b2101e90b"
+                "id": 95
             },
             {
                 "type": "find",
-                "target": "Military COFDM wireless Signal Transmitter",
+                "target": "5c052f6886f7746b1e3db148",
                 "number": 1,
                 "location": "Any",
-                "id": 96,
-                "bsgId": "5c052f6886f7746b1e3db148"
+                "id": 96
             }
         ]
     },
@@ -2601,11 +2574,10 @@
             },
             {
                 "type": "collect",
-                "target": "MRE lunch box",
+                "target": "590c5f0d86f77413997acfab",
                 "number": 5,
                 "location": "Any",
-                "id": 128,
-                "bsgId": "590c5f0d86f77413997acfab"
+                "id": 128
             },
             {
                 "type": "kill",
@@ -2811,35 +2783,31 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "WD-40 100ml.",
+                "target": "590c5bbd86f774785762df04",
                 "number": 1,
                 "location": "Any",
-                "id": 138,
-                "bsgId": "590c5bbd86f774785762df04"
+                "id": 138
             },
             {
                 "type": "find",
-                "target": "Clin wiper",
+                "target": "59e358a886f7741776641ac3",
                 "number": 2,
                 "location": "Any",
-                "id": 139,
-                "bsgId": "59e358a886f7741776641ac3"
+                "id": 139
             },
             {
                 "type": "find",
-                "target": "Corrugated hose",
+                "target": "59e35cbb86f7741778269d83",
                 "number": 2,
                 "location": "Any",
-                "id": 140,
-                "bsgId": "59e35cbb86f7741778269d83"
+                "id": 140
             },
             {
                 "type": "find",
-                "target": "Ox bleach",
+                "target": "59e3556c86f7741776641ac2",
                 "number": 2,
                 "location": "Any",
-                "id": 141,
-                "bsgId": "59e3556c86f7741776641ac2"
+                "id": 141
             }
         ]
     },
@@ -2940,11 +2908,10 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "Dollars",
+                "target": "5696686a4bdc2da3298b456a",
                 "number": 8000,
                 "location": "Any",
-                "id": 146,
-                "bsgId": "5696686a4bdc2da3298b456a"
+                "id": 146
             }
         ]
     },
@@ -2975,35 +2942,31 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Morphine injector",
+                "target": "544fb3f34bdc2d03748b456a",
                 "number": 4,
                 "location": "Any",
-                "id": 147,
-                "bsgId": "544fb3f34bdc2d03748b456a"
+                "id": 147
             },
             {
                 "type": "find",
-                "target": "Heat-exchange alkali surface washer",
+                "target": "59faf98186f774067b6be103",
                 "number": 2,
                 "location": "Any",
-                "id": 148,
-                "bsgId": "59faf98186f774067b6be103"
+                "id": 148
             },
             {
                 "type": "find",
-                "target": "Corrugated hose",
+                "target": "59e35cbb86f7741778269d83",
                 "number": 2,
                 "location": "Any",
-                "id": 149,
-                "bsgId": "59e35cbb86f7741778269d83"
+                "id": 149
             },
             {
                 "type": "find",
-                "target": "5L propane tank",
+                "target": "59fafb5d86f774067a6f2084",
                 "number": 2,
                 "location": "Any",
-                "id": 150,
-                "bsgId": "59fafb5d86f774067a6f2084"
+                "id": 150
             }
         ]
     },
@@ -3770,35 +3733,31 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "PC CPU",
+                "target": "573477e124597737dd42e191",
                 "number": 3,
                 "location": "Any",
-                "id": 165,
-                "bsgId": "573477e124597737dd42e191"
+                "id": 165
             },
             {
                 "type": "find",
-                "target": "Rechargeable battery",
+                "target": "590a358486f77429692b2790",
                 "number": 3,
                 "location": "Any",
-                "id": 166,
-                "bsgId": "590a358486f77429692b2790"
+                "id": 166
             },
             {
                 "type": "find",
-                "target": "Printed circuit board",
+                "target": "590a3b0486f7743954552bdb",
                 "number": 3,
                 "location": "Any",
-                "id": 167,
-                "bsgId": "590a3b0486f7743954552bdb"
+                "id": 167
             },
             {
                 "type": "find",
-                "target": "Broken GPhone",
+                "target": "56742c324bdc2d150f8b456d",
                 "number": 3,
                 "location": "Any",
-                "id": 168,
-                "bsgId": "56742c324bdc2d150f8b456d"
+                "id": 168
             }
         ]
     },
@@ -4022,27 +3981,24 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Powercord",
+                "target": "59e36c6f86f774176c10a2a7",
                 "number": 2,
                 "location": "Any",
-                "id": 179,
-                "bsgId": "59e36c6f86f774176c10a2a7"
+                "id": 179
             },
             {
                 "type": "find",
-                "target": "T-Shaped Plug",
+                "target": "57347cd0245977445a2d6ff1",
                 "number": 4,
                 "location": "Any",
-                "id": 180,
-                "bsgId": "57347cd0245977445a2d6ff1"
+                "id": 180
             },
             {
                 "type": "find",
-                "target": "Printed circuit board",
+                "target": "590a3b0486f7743954552bdb",
                 "number": 2,
                 "location": "Any",
-                "id": 181,
-                "bsgId": "590a3b0486f7743954552bdb"
+                "id": 181
             }
         ]
     },
@@ -4106,19 +4062,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Graphics card",
+                "target": "57347ca924597744596b4e71",
                 "number": 3,
                 "location": "Any",
-                "id": 184,
-                "bsgId": "57347ca924597744596b4e71"
+                "id": 184
             },
             {
                 "type": "find",
-                "target": "CPU Fan",
+                "target": "5734779624597737e04bf329",
                 "number": 8,
                 "location": "Any",
-                "id": 185,
-                "bsgId": "5734779624597737e04bf329"
+                "id": 185
             }
         ]
     },
@@ -4146,19 +4100,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "UHF RFID Reader",
+                "target": "5c052fb986f7746b2101e909",
                 "number": 1,
                 "location": "Any",
-                "id": 186,
-                "bsgId": "5c052fb986f7746b2101e909"
+                "id": 186
             },
             {
                 "type": "find",
-                "target": "VPX Flash Storage Module",
+                "target": "5c05300686f7746dce784e5d",
                 "number": 1,
                 "location": "Any",
-                "id": 187,
-                "bsgId": "5c05300686f7746dce784e5d"
+                "id": 187
             }
         ]
     },
@@ -4185,19 +4137,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Wires",
+                "target": "5c06779c86f77426e00dd782",
                 "number": 5,
                 "location": "Any",
-                "id": 188,
-                "bsgId": "5c06779c86f77426e00dd782"
+                "id": 188
             },
             {
                 "type": "find",
-                "target": "Capacitors",
+                "target": "5c06782b86f77426df5407d2",
                 "number": 5,
                 "location": "Any",
-                "id": 189,
-                "bsgId": "5c06782b86f77426df5407d2"
+                "id": 189
             }
         ]
     },
@@ -4423,19 +4373,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Ushanka ear-flap cap",
+                "target": "59e7708286f7742cbd762753",
                 "number": 2,
                 "location": "Any",
-                "id": 203,
-                "bsgId": "59e7708286f7742cbd762753"
+                "id": 203
             },
             {
                 "type": "find",
-                "target": "Kinda cowboy hat",
+                "target": "5aa2b9ede5b5b000137b758b",
                 "number": 2,
                 "location": "Any",
-                "id": 204,
-                "bsgId": "5aa2b9ede5b5b000137b758b"
+                "id": 204
             }
         ]
     },
@@ -4625,11 +4573,10 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "Key to Goshan cash register",
+                "target": "5ad7247386f7747487619dc3",
                 "number": 1,
                 "location": "Any",
-                "id": 214,
-                "bsgId": "5ad7247386f7747487619dc3"
+                "id": 214
             }
         ]
     },
@@ -4813,19 +4760,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Ski hat with holes for eyes",
+                "target": "5ab8f20c86f7745cdb629fb2",
                 "number": 1,
                 "location": "Any",
-                "id": 223,
-                "bsgId": "5ab8f20c86f7745cdb629fb2"
+                "id": 223
             },
             {
                 "type": "find",
-                "target": "Pilgrim tourist backpack",
+                "target": "59e763f286f7742ee57895da",
                 "number": 1,
                 "location": "Any",
-                "id": 224,
-                "bsgId": "59e763f286f7742ee57895da"
+                "id": 224
             }
         ]
     },
@@ -4852,21 +4797,19 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "BNTI Gzhel-K armor",
+                "target": "5ab8e79e86f7742d8b372e78",
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 225,
-                "bsgId": "5ab8e79e86f7742d8b372e78"
+                "id": 225
             },
             {
                 "type": "collect",
-                "target": "BNTI Gzhel-K armor",
+                "target": "5ab8e79e86f7742d8b372e78",
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 226,
-                "bsgId": "5ab8e79e86f7742d8b372e78"
+                "id": 226
             }
         ]
     },
@@ -4893,21 +4836,19 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "6B43 Zabralo-Sh 6A Armor",
+                "target": "545cdb794bdc2d3a198b456a",
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 227,
-                "bsgId": "545cdb794bdc2d3a198b456a"
+                "id": 227
             },
             {
                 "type": "collect",
-                "target": "6B43 Zabralo-Sh 6A Armor",
+                "target": "545cdb794bdc2d3a198b456a",
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
-                "id": 228,
-                "bsgId": "545cdb794bdc2d3a198b456a"
+                "id": 228
             }
         ]
     },
@@ -4934,19 +4875,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Wartech gear rig (TV-109, TV-106)",
+                "target": "59e7643b86f7742cbf2c109a",
                 "number": 2,
                 "location": "Any",
-                "id": 229,
-                "bsgId": "59e7643b86f7742cbf2c109a"
+                "id": 229
             },
             {
                 "type": "find",
-                "target": "BlackRock chest rig",
+                "target": "5648a69d4bdc2ded0b8b457b",
                 "number": 2,
                 "location": "Any",
-                "id": 230,
-                "bsgId": "5648a69d4bdc2ded0b8b457b"
+                "id": 230
             }
         ]
     },
@@ -5034,11 +4973,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Fuel conditioner",
+                "target": "5b43575a86f77424f443fe62",
                 "number": 4,
                 "location": "Any",
-                "id": 233,
-                "bsgId": "5b43575a86f77424f443fe62"
+                "id": 233
             }
         ]
     },
@@ -5116,35 +5054,31 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Bronze lion",
+                "target": "59e3639286f7741777737013",
                 "number": 2,
                 "location": "Any",
-                "id": 237,
-                "bsgId": "59e3639286f7741777737013"
+                "id": 237
             },
             {
                 "type": "find",
-                "target": "Horse figurine",
+                "target": "573478bc24597738002c6175",
                 "number": 2,
                 "location": "Any",
-                "id": 238,
-                "bsgId": "573478bc24597738002c6175"
+                "id": 238
             },
             {
                 "type": "find",
-                "target": "Cat figurine",
+                "target": "59e3658a86f7741776641ac4",
                 "number": 1,
                 "location": "Any",
-                "id": 239,
-                "bsgId": "59e3658a86f7741776641ac4"
+                "id": 239
             },
             {
                 "type": "find",
-                "target": "Roler submariner gold wrist watch",
+                "target": "59faf7ca86f7740dbe19f6c2",
                 "number": 1,
                 "location": "Any",
-                "id": 240,
-                "bsgId": "59faf7ca86f7740dbe19f6c2"
+                "id": 240
             }
         ]
     },
@@ -5171,19 +5105,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Antique teapot",
+                "target": "590de71386f774347051a052",
                 "number": 3,
                 "location": "Any",
-                "id": 241,
-                "bsgId": "590de71386f774347051a052"
+                "id": 241
             },
             {
                 "type": "find",
-                "target": "Antique vase",
+                "target": "590de7e986f7741b096e5f32",
                 "number": 2,
                 "location": "Any",
-                "id": 242,
-                "bsgId": "590de7e986f7741b096e5f32"
+                "id": 242
             }
         ]
     },
@@ -5238,27 +5170,24 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Iskra lunch box",
+                "target": "590c5d4b86f774784e1b9c45",
                 "number": 3,
                 "location": "Any",
-                "id": 244,
-                "bsgId": "590c5d4b86f774784e1b9c45"
+                "id": 244
             },
             {
                 "type": "find",
-                "target": "Emelya rye croutons",
+                "target": "5751487e245977207e26a315",
                 "number": 2,
                 "location": "Any",
-                "id": 245,
-                "bsgId": "5751487e245977207e26a315"
+                "id": 245
             },
             {
                 "type": "find",
-                "target": "Can of delicious beef stew",
+                "target": "57347da92459774491567cf5",
                 "number": 2,
                 "location": "Any",
-                "id": 246,
-                "bsgId": "57347da92459774491567cf5"
+                "id": 246
             }
         ]
     },
@@ -5904,35 +5833,31 @@
             },
             {
                 "type": "find",
-                "target": "AHF1-M",
+                "target": "5ed515f6915ec335206e4152",
                 "number": 1,
                 "location": "Any",
-                "id": 322,
-                "bsgId": "5ed515f6915ec335206e4152"
+                "id": 322
             },
             {
                 "type": "find",
-                "target": "3-(b-TG)",
+                "target": "5ed515c8d380ab312177c0fa",
                 "number": 1,
                 "location": "Any",
-                "id": 323,
-                "bsgId": "5ed515c8d380ab312177c0fa"
+                "id": 323
             },
             {
                 "type": "collect",
-                "target": "Lab. Blue keycard",
+                "target": "5c1d0c5f86f7744bb2683cf0",
                 "number": 1,
                 "location": "Any",
-                "id": 324,
-                "bsgId": "5c1d0c5f86f7744bb2683cf0"
+                "id": 324
             },
             {
                 "type": "collect",
-                "target": "Lab. Green keycard",
+                "target": "5c1d0dc586f7744baf2e7b79",
                 "number": 1,
                 "location": "Any",
-                "id": 325,
-                "bsgId": "5c1d0dc586f7744baf2e7b79"
+                "id": 325
             }
         ],
         "alternatives": [
@@ -5992,19 +5917,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "CMS kit",
+                "target": "5d02778e86f774203e7dedbe",
                 "number": 2,
                 "location": "Any",
-                "id": 271,
-                "bsgId": "5d02778e86f774203e7dedbe"
+                "id": 271
             },
             {
                 "type": "find",
-                "target": "Portable defibrillator",
+                "target": "5c052e6986f7746b207bc3c9",
                 "number": 1,
                 "location": "Any",
-                "id": 272,
-                "bsgId": "5c052e6986f7746b207bc3c9"
+                "id": 272
             }
         ]
     },
@@ -6192,11 +6115,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "TerraGroup Labs access keycard",
+                "target": "5c94bbff86f7747ee735c08f",
                 "number": 2,
                 "location": "Any",
-                "id": 278,
-                "bsgId": "5c94bbff86f7747ee735c08f"
+                "id": 278
             }
         ]
     },
@@ -6230,11 +6152,10 @@
             },
             {
                 "type": "find",
-                "target": "TT pistol 7.62x25 TT Gold",
+                "target": "5b3b713c5acfc4330140bd8d",
                 "number": 1,
                 "location": "Customs",
-                "id": 280,
-                "bsgId": "5b3b713c5acfc4330140bd8d"
+                "id": 280
             }
         ]
     },
@@ -6302,11 +6223,10 @@
             },
             {
                 "type": "find",
-                "target": "Maska 1Sch helmet (Killa)",
+                "target": "5c0e874186f7745dc7616606",
                 "number": 1,
                 "location": "Interchange",
-                "id": 283,
-                "bsgId": "5c0e874186f7745dc7616606"
+                "id": 283
             }
         ]
     },
@@ -6340,11 +6260,10 @@
             },
             {
                 "type": "find",
-                "target": "Shturman key",
+                "target": "5d08d21286f774736e7c94c3",
                 "number": 1,
                 "location": "Woods",
-                "id": 285,
-                "bsgId": "5d08d21286f774736e7c94c3"
+                "id": 285
             }
         ]
     },
@@ -6575,19 +6494,17 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "6-STEN-140-M military battery",
+                "target": "5d03794386f77420415576f5",
                 "number": 1,
                 "location": "Any",
-                "id": 293,
-                "bsgId": "5d03794386f77420415576f5"
+                "id": 293
             },
             {
                 "type": "find",
-                "target": "OFZ 30x160mm shell",
+                "target": "5d0379a886f77420407aa271",
                 "number": 5,
                 "location": "Any",
-                "id": 294,
-                "bsgId": "5d0379a886f77420407aa271"
+                "id": 294
             }
         ]
     },
@@ -6651,11 +6568,10 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "Euros",
+                "target": "569668774bdc2da2298b4568",
                 "number": 50000,
                 "location": "Any",
-                "id": 296,
-                "bsgId": "569668774bdc2da2298b4568"
+                "id": 296
             }
         ]
     },
@@ -6682,27 +6598,24 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Malboro cigarettes",
+                "target": "573476d324597737da2adc13",
                 "number": 5,
                 "location": "Any",
-                "id": 297,
-                "bsgId": "573476d324597737da2adc13"
+                "id": 297
             },
             {
                 "type": "find",
-                "target": "Strike cigarettes",
+                "target": "5734770f24597738025ee254",
                 "number": 5,
                 "location": "Any",
-                "id": 298,
-                "bsgId": "5734770f24597738025ee254"
+                "id": 298
             },
             {
                 "type": "find",
-                "target": "Wilston cigarettes",
+                "target": "573476f124597737e04bf328",
                 "number": 5,
                 "location": "Any",
-                "id": 299,
-                "bsgId": "573476f124597737e04bf328"
+                "id": 299
             }
         ]
     },
@@ -6768,11 +6681,10 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Secure Flash drive",
+                "target": "590c621186f774138d11ea29",
                 "number": 3,
                 "location": "Any",
-                "id": 302,
-                "bsgId": "590c621186f774138d11ea29"
+                "id": 302
             }
         ]
     },
@@ -6947,27 +6859,24 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Aramid fiber cloth",
+                "target": "5e2af4d286f7746d4159f07a",
                 "number": 5,
                 "location": "Any",
-                "id": 306,
-                "bsgId": "5e2af4d286f7746d4159f07a"
+                "id": 306
             },
             {
                 "type": "find",
-                "target": "Ripstop cloth",
+                "target": "5e2af4a786f7746d3f3c3400",
                 "number": 10,
                 "location": "Any",
-                "id": 307,
-                "bsgId": "5e2af4a786f7746d3f3c3400"
+                "id": 307
             },
             {
                 "type": "find",
-                "target": "Paracord",
+                "target": "5c12688486f77426843c7d32",
                 "number": 3,
                 "location": "Any",
-                "id": 308,
-                "bsgId": "5c12688486f77426843c7d32"
+                "id": 308
             }
         ]
     },
@@ -6990,27 +6899,24 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Fleece cloth",
+                "target": "5e2af47786f7746d404f3aaa",
                 "number": 10,
                 "location": "Any",
-                "id": 309,
-                "bsgId": "5e2af47786f7746d404f3aaa"
+                "id": 309
             },
             {
                 "type": "find",
-                "target": "Polyamide fabric Cordura",
+                "target": "5e2af41e86f774755a234b67",
                 "number": 10,
                 "location": "Any",
-                "id": 310,
-                "bsgId": "5e2af41e86f774755a234b67"
+                "id": 310
             },
             {
                 "type": "find",
-                "target": "KEKTAPE duct tape",
+                "target": "5e2af29386f7746d4159f077",
                 "number": 5,
                 "location": "Any",
-                "id": 311,
-                "bsgId": "5e2af29386f7746d4159f077"
+                "id": 311
             }
         ]
     },
@@ -7222,59 +7128,52 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "M.U.L.E. stimulator",
+                "target": "5ed51652f6c34d2cc26336a1",
                 "number": 1,
                 "location": "Any",
-                "id": 331,
-                "bsgId": "5ed51652f6c34d2cc26336a1"
+                "id": 331
             },
             {
                 "type": "find",
-                "target": "Cocktail \"Obdolbos\"",
+                "target": "5ed5166ad380ab312177c100",
                 "number": 1,
                 "location": "Any",
-                "id": 332,
-                "bsgId": "5ed5166ad380ab312177c100"
+                "id": 332
             },
             {
                 "type": "find",
-                "target": "Meldonin",
+                "target": "5ed5160a87bb8443d10680b5",
                 "number": 1,
                 "location": "Any",
-                "id": 333,
-                "bsgId": "5ed5160a87bb8443d10680b5"
+                "id": 333
             },
             {
                 "type": "find",
-                "target": "AHF1-M",
+                "target": "5ed515f6915ec335206e4152",
                 "number": 1,
                 "location": "Any",
-                "id": 334,
-                "bsgId": "5ed515f6915ec335206e4152"
+                "id": 334
             },
             {
                 "type": "find",
-                "target": "P22",
+                "target": "5ed515ece452db0eb56fc028",
                 "number": 1,
                 "location": "Any",
-                "id": 335,
-                "bsgId": "5ed515ece452db0eb56fc028"
+                "id": 335
             },
             {
                 "type": "find",
-                "target": "L1 (Norepinephrine)",
+                "target": "5ed515e03a40a50460332579",
                 "number": 1,
                 "location": "Any",
-                "id": 336,
-                "bsgId": "5ed515e03a40a50460332579"
+                "id": 336
             },
             {
                 "type": "find",
-                "target": "3-(b-TG)",
+                "target": "5ed515c8d380ab312177c0fa",
                 "number": 1,
                 "location": "Any",
-                "id": 337,
-                "bsgId": "5ed515c8d380ab312177c0fa"
+                "id": 337
             }
         ]
     },
@@ -7628,147 +7527,129 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "Old firesteel",
+                "target": "5bc9c377d4351e3bac12251b",
                 "number": 1,
                 "location": "Any",
-                "id": 353,
-                "bsgId": "5bc9c377d4351e3bac12251b"
+                "id": 353
             },
             {
                 "type": "find",
-                "target": "Antique axe",
+                "target": "5bc9c1e2d4351e00367fbcf0",
                 "number": 1,
                 "location": "Any",
-                "id": 354,
-                "bsgId": "5bc9c1e2d4351e00367fbcf0"
+                "id": 354
             },
             {
                 "type": "find",
-                "target": "Battered antique Book",
+                "target": "5bc9c049d4351e44f824d360",
                 "number": 1,
                 "location": "Any",
-                "id": 355,
-                "bsgId": "5bc9c049d4351e44f824d360"
+                "id": 355
             },
             {
                 "type": "find",
-                "target": "#FireKlean gun lube",
+                "target": "5bc9b355d4351e6d1509862a",
                 "number": 1,
                 "location": "Any",
-                "id": 356,
-                "bsgId": "5bc9b355d4351e6d1509862a"
+                "id": 356
             },
             {
                 "type": "find",
-                "target": "Golden rooster",
+                "target": "5bc9bc53d4351e00367fbcee",
                 "number": 1,
                 "location": "Any",
-                "id": 357,
-                "bsgId": "5bc9bc53d4351e00367fbcee"
+                "id": 357
             },
             {
                 "type": "find",
-                "target": "Silver Badge",
+                "target": "5bc9bdb8d4351e003562b8a1",
                 "number": 1,
                 "location": "Any",
-                "id": 358,
-                "bsgId": "5bc9bdb8d4351e003562b8a1"
+                "id": 358
             },
             {
                 "type": "find",
-                "target": "Deadlyslob's beard oil",
+                "target": "5bc9b9ecd4351e3bac122519",
                 "number": 1,
                 "location": "Any",
-                "id": 359,
-                "bsgId": "5bc9b9ecd4351e3bac122519"
+                "id": 359
             },
             {
                 "type": "find",
-                "target": "Golden 1GPhone",
+                "target": "5bc9b720d4351e450201234b",
                 "number": 1,
                 "location": "Any",
-                "id": 360,
-                "bsgId": "5bc9b720d4351e450201234b"
+                "id": 360
             },
             {
                 "type": "find",
-                "target": "Jar of DevilDog mayo",
+                "target": "5bc9b156d4351e00367fbce9",
                 "number": 1,
                 "location": "Any",
-                "id": 361,
-                "bsgId": "5bc9b156d4351e00367fbce9"
+                "id": 361
             },
             {
                 "type": "find",
-                "target": "Can of sprats",
+                "target": "5bc9c29cd4351e003562b8a3",
                 "number": 1,
                 "location": "Any",
-                "id": 362,
-                "bsgId": "5bc9c29cd4351e003562b8a3"
+                "id": 362
             },
             {
                 "type": "find",
-                "target": "Fake mustache",
+                "target": "5bd073a586f7747e6f135799",
                 "number": 1,
                 "location": "Any",
-                "id": 363,
-                "bsgId": "5bd073a586f7747e6f135799"
+                "id": 363
             },
             {
                 "type": "find",
-                "target": "Kotton beanie",
+                "target": "5bd073c986f7747f627e796c",
                 "number": 1,
                 "location": "Any",
-                "id": 364,
-                "bsgId": "5bd073c986f7747f627e796c"
+                "id": 364
             },
             {
                 "type": "find",
-                "target": "Can of Dr. Lupo's coffee beans",
+                "target": "5e54f6af86f7742199090bf3",
                 "number": 1,
                 "location": "Any",
-                "id": 365,
-                "bsgId": "5e54f6af86f7742199090bf3"
+                "id": 365
             },
             {
                 "type": "find",
-                "target": "Pestily plague mask",
+                "target": "5e54f79686f7744022011103",
                 "number": 1,
                 "location": "Any",
-                "id": 366,
-                "bsgId": "5e54f79686f7744022011103"
+                "id": 366
             },
             {
                 "type": "find",
-                "target": "Raven figurine",
+                "target": "5e54f62086f774219b0f1937",
                 "number": 1,
                 "location": "Any",
-                "id": 367,
-                "bsgId": "5e54f62086f774219b0f1937"
+                "id": 367
             },
             {
                 "type": "find",
-                "target": "Shroud half-mask",
+                "target": "5e54f76986f7740366043752",
                 "number": 1,
                 "location": "Any",
-                "id": 368,
-                "bsgId": "5e54f76986f7740366043752"
+                "id": 368
             },
             {
                 "type": "find",
-                "target": "Veritas guitar pick",
+                "target": "5f745ee30acaeb0d490d8c5b",
                 "number": 1,
                 "location": "Any",
-                "id": 369,
-                "bsgId": "5f745ee30acaeb0d490d8c5b"
+                "id": 369
             },
             {
                 "type": "find",
-                "target": "42nd Signature Blend English Tea",
+                "target": "5bc9be8fd4351e00334cae6e",
                 "number": 1,
                 "location": "Any",
-                "id": 370,
-                "bsgId": "5bc9be8fd4351e00334cae6e"
+                "id": 370
             }
         ]
     },

--- a/quests.json
+++ b/quests.json
@@ -29,7 +29,7 @@
             },
             {
                 "type": "collect",
-                "target": "54491c4f4bdc2db1078b4568",
+                "target": "MP-133 12ga shotgun",
                 "number": 2,
                 "location": "Any",
                 "id": 1
@@ -276,7 +276,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "55d482194bdc2d1d4e8b456b",
+                "target": "60-round 6L31 5.45x39 magazine for АК-74 and compatibles",
                 "number": 3,
                 "location": "Any",
                 "have": 0,
@@ -587,7 +587,7 @@
             },
             {
                 "type": "find",
-                "target": "572b7fa524597762b747ce82",
+                "target": "Lower half-mask",
                 "number": 7,
                 "location": "Any",
                 "id": 27
@@ -681,7 +681,7 @@
             },
             {
                 "type": "find",
-                "target": "57e26fc7245977162a14b800",
+                "target": "Bars A-2607- 95x18",
                 "number": 5,
                 "location": "Any",
                 "id": 31
@@ -724,21 +724,21 @@
             },
             {
                 "type": "find",
-                "target": "5644bd2b4bdc2d3b4c8b4572",
+                "target": "AK-74N 5.45x39 assault rifle",
                 "number": 1,
                 "location": "Any",
                 "id": 33
             },
             {
                 "type": "find",
-                "target": "5447a9cd4bdc2dbd208b4567",
+                "target": "Colt M4A1 5.56x45 Assault Rifle",
                 "number": 1,
                 "location": "Any",
                 "id": 34
             },
             {
                 "type": "find",
-                "target": "5448bd6b4bdc2dfc2f8b4569",
+                "target": "PM 9x18PM pistol",
                 "number": 2,
                 "location": "Any",
                 "id": 35
@@ -786,14 +786,14 @@
             },
             {
                 "type": "collect",
-                "target": "59f32c3b86f77472a31742f0",
+                "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
                 "id": 37
             },
             {
                 "type": "collect",
-                "target": "59f32bb586f774757e1e8442",
+                "target": "Dogtag BEAR",
                 "number": 7,
                 "location": "Any",
                 "id": 38
@@ -821,7 +821,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "544fb45d4bdc2dee738b4568",
+                "target": "Salewa First Aid Kit",
                 "number": 3,
                 "location": "Any",
                 "id": 39
@@ -853,7 +853,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590a3efd86f77437d351a25b",
+                "target": "Gas analyzer",
                 "number": 1,
                 "location": "Any",
                 "id": 40
@@ -883,7 +883,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590a3efd86f77437d351a25b",
+                "target": "Gas analyzer",
                 "number": 2,
                 "location": "Any",
                 "id": 41
@@ -913,7 +913,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "544fb3f34bdc2d03748b456a",
+                "target": "Morphine injector",
                 "number": 4,
                 "location": "Any",
                 "have": 0,
@@ -1057,7 +1057,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "57347d7224597744596b4e72",
+                "target": "Can of beef stew",
                 "number": 15,
                 "location": "Any",
                 "id": 47
@@ -1087,7 +1087,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5733279d245977289b77ec24",
+                "target": "Car battery",
                 "number": 4,
                 "location": "Any",
                 "have": 0,
@@ -1095,7 +1095,7 @@
             },
             {
                 "type": "find",
-                "target": "590a3c0a86f774385a33c450",
+                "target": "Spark plug",
                 "number": 8,
                 "location": "Any",
                 "have": 0,
@@ -1342,14 +1342,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5af0534a86f7743b6f354284",
+                "target": "Ophthalmoscope",
                 "number": 1,
                 "location": "Any",
                 "id": 59
             },
             {
                 "type": "find",
-                "target": "5c0530ee86f774697952d952",
+                "target": "LEDX Skin Transilluminator",
                 "number": 1,
                 "location": "Any",
                 "id": 60
@@ -1411,14 +1411,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e7635f86f7742cbf2c1095",
+                "target": "Module-3M bodyarmor",
                 "number": 1,
                 "location": "Any",
                 "id": 62
             },
             {
                 "type": "find",
-                "target": "5a38e6bac4a2826c6e06d79b",
+                "target": "TOZ-106 bolt-action shotgun",
                 "number": 1,
                 "location": "Any",
                 "id": 63
@@ -1489,7 +1489,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590c621186f774138d11ea29",
+                "target": "Secure Flash drive",
                 "number": 2,
                 "location": "Any",
                 "id": 66
@@ -1802,14 +1802,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e7715586f7742ee5789605",
+                "target": "Respirator",
                 "number": 4,
                 "location": "Any",
                 "id": 83
             },
             {
                 "type": "find",
-                "target": "5b4335ba86f7744d2837a264",
+                "target": "Medical bloodset",
                 "number": 3,
                 "location": "Any",
                 "id": 84
@@ -1849,7 +1849,7 @@
             },
             {
                 "type": "find",
-                "target": "59f32c3b86f77472a31742f0",
+                "target": "Dogtag USEC",
                 "number": 7,
                 "location": "Any",
                 "id": 85
@@ -1879,7 +1879,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "5696686a4bdc2da3298b456a",
+                "target": "Dollars",
                 "number": 6000,
                 "location": "Any",
                 "id": 87
@@ -1986,14 +1986,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5c05308086f7746b2101e90b",
+                "target": "Virtex programmable processor",
                 "number": 2,
                 "location": "Any",
                 "id": 95
             },
             {
                 "type": "find",
-                "target": "5c052f6886f7746b1e3db148",
+                "target": "Military COFDM wireless Signal Transmitter",
                 "number": 1,
                 "location": "Any",
                 "id": 96
@@ -2574,7 +2574,7 @@
             },
             {
                 "type": "collect",
-                "target": "590c5f0d86f77413997acfab",
+                "target": "MRE lunch box",
                 "number": 5,
                 "location": "Any",
                 "id": 128
@@ -2783,28 +2783,28 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590c5bbd86f774785762df04",
+                "target": "WD-40 100ml.",
                 "number": 1,
                 "location": "Any",
                 "id": 138
             },
             {
                 "type": "find",
-                "target": "59e358a886f7741776641ac3",
+                "target": "Clin wiper",
                 "number": 2,
                 "location": "Any",
                 "id": 139
             },
             {
                 "type": "find",
-                "target": "59e35cbb86f7741778269d83",
+                "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
                 "id": 140
             },
             {
                 "type": "find",
-                "target": "59e3556c86f7741776641ac2",
+                "target": "Ox bleach",
                 "number": 2,
                 "location": "Any",
                 "id": 141
@@ -2908,7 +2908,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "5696686a4bdc2da3298b456a",
+                "target": "Dollars",
                 "number": 8000,
                 "location": "Any",
                 "id": 146
@@ -2942,28 +2942,28 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "544fb3f34bdc2d03748b456a",
+                "target": "Morphine injector",
                 "number": 4,
                 "location": "Any",
                 "id": 147
             },
             {
                 "type": "find",
-                "target": "59faf98186f774067b6be103",
+                "target": "Heat-exchange alkali surface washer",
                 "number": 2,
                 "location": "Any",
                 "id": 148
             },
             {
                 "type": "find",
-                "target": "59e35cbb86f7741778269d83",
+                "target": "Corrugated hose",
                 "number": 2,
                 "location": "Any",
                 "id": 149
             },
             {
                 "type": "find",
-                "target": "59fafb5d86f774067a6f2084",
+                "target": "5L propane tank",
                 "number": 2,
                 "location": "Any",
                 "id": 150
@@ -3733,28 +3733,28 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "573477e124597737dd42e191",
+                "target": "PC CPU",
                 "number": 3,
                 "location": "Any",
                 "id": 165
             },
             {
                 "type": "find",
-                "target": "590a358486f77429692b2790",
+                "target": "Rechargeable battery",
                 "number": 3,
                 "location": "Any",
                 "id": 166
             },
             {
                 "type": "find",
-                "target": "590a3b0486f7743954552bdb",
+                "target": "Printed circuit board",
                 "number": 3,
                 "location": "Any",
                 "id": 167
             },
             {
                 "type": "find",
-                "target": "56742c324bdc2d150f8b456d",
+                "target": "Broken GPhone",
                 "number": 3,
                 "location": "Any",
                 "id": 168
@@ -3981,21 +3981,21 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e36c6f86f774176c10a2a7",
+                "target": "Powercord",
                 "number": 2,
                 "location": "Any",
                 "id": 179
             },
             {
                 "type": "find",
-                "target": "57347cd0245977445a2d6ff1",
+                "target": "T-Shaped Plug",
                 "number": 4,
                 "location": "Any",
                 "id": 180
             },
             {
                 "type": "find",
-                "target": "590a3b0486f7743954552bdb",
+                "target": "Printed circuit board",
                 "number": 2,
                 "location": "Any",
                 "id": 181
@@ -4062,14 +4062,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "57347ca924597744596b4e71",
+                "target": "Graphics card",
                 "number": 3,
                 "location": "Any",
                 "id": 184
             },
             {
                 "type": "find",
-                "target": "5734779624597737e04bf329",
+                "target": "CPU Fan",
                 "number": 8,
                 "location": "Any",
                 "id": 185
@@ -4100,14 +4100,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5c052fb986f7746b2101e909",
+                "target": "UHF RFID Reader",
                 "number": 1,
                 "location": "Any",
                 "id": 186
             },
             {
                 "type": "find",
-                "target": "5c05300686f7746dce784e5d",
+                "target": "VPX Flash Storage Module",
                 "number": 1,
                 "location": "Any",
                 "id": 187
@@ -4137,14 +4137,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5c06779c86f77426e00dd782",
+                "target": "Wires",
                 "number": 5,
                 "location": "Any",
                 "id": 188
             },
             {
                 "type": "find",
-                "target": "5c06782b86f77426df5407d2",
+                "target": "Capacitors",
                 "number": 5,
                 "location": "Any",
                 "id": 189
@@ -4373,14 +4373,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e7708286f7742cbd762753",
+                "target": "Ushanka ear-flap cap",
                 "number": 2,
                 "location": "Any",
                 "id": 203
             },
             {
                 "type": "find",
-                "target": "5aa2b9ede5b5b000137b758b",
+                "target": "Kinda cowboy hat",
                 "number": 2,
                 "location": "Any",
                 "id": 204
@@ -4573,7 +4573,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "5ad7247386f7747487619dc3",
+                "target": "Key to Goshan cash register",
                 "number": 1,
                 "location": "Any",
                 "id": 214
@@ -4760,14 +4760,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5ab8f20c86f7745cdb629fb2",
+                "target": "Ski hat with holes for eyes",
                 "number": 1,
                 "location": "Any",
                 "id": 223
             },
             {
                 "type": "find",
-                "target": "59e763f286f7742ee57895da",
+                "target": "Pilgrim tourist backpack",
                 "number": 1,
                 "location": "Any",
                 "id": 224
@@ -4797,7 +4797,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "5ab8e79e86f7742d8b372e78",
+                "target": "BNTI Gzhel-K armor",
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
@@ -4805,7 +4805,7 @@
             },
             {
                 "type": "collect",
-                "target": "5ab8e79e86f7742d8b372e78",
+                "target": "BNTI Gzhel-K armor",
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
@@ -4836,7 +4836,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "545cdb794bdc2d3a198b456a",
+                "target": "6B43 Zabralo-Sh 6A Armor",
                 "hint": "0-50% condition",
                 "number": 1,
                 "location": "Any",
@@ -4844,7 +4844,7 @@
             },
             {
                 "type": "collect",
-                "target": "545cdb794bdc2d3a198b456a",
+                "target": "6B43 Zabralo-Sh 6A Armor",
                 "hint": "50-100% condition",
                 "number": 1,
                 "location": "Any",
@@ -4875,14 +4875,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e7643b86f7742cbf2c109a",
+                "target": "Wartech gear rig (TV-109, TV-106)",
                 "number": 2,
                 "location": "Any",
                 "id": 229
             },
             {
                 "type": "find",
-                "target": "5648a69d4bdc2ded0b8b457b",
+                "target": "BlackRock chest rig",
                 "number": 2,
                 "location": "Any",
                 "id": 230
@@ -4973,7 +4973,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5b43575a86f77424f443fe62",
+                "target": "Fuel conditioner",
                 "number": 4,
                 "location": "Any",
                 "id": 233
@@ -5054,28 +5054,28 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "59e3639286f7741777737013",
+                "target": "Bronze lion",
                 "number": 2,
                 "location": "Any",
                 "id": 237
             },
             {
                 "type": "find",
-                "target": "573478bc24597738002c6175",
+                "target": "Horse figurine",
                 "number": 2,
                 "location": "Any",
                 "id": 238
             },
             {
                 "type": "find",
-                "target": "59e3658a86f7741776641ac4",
+                "target": "Cat figurine",
                 "number": 1,
                 "location": "Any",
                 "id": 239
             },
             {
                 "type": "find",
-                "target": "59faf7ca86f7740dbe19f6c2",
+                "target": "Roler submariner gold wrist watch",
                 "number": 1,
                 "location": "Any",
                 "id": 240
@@ -5105,14 +5105,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590de71386f774347051a052",
+                "target": "Antique teapot",
                 "number": 3,
                 "location": "Any",
                 "id": 241
             },
             {
                 "type": "find",
-                "target": "590de7e986f7741b096e5f32",
+                "target": "Antique vase",
                 "number": 2,
                 "location": "Any",
                 "id": 242
@@ -5170,21 +5170,21 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590c5d4b86f774784e1b9c45",
+                "target": "Iskra lunch box",
                 "number": 3,
                 "location": "Any",
                 "id": 244
             },
             {
                 "type": "find",
-                "target": "5751487e245977207e26a315",
+                "target": "Emelya rye croutons",
                 "number": 2,
                 "location": "Any",
                 "id": 245
             },
             {
                 "type": "find",
-                "target": "57347da92459774491567cf5",
+                "target": "Can of delicious beef stew",
                 "number": 2,
                 "location": "Any",
                 "id": 246
@@ -5833,28 +5833,28 @@
             },
             {
                 "type": "find",
-                "target": "5ed515f6915ec335206e4152",
+                "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
                 "id": 322
             },
             {
                 "type": "find",
-                "target": "5ed515c8d380ab312177c0fa",
+                "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
                 "id": 323
             },
             {
                 "type": "collect",
-                "target": "5c1d0c5f86f7744bb2683cf0",
+                "target": "Lab. Blue keycard",
                 "number": 1,
                 "location": "Any",
                 "id": 324
             },
             {
                 "type": "collect",
-                "target": "5c1d0dc586f7744baf2e7b79",
+                "target": "Lab. Green keycard",
                 "number": 1,
                 "location": "Any",
                 "id": 325
@@ -5917,14 +5917,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5d02778e86f774203e7dedbe",
+                "target": "CMS kit",
                 "number": 2,
                 "location": "Any",
                 "id": 271
             },
             {
                 "type": "find",
-                "target": "5c052e6986f7746b207bc3c9",
+                "target": "Portable defibrillator",
                 "number": 1,
                 "location": "Any",
                 "id": 272
@@ -6115,7 +6115,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5c94bbff86f7747ee735c08f",
+                "target": "TerraGroup Labs access keycard",
                 "number": 2,
                 "location": "Any",
                 "id": 278
@@ -6152,7 +6152,7 @@
             },
             {
                 "type": "find",
-                "target": "5b3b713c5acfc4330140bd8d",
+                "target": "TT pistol 7.62x25 TT Gold",
                 "number": 1,
                 "location": "Customs",
                 "id": 280
@@ -6223,7 +6223,7 @@
             },
             {
                 "type": "find",
-                "target": "5c0e874186f7745dc7616606",
+                "target": "Maska 1Sch helmet (Killa)",
                 "number": 1,
                 "location": "Interchange",
                 "id": 283
@@ -6260,7 +6260,7 @@
             },
             {
                 "type": "find",
-                "target": "5d08d21286f774736e7c94c3",
+                "target": "Shturman key",
                 "number": 1,
                 "location": "Woods",
                 "id": 285
@@ -6494,14 +6494,14 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5d03794386f77420415576f5",
+                "target": "6-STEN-140-M military battery",
                 "number": 1,
                 "location": "Any",
                 "id": 293
             },
             {
                 "type": "find",
-                "target": "5d0379a886f77420407aa271",
+                "target": "OFZ 30x160mm shell",
                 "number": 5,
                 "location": "Any",
                 "id": 294
@@ -6568,7 +6568,7 @@
         "objectives": [
             {
                 "type": "collect",
-                "target": "569668774bdc2da2298b4568",
+                "target": "Euros",
                 "number": 50000,
                 "location": "Any",
                 "id": 296
@@ -6598,21 +6598,21 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "573476d324597737da2adc13",
+                "target": "Malboro cigarettes",
                 "number": 5,
                 "location": "Any",
                 "id": 297
             },
             {
                 "type": "find",
-                "target": "5734770f24597738025ee254",
+                "target": "Strike cigarettes",
                 "number": 5,
                 "location": "Any",
                 "id": 298
             },
             {
                 "type": "find",
-                "target": "573476f124597737e04bf328",
+                "target": "Wilston cigarettes",
                 "number": 5,
                 "location": "Any",
                 "id": 299
@@ -6681,7 +6681,7 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "590c621186f774138d11ea29",
+                "target": "Secure Flash drive",
                 "number": 3,
                 "location": "Any",
                 "id": 302
@@ -6859,21 +6859,21 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5e2af4d286f7746d4159f07a",
+                "target": "Aramid fiber cloth",
                 "number": 5,
                 "location": "Any",
                 "id": 306
             },
             {
                 "type": "find",
-                "target": "5e2af4a786f7746d3f3c3400",
+                "target": "Ripstop cloth",
                 "number": 10,
                 "location": "Any",
                 "id": 307
             },
             {
                 "type": "find",
-                "target": "5c12688486f77426843c7d32",
+                "target": "Paracord",
                 "number": 3,
                 "location": "Any",
                 "id": 308
@@ -6899,21 +6899,21 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5e2af47786f7746d404f3aaa",
+                "target": "Fleece cloth",
                 "number": 10,
                 "location": "Any",
                 "id": 309
             },
             {
                 "type": "find",
-                "target": "5e2af41e86f774755a234b67",
+                "target": "Polyamide fabric Cordura",
                 "number": 10,
                 "location": "Any",
                 "id": 310
             },
             {
                 "type": "find",
-                "target": "5e2af29386f7746d4159f077",
+                "target": "KEKTAPE duct tape",
                 "number": 5,
                 "location": "Any",
                 "id": 311
@@ -7128,49 +7128,49 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5ed51652f6c34d2cc26336a1",
+                "target": "M.U.L.E. stimulator",
                 "number": 1,
                 "location": "Any",
                 "id": 331
             },
             {
                 "type": "find",
-                "target": "5ed5166ad380ab312177c100",
+                "target": "Cocktail \"Obdolbos\"",
                 "number": 1,
                 "location": "Any",
                 "id": 332
             },
             {
                 "type": "find",
-                "target": "5ed5160a87bb8443d10680b5",
+                "target": "Meldonin",
                 "number": 1,
                 "location": "Any",
                 "id": 333
             },
             {
                 "type": "find",
-                "target": "5ed515f6915ec335206e4152",
+                "target": "AHF1-M",
                 "number": 1,
                 "location": "Any",
                 "id": 334
             },
             {
                 "type": "find",
-                "target": "5ed515ece452db0eb56fc028",
+                "target": "P22",
                 "number": 1,
                 "location": "Any",
                 "id": 335
             },
             {
                 "type": "find",
-                "target": "5ed515e03a40a50460332579",
+                "target": "L1 (Norepinephrine)",
                 "number": 1,
                 "location": "Any",
                 "id": 336
             },
             {
                 "type": "find",
-                "target": "5ed515c8d380ab312177c0fa",
+                "target": "3-(b-TG)",
                 "number": 1,
                 "location": "Any",
                 "id": 337
@@ -7527,126 +7527,126 @@
         "objectives": [
             {
                 "type": "find",
-                "target": "5bc9c377d4351e3bac12251b",
+                "target": "Old firesteel",
                 "number": 1,
                 "location": "Any",
                 "id": 353
             },
             {
                 "type": "find",
-                "target": "5bc9c1e2d4351e00367fbcf0",
+                "target": "Antique axe",
                 "number": 1,
                 "location": "Any",
                 "id": 354
             },
             {
                 "type": "find",
-                "target": "5bc9c049d4351e44f824d360",
+                "target": "Battered antique Book",
                 "number": 1,
                 "location": "Any",
                 "id": 355
             },
             {
                 "type": "find",
-                "target": "5bc9b355d4351e6d1509862a",
+                "target": "#FireKlean gun lube",
                 "number": 1,
                 "location": "Any",
                 "id": 356
             },
             {
                 "type": "find",
-                "target": "5bc9bc53d4351e00367fbcee",
+                "target": "Golden rooster",
                 "number": 1,
                 "location": "Any",
                 "id": 357
             },
             {
                 "type": "find",
-                "target": "5bc9bdb8d4351e003562b8a1",
+                "target": "Silver Badge",
                 "number": 1,
                 "location": "Any",
                 "id": 358
             },
             {
                 "type": "find",
-                "target": "5bc9b9ecd4351e3bac122519",
+                "target": "Deadlyslob's beard oil",
                 "number": 1,
                 "location": "Any",
                 "id": 359
             },
             {
                 "type": "find",
-                "target": "5bc9b720d4351e450201234b",
+                "target": "Golden 1GPhone",
                 "number": 1,
                 "location": "Any",
                 "id": 360
             },
             {
                 "type": "find",
-                "target": "5bc9b156d4351e00367fbce9",
+                "target": "Jar of DevilDog mayo",
                 "number": 1,
                 "location": "Any",
                 "id": 361
             },
             {
                 "type": "find",
-                "target": "5bc9c29cd4351e003562b8a3",
+                "target": "Can of sprats",
                 "number": 1,
                 "location": "Any",
                 "id": 362
             },
             {
                 "type": "find",
-                "target": "5bd073a586f7747e6f135799",
+                "target": "Fake mustache",
                 "number": 1,
                 "location": "Any",
                 "id": 363
             },
             {
                 "type": "find",
-                "target": "5bd073c986f7747f627e796c",
+                "target": "Kotton beanie",
                 "number": 1,
                 "location": "Any",
                 "id": 364
             },
             {
                 "type": "find",
-                "target": "5e54f6af86f7742199090bf3",
+                "target": "Can of Dr. Lupo's coffee beans",
                 "number": 1,
                 "location": "Any",
                 "id": 365
             },
             {
                 "type": "find",
-                "target": "5e54f79686f7744022011103",
+                "target": "Pestily plague mask",
                 "number": 1,
                 "location": "Any",
                 "id": 366
             },
             {
                 "type": "find",
-                "target": "5e54f62086f774219b0f1937",
+                "target": "Raven figurine",
                 "number": 1,
                 "location": "Any",
                 "id": 367
             },
             {
                 "type": "find",
-                "target": "5e54f76986f7740366043752",
+                "target": "Shroud half-mask",
                 "number": 1,
                 "location": "Any",
                 "id": 368
             },
             {
                 "type": "find",
-                "target": "5f745ee30acaeb0d490d8c5b",
+                "target": "Veritas guitar pick",
                 "number": 1,
                 "location": "Any",
                 "id": 369
             },
             {
                 "type": "find",
-                "target": "5bc9be8fd4351e00334cae6e",
+                "target": "42nd Signature Blend English Tea",
                 "number": 1,
                 "location": "Any",
                 "id": 370


### PR DESCRIPTION
This solves #23 

Decided to go another route than your suggested one.
Basically, the structure is
```
{
    "54009119af1c881c07000029": {
        "id": "54009119af1c881c07000029",
        "name": "Item",
        "shortName": "Item"
    }
}
```
in a file called `items.en.json`

This way it's i18n compatible so you can do stuff like `i18n.t("54009119af1c881c07000029.name");` after you've loaded the localisation file of choice by path.