### PR TITLE
Update quests.json - "Flint"

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -2285,7 +2285,7 @@
     {
         "id": 54,
         "require": {
-            "level": 27,
+            "level": 35,
             "quests": [
                 52
             ]


### PR DESCRIPTION
"Flint" now requires level 35

![EscapeFromTarkov_crmcq6KnAH](https://user-images.githubusercontent.com/5495465/125959890-073e70e8-d8da-40e6-9d71-f3339313d9f7.jpg)

