### PR TITLE
Fix for 'Shaking up Teller'

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -329,7 +329,7 @@
         "require": {
             "level": 10,
             "quests": [
-                7
+                6
             ],
             "loyalty": [
                 {


### PR DESCRIPTION
Shaking up Teller unlocks after Ice Cream Cones now, instead of after Postman Pat. Fixes #72 