### PR TITLE
Required level fix for "Textile - 1, 2" quests

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -7092,7 +7092,7 @@
     {
         "id": 182,
         "require": {
-            "level": 40,
+            "level": 42,
             "quests": [
                 127
             ]
@@ -7133,7 +7133,7 @@
     {
         "id": 183,
         "require": {
-            "level": 40,
+            "level": 42,
             "quests": [
                 182
             ]


### PR DESCRIPTION
"Textile - 1, 2" now requires level 42.