### PR TITLE
Fix "Gunsmith - Part 1"

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -3436,7 +3436,7 @@
     {
         "id": 82,
         "require": {
-            "level": 10,
+            "level": 2,
             "quests": []
         },
         "giver": "Mechanic",


### PR DESCRIPTION
"Gunsmith - Part 1" requires level 2, not 10. Fixes #88 