### PR TITLE
Fixed typo in Intelligence Center

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -1793,7 +1793,7 @@
                 },
                 {
                     "type": "module",
-                    "name": "Intelligence Center",
+                    "name": "Intelligence center",
                     "quantity": 2,
                     "id": 270
                 },


### PR DESCRIPTION
Other occurences of this name have Center with lowercase C, so I changed it to be consistent.