### PR TITLE
Fix false flash drive on bullshit

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -2578,7 +2578,7 @@
             },
             {
                 "type": "place",
-                "target": "5c12301c86f77419522ba7e4",
+                "target": "False flash drive",
                 "number": 1,
                 "location": "Customs",
                 "id": 112


### PR DESCRIPTION
Use the quest item's English name rather than unknown item id