### PR TITLE
Traders name to ID

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -19,7 +19,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -61,7 +61,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -103,7 +103,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -140,7 +140,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -189,11 +189,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -259,7 +259,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -303,7 +303,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -341,7 +341,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -385,11 +385,11 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -431,7 +431,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -537,7 +537,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -575,7 +575,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -617,7 +617,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -655,7 +655,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -702,11 +702,11 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.04
             },
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.02
             }
         ],
@@ -746,11 +746,11 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -808,7 +808,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -868,15 +868,15 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.04
             },
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.01
             },
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.05
             }
         ],
@@ -926,7 +926,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -963,7 +963,7 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -998,7 +998,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -1033,7 +1033,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -1071,7 +1071,7 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1113,7 +1113,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1157,7 +1157,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -1201,7 +1201,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -1236,7 +1236,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1282,7 +1282,7 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -1337,7 +1337,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1381,7 +1381,7 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1416,7 +1416,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.09
             }
         ],
@@ -1451,7 +1451,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1487,7 +1487,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.05
             }
         ],
@@ -1526,7 +1526,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.05
             }
         ],
@@ -1570,7 +1570,7 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -1605,7 +1605,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -1647,7 +1647,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -1689,11 +1689,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -1730,7 +1730,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -1786,7 +1786,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -1830,7 +1830,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -1879,11 +1879,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -1920,11 +1920,11 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -1970,11 +1970,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -2041,7 +2041,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2083,7 +2083,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.06
             }
         ],
@@ -2128,7 +2128,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.12
             }
         ],
@@ -2165,7 +2165,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2250,7 +2250,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             }
         ],
@@ -2295,7 +2295,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             }
         ],
@@ -2373,7 +2373,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2425,7 +2425,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2484,7 +2484,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2534,7 +2534,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2571,7 +2571,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.07
             }
         ],
@@ -2636,7 +2636,7 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -2678,7 +2678,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.02
             }
         ],
@@ -2720,11 +2720,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -2781,11 +2781,11 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -2840,7 +2840,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -2886,7 +2886,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -2950,7 +2950,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.02
             }
         ],
@@ -2985,7 +2985,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3054,7 +3054,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3094,7 +3094,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.02
             }
         ],
@@ -3138,7 +3138,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3194,7 +3194,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3246,7 +3246,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.02
             }
         ],
@@ -3283,7 +3283,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             }
         ],
@@ -3318,11 +3318,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -3378,7 +3378,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3425,7 +3425,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3461,7 +3461,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3496,11 +3496,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -3540,7 +3540,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3576,7 +3576,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3611,7 +3611,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3648,7 +3648,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -3695,11 +3695,11 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.06
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -3768,7 +3768,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.12
             }
         ],
@@ -3793,7 +3793,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -3820,7 +3820,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -3847,7 +3847,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -3874,7 +3874,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -3901,7 +3901,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -3928,7 +3928,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -3955,7 +3955,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -3982,7 +3982,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4009,7 +4009,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4038,7 +4038,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4065,7 +4065,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4095,7 +4095,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4124,7 +4124,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4153,7 +4153,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4180,7 +4180,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4207,7 +4207,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.04
             }
         ],
@@ -4234,7 +4234,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4276,7 +4276,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4334,7 +4334,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4389,7 +4389,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4424,7 +4424,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4477,7 +4477,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.04
             }
         ],
@@ -4512,7 +4512,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4556,7 +4556,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4605,7 +4605,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4647,7 +4647,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4690,11 +4690,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -4736,7 +4736,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -4780,7 +4780,7 @@
         ],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -4846,7 +4846,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.02
             }
         ],
@@ -4881,7 +4881,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -4944,7 +4944,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.02
             }
         ],
@@ -4999,7 +4999,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5041,7 +5041,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5090,7 +5090,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5132,7 +5132,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5190,7 +5190,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5227,7 +5227,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.09
             }
         ],
@@ -5264,7 +5264,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.04
             }
         ],
@@ -5318,7 +5318,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5353,7 +5353,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.02
             }
         ],
@@ -5388,7 +5388,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5443,7 +5443,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.02
             }
         ],
@@ -5485,7 +5485,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5529,7 +5529,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5573,7 +5573,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5616,7 +5616,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5653,7 +5653,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5688,7 +5688,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5725,7 +5725,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.04
             }
         ],
@@ -5781,7 +5781,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -5839,7 +5839,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.05
             }
         ],
@@ -5879,7 +5879,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.03
             }
         ],
@@ -5914,7 +5914,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.01
             }
         ],
@@ -5963,7 +5963,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6001,7 +6001,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6061,7 +6061,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6096,7 +6096,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6134,7 +6134,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6173,7 +6173,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.03
             }
         ],
@@ -6222,7 +6222,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6257,7 +6257,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6298,7 +6298,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6353,7 +6353,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6395,7 +6395,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6432,7 +6432,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -6473,7 +6473,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6514,7 +6514,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -6556,7 +6556,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.06
             }
         ],
@@ -6595,7 +6595,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6635,7 +6635,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -6687,11 +6687,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.04
             }
         ],
@@ -6757,7 +6757,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6794,7 +6794,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6836,7 +6836,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6874,7 +6874,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6909,7 +6909,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6945,7 +6945,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -6984,7 +6984,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7022,7 +7022,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7057,7 +7057,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -7100,7 +7100,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7138,7 +7138,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -7180,7 +7180,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7222,7 +7222,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7257,7 +7257,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -7298,7 +7298,7 @@
         ],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7337,11 +7337,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             },
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": -0.02
             }
         ],
@@ -7385,11 +7385,11 @@
         ],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             },
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": -0.02
             }
         ],
@@ -7424,7 +7424,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -7462,7 +7462,7 @@
         ],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -7506,15 +7506,15 @@
         ],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             },
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": -0.05
             },
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": -0.02
             }
         ],
@@ -7583,7 +7583,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -7634,7 +7634,7 @@
         ],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -7678,7 +7678,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7713,7 +7713,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.02
             }
         ],
@@ -7748,7 +7748,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -7794,11 +7794,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             },
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": -0.01
             }
         ],
@@ -7843,7 +7843,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -7972,7 +7972,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.04
             }
         ],
@@ -8028,7 +8028,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.04
             }
         ],
@@ -8078,7 +8078,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.05
             }
         ],
@@ -8132,7 +8132,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.05
             }
         ],
@@ -8178,7 +8178,7 @@
         ],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             }
         ],
@@ -8257,7 +8257,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.04
             }
         ],
@@ -8309,11 +8309,11 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             },
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": -0.02
             }
         ],
@@ -8352,7 +8352,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -8395,7 +8395,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -8458,7 +8458,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.02
             }
         ],
@@ -8530,7 +8530,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],
@@ -8879,7 +8879,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.25
             }
         ],
@@ -8918,7 +8918,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.25
             }
         ],
@@ -8978,7 +8978,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.25
             }
         ],
@@ -9015,7 +9015,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.2
             }
         ],
@@ -9058,7 +9058,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": 0.03
             }
         ],
@@ -9116,7 +9116,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -9161,7 +9161,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -9204,7 +9204,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Mechanic",
+                "trader": 4,
                 "rep": 0.02
             }
         ],
@@ -9240,7 +9240,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.03
             }
         ],
@@ -9329,7 +9329,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Peacekeeper",
+                "trader": 3,
                 "rep": 0.02
             }
         ],
@@ -9364,7 +9364,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Ragman",
+                "trader": 5,
                 "rep": 0.03
             }
         ],
@@ -9448,7 +9448,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.03
             }
         ],
@@ -9483,7 +9483,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": 0.04
             }
         ],
@@ -9532,7 +9532,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": 0.04
             }
         ],
@@ -9570,7 +9570,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.04
             }
         ],
@@ -9612,7 +9612,7 @@
         "unlocks": [],
         "reputation": [
             {
-                "trader": "Jaeger",
+                "trader": 6,
                 "rep": 0.02
             }
         ],

--- a/quests.json
+++ b/quests.json
@@ -1119,7 +1119,7 @@
         ],
         "reputationFailure": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": -0.04
             }
         ],
@@ -1163,7 +1163,7 @@
         ],
         "reputationFailure": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": -0.04
             }
         ],
@@ -1930,7 +1930,7 @@
         ],
         "reputationFailure": [
             {
-                "trader": "Skier",
+                "trader": 2,
                 "rep": -0.25
             }
         ],
@@ -7754,7 +7754,7 @@
         ],
         "reputationFailure": [
             {
-                "trader": "Therapist",
+                "trader": 1,
                 "rep": -0.25
             }
         ],
@@ -7804,7 +7804,7 @@
         ],
         "reputationFailure": [
             {
-                "trader": "Prapor",
+                "trader": 0,
                 "rep": -0.25
             }
         ],

--- a/quests.json
+++ b/quests.json
@@ -5,7 +5,7 @@
             "level": 1,
             "quests": []
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Debut",
         "locales": {
@@ -49,7 +49,7 @@
                 0
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Checking",
         "locales": {
@@ -91,7 +91,7 @@
                 1
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Shootout picnic",
         "locales": {
@@ -126,7 +126,7 @@
                 1
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Delivery from the past",
         "locales": {
@@ -177,7 +177,7 @@
                 3
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "BP depot",
         "locales": {
@@ -245,7 +245,7 @@
                 4
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Bad rep evidence",
         "locales": {
@@ -289,7 +289,7 @@
                 5
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Ice cream cones",
         "locales": {
@@ -327,7 +327,7 @@
                 6
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Therapist",
         "title": "Postman Pat",
         "locales": {
@@ -370,7 +370,7 @@
                 }
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Shaking up teller",
         "locales": {
@@ -419,7 +419,7 @@
                 8
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Perfect mediator",
         "locales": {
@@ -489,7 +489,7 @@
                 8
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Grenadier",
         "locales": {
@@ -525,7 +525,7 @@
                 10
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Insomnia",
         "locales": {
@@ -563,7 +563,7 @@
                 10
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Test drive. Pt. 1",
         "locales": {
@@ -603,7 +603,7 @@
                 8
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 1",
         "locales": {
@@ -643,7 +643,7 @@
                 13
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 2",
         "locales": {
@@ -688,7 +688,7 @@
                 14
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 3",
         "locales": {
@@ -732,7 +732,7 @@
                 15
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 4",
         "locales": {
@@ -794,7 +794,7 @@
                 16
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 5",
         "locales": {
@@ -856,7 +856,7 @@
                 17
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The Punisher - Part 6",
         "locales": {
@@ -914,7 +914,7 @@
             "level": 1,
             "quests": []
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Shortage",
         "locales": {
@@ -949,7 +949,7 @@
                 19
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Sanitary Standards - Part 1",
         "locales": {
@@ -986,7 +986,7 @@
                 20
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Sanitary Standards - Part 2",
         "locales": {
@@ -1021,7 +1021,7 @@
                 21
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Painkiller",
         "locales": {
@@ -1057,7 +1057,7 @@
                 22
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Pharmacist",
         "locales": {
@@ -1101,7 +1101,7 @@
                 23
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Supply plans",
         "locales": {
@@ -1145,7 +1145,7 @@
                 23
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Kind of sabotage",
         "locales": {
@@ -1189,7 +1189,7 @@
                 23
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "General wares",
         "locales": {
@@ -1224,7 +1224,7 @@
                 23
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Car repair",
         "locales": {
@@ -1268,7 +1268,7 @@
                 23
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Health Care Privacy - Part 1",
         "locales": {
@@ -1325,7 +1325,7 @@
                 28
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Health Care Privacy - Part 2",
         "locales": {
@@ -1367,7 +1367,7 @@
                 29
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Health Care Privacy - Part 3",
         "locales": {
@@ -1404,7 +1404,7 @@
                 30
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Health Care Privacy - Part 4",
         "locales": {
@@ -1439,7 +1439,7 @@
                 31
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Health Care Privacy - Part 5",
         "locales": {
@@ -1475,7 +1475,7 @@
                 34
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Decontamination Service",
         "locales": {
@@ -1514,7 +1514,7 @@
                 31
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Private clinic",
         "locales": {
@@ -1556,7 +1556,7 @@
                 31
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Athlete",
         "locales": {
@@ -1591,7 +1591,7 @@
             "level": 5,
             "quests": []
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Supplier",
         "locales": {
@@ -1635,7 +1635,7 @@
                 36
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "The Extortionist",
         "locales": {
@@ -1677,7 +1677,7 @@
                 37
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "What's on the flash drive?",
         "locales": {
@@ -1716,7 +1716,7 @@
                 38
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Golden swag",
         "locales": {
@@ -1774,7 +1774,7 @@
                 39
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Chemical - Part 1",
         "locales": {
@@ -1816,7 +1816,7 @@
                 40
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Chemical - Part 2",
         "locales": {
@@ -1867,7 +1867,7 @@
                 41
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Chemical - Part 3",
         "locales": {
@@ -1906,7 +1906,7 @@
                 42
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Chemical - Part 4",
         "locales": {
@@ -1958,7 +1958,7 @@
                 42
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Vitamins - Part 1",
         "locales": {
@@ -2027,7 +2027,7 @@
                 44
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Vitamins - Part 2",
         "locales": {
@@ -2071,7 +2071,7 @@
                 39
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Friend from the West - Part 1",
         "locales": {
@@ -2116,7 +2116,7 @@
                 46
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Friend from the West - Part 2",
         "locales": {
@@ -2151,7 +2151,7 @@
                 47
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Lend lease - Part 1",
         "locales": {
@@ -2238,7 +2238,7 @@
                 48
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Lend lease - Part 2",
         "locales": {
@@ -2280,7 +2280,7 @@
                 49
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Peacekeeping mission",
         "locales": {
@@ -2359,7 +2359,7 @@
                 47
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Informed means armed",
         "locales": {
@@ -2413,7 +2413,7 @@
                 51
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Chumming",
         "locales": {
@@ -2472,7 +2472,7 @@
                 52
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Silent caliber",
         "locales": {
@@ -2520,7 +2520,7 @@
                 52
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Flint",
         "locales": {
@@ -2557,7 +2557,7 @@
                 52
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Bullshit",
         "locales": {
@@ -2622,7 +2622,7 @@
                 55
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Setup",
         "locales": {
@@ -2664,7 +2664,7 @@
                 47
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Fishing Gear",
         "locales": {
@@ -2708,7 +2708,7 @@
                 57
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Tigr Safari",
         "locales": {
@@ -2767,7 +2767,7 @@
                 58
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Scrap Metal",
         "locales": {
@@ -2828,7 +2828,7 @@
                 59
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Eagle Eye",
         "locales": {
@@ -2872,7 +2872,7 @@
                 60
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Humanitarian Supplies",
         "locales": {
@@ -2936,7 +2936,7 @@
                 61
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "The Cult - Part 1",
         "locales": {
@@ -2973,7 +2973,7 @@
                 62
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "The Cult - Part 2",
         "locales": {
@@ -3042,7 +3042,7 @@
                 61
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 1",
         "locales": {
@@ -3080,7 +3080,7 @@
                 64
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 2",
         "locales": {
@@ -3126,7 +3126,7 @@
                 65
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 3",
         "locales": {
@@ -3182,7 +3182,7 @@
                 66
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 4",
         "locales": {
@@ -3234,7 +3234,7 @@
                 67
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 5",
         "locales": {
@@ -3269,7 +3269,7 @@
                 68
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 6",
         "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_5",
@@ -3306,7 +3306,7 @@
                 69
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 7",
         "locales": {
@@ -3366,7 +3366,7 @@
                 70
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Cargo X - Part 1",
         "locales": {
@@ -3411,7 +3411,7 @@
                 71
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Cargo X - Part 2",
         "locales": {
@@ -3449,7 +3449,7 @@
                 72
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Cargo X - Part 3",
         "locales": {
@@ -3484,7 +3484,7 @@
                 70
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 1",
         "locales": {
@@ -3526,7 +3526,7 @@
                 74
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 2",
         "locales": {
@@ -3564,7 +3564,7 @@
                 75
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 3",
         "locales": {
@@ -3599,7 +3599,7 @@
                 76
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 4",
         "locales": {
@@ -3634,7 +3634,7 @@
                 77
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 5",
         "locales": {
@@ -3681,7 +3681,7 @@
                 78
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Wet Job - Part 6",
         "locales": {
@@ -3722,7 +3722,7 @@
                 79
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Psycho Sniper",
         "locales": {
@@ -3752,7 +3752,7 @@
                 79
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "The guide",
         "locales": {
@@ -3781,7 +3781,7 @@
             "level": 2,
             "quests": []
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 1",
         "locales": {
@@ -3808,7 +3808,7 @@
                 82
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 2",
         "locales": {
@@ -3835,7 +3835,7 @@
                 82
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 3",
         "locales": {
@@ -3862,7 +3862,7 @@
                 84
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 4",
         "locales": {
@@ -3889,7 +3889,7 @@
                 85
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 5",
         "locales": {
@@ -3916,7 +3916,7 @@
                 86
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 6",
         "locales": {
@@ -3943,7 +3943,7 @@
                 87
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 7",
         "locales": {
@@ -3970,7 +3970,7 @@
                 88
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 8",
         "locales": {
@@ -3997,7 +3997,7 @@
                 89
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 9",
         "locales": {
@@ -4024,7 +4024,7 @@
                 90
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 10",
         "locales": {
@@ -4053,7 +4053,7 @@
                 91
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 11",
         "locales": {
@@ -4080,7 +4080,7 @@
                 92
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 12",
         "locales": {
@@ -4110,7 +4110,7 @@
                 93
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 13",
         "locales": {
@@ -4139,7 +4139,7 @@
                 94
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 14",
         "locales": {
@@ -4168,7 +4168,7 @@
                 95
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 15",
         "locales": {
@@ -4195,7 +4195,7 @@
                 96
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Gunsmith - Part 16",
         "locales": {
@@ -4222,7 +4222,7 @@
                 83
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Signal - Part 1",
         "locales": {
@@ -4264,7 +4264,7 @@
                 98
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Signal - Part 2",
         "locales": {
@@ -4320,7 +4320,7 @@
                 99
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Signal - Part 3",
         "locales": {
@@ -4377,7 +4377,7 @@
                 100
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Signal - Part 4",
         "locales": {
@@ -4412,7 +4412,7 @@
                 99
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Scout",
         "locales": {
@@ -4465,7 +4465,7 @@
                 84
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Insider",
         "locales": {
@@ -4500,7 +4500,7 @@
                 82
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Farming - Part 1",
         "locales": {
@@ -4544,7 +4544,7 @@
                 104
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Farming - Part 2",
         "locales": {
@@ -4593,7 +4593,7 @@
                 105
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Farming - Part 3",
         "locales": {
@@ -4635,7 +4635,7 @@
                 106
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Farming - Part 4",
         "locales": {
@@ -4677,7 +4677,7 @@
                 107
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Import",
         "locales": {
@@ -4724,7 +4724,7 @@
                 107
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Fertilizers",
         "locales": {
@@ -4766,7 +4766,7 @@
                 106
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "A Shooter Born in Heaven",
         "locales": {
@@ -4834,7 +4834,7 @@
             "level": 15,
             "quests": []
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Only business",
         "locales": {
@@ -4869,7 +4869,7 @@
                 111
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Big sale",
         "locales": {
@@ -4932,7 +4932,7 @@
                 112
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "The Blood of War - Part 1",
         "locales": {
@@ -4987,7 +4987,7 @@
                 113
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Dressed to kill",
         "locales": {
@@ -5029,7 +5029,7 @@
                 112
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Database - Part 1",
         "locales": {
@@ -5078,7 +5078,7 @@
                 115
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Database - Part 2",
         "locales": {
@@ -5120,7 +5120,7 @@
                 114
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Gratitude",
         "locales": {
@@ -5176,7 +5176,7 @@
                 117
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Sales Night",
         "locales": {
@@ -5213,7 +5213,7 @@
                 118
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Supervisor",
         "locales": {
@@ -5250,7 +5250,7 @@
                 117
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Hot Delivery",
         "locales": {
@@ -5304,7 +5304,7 @@
                 120
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Scavenger",
         "locales": {
@@ -5341,7 +5341,7 @@
                 111
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Make ULTRA Great Again",
         "locales": {
@@ -5376,7 +5376,7 @@
                 116
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Minibus",
         "locales": {
@@ -5431,7 +5431,7 @@
                 116
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Sew it good - Part 1",
         "locales": {
@@ -5473,7 +5473,7 @@
                 124
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Sew it good - Part 2",
         "locales": {
@@ -5517,7 +5517,7 @@
                 125
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Sew it good - Part 3",
         "locales": {
@@ -5561,7 +5561,7 @@
                 126
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Sew it good - Part 4",
         "locales": {
@@ -5603,7 +5603,7 @@
                 127
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Charisma brings success",
         "locales": {
@@ -5639,7 +5639,7 @@
                 176
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "No fuss needed",
         "locales": {
@@ -5676,7 +5676,7 @@
                 124
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "The Blood of War - Part 2",
         "locales": {
@@ -5711,7 +5711,7 @@
                 130
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "The Blood of War - Part 3",
         "locales": {
@@ -5768,7 +5768,7 @@
                 126
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Living high is not a crime - Part 1",
         "locales": {
@@ -5825,7 +5825,7 @@
                 131
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Living high is not a crime - Part 2",
         "locales": {
@@ -5867,7 +5867,7 @@
             "level": 2,
             "quests": []
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Introduction",
         "locales": {
@@ -5902,7 +5902,7 @@
                 134
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Acquaintance",
         "locales": {
@@ -5951,7 +5951,7 @@
                 135
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Unprotected, but dangerous",
         "locales": {
@@ -5989,7 +5989,7 @@
                 135
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Thrifty",
         "locales": {
@@ -6049,7 +6049,7 @@
                 137
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Zhivchik",
         "locales": {
@@ -6084,7 +6084,7 @@
                 138
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Wounded beast",
         "locales": {
@@ -6122,7 +6122,7 @@
                 139
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Tough guy",
         "locales": {
@@ -6161,7 +6161,7 @@
                 140
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Courtesy visit",
         "locales": {
@@ -6210,7 +6210,7 @@
                 141
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Nostalgia",
         "locales": {
@@ -6245,7 +6245,7 @@
                 86
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 1",
         "locales": {
@@ -6284,7 +6284,7 @@
                 143
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 2",
         "locales": {
@@ -6338,7 +6338,7 @@
                 144
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 3",
         "locales": {
@@ -6380,7 +6380,7 @@
                 145
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 4",
         "locales": {
@@ -6418,7 +6418,7 @@
                 146
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 5",
         "locales": {
@@ -6459,7 +6459,7 @@
                 147
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 6",
         "locales": {
@@ -6500,7 +6500,7 @@
                 148
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 7",
         "locales": {
@@ -6541,7 +6541,7 @@
                 149
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 8",
         "locales": {
@@ -6583,7 +6583,7 @@
                 139
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Cold blooded",
         "locales": {
@@ -6622,7 +6622,7 @@
                 185
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Colleagues - Part 2",
         "locales": {
@@ -6674,7 +6674,7 @@
                 187
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Colleagues - Part 3",
         "locales": {
@@ -6745,7 +6745,7 @@
                 151
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Combat medic",
         "locales": {
@@ -6780,7 +6780,7 @@
                 151
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Ambulance",
         "locales": {
@@ -6824,7 +6824,7 @@
                 139
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Secured perimeter",
         "locales": {
@@ -6862,7 +6862,7 @@
                 156
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Reserve",
         "locales": {
@@ -6897,7 +6897,7 @@
                 156
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Woods cleaning",
         "locales": {
@@ -6932,7 +6932,7 @@
                 158
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Controller",
         "locales": {
@@ -6971,7 +6971,7 @@
                 158
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Evil watchman",
         "locales": {
@@ -7010,7 +7010,7 @@
                 158
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Fishing place",
         "locales": {
@@ -7045,7 +7045,7 @@
                 156
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - The trophy",
         "locales": {
@@ -7087,7 +7087,7 @@
                 162
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Justice",
         "locales": {
@@ -7126,7 +7126,7 @@
                 162
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Sellout",
         "locales": {
@@ -7168,7 +7168,7 @@
                 164
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Woods keeper",
         "locales": {
@@ -7210,7 +7210,7 @@
                 213
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Eraser - Part 1",
         "locales": {
@@ -7245,7 +7245,7 @@
                 166
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Eraser - Part 2",
         "locales": {
@@ -7280,7 +7280,7 @@
                 165
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Hunting trip",
         "locales": {
@@ -7325,7 +7325,7 @@
                 19
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Operation Aquarius - Part 1",
         "locales": {
@@ -7371,7 +7371,7 @@
                 169
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Operation Aquarius - Part 2",
         "locales": {
@@ -7412,7 +7412,7 @@
                 39
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Polikhim hobo",
         "locales": {
@@ -7447,7 +7447,7 @@
                 171
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Regulated materials",
         "locales": {
@@ -7492,7 +7492,7 @@
                 37
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Stirrup",
         "locales": {
@@ -7540,7 +7540,7 @@
                 77
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Mentor",
         "locales": {
@@ -7571,7 +7571,7 @@
                 105
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Bad habit",
         "locales": {
@@ -7620,7 +7620,7 @@
                 125
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "The key to success",
         "locales": {
@@ -7666,7 +7666,7 @@
                 38
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Shady Business",
         "locales": {
@@ -7701,7 +7701,7 @@
                 6
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Postman Pat - Part 2",
         "locales": {
@@ -7736,7 +7736,7 @@
                 42
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Out of curiosity",
         "locales": {
@@ -7782,7 +7782,7 @@
                 42
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Big customer",
         "locales": {
@@ -7831,7 +7831,7 @@
                 151
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Junkie",
         "locales": {
@@ -7869,7 +7869,7 @@
                 127
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Textile - Part 1",
         "locales": {
@@ -7914,7 +7914,7 @@
                 182
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Textile - Part 2",
         "locales": {
@@ -7959,7 +7959,7 @@
                 8
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Anesthesia",
         "locales": {
@@ -8015,7 +8015,7 @@
                 26
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Colleagues - Part 1",
         "locales": {
@@ -8065,7 +8065,7 @@
                 184
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Rigged game",
         "locales": {
@@ -8119,7 +8119,7 @@
                 185
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Chemistry closet",
         "locales": {
@@ -8162,7 +8162,7 @@
                 184
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Samples",
         "locales": {
@@ -8244,7 +8244,7 @@
                 190
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "TerraGroup employee",
         "locales": {
@@ -8296,7 +8296,7 @@
                 187
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman path - Sadist",
         "locales": {
@@ -8339,7 +8339,7 @@
                 4
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The bunker - Part 1",
         "locales": {
@@ -8382,7 +8382,7 @@
                 191
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "The bunker - Part 2",
         "locales": {
@@ -8446,7 +8446,7 @@
                 0
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Search mission",
         "locales": {
@@ -8488,7 +8488,7 @@
                 176
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "The stylish one",
         "locales": {
@@ -8518,7 +8518,7 @@
                 151
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "The survivalist path - Eagle-owl",
         "locales": {
@@ -8611,7 +8611,7 @@
                 206
             ]
         },
-        "giver": "Fence",
+        "giver": 7,
         "turnin": "Fence",
         "title": "Collector",
         "locales": {
@@ -8794,7 +8794,7 @@
                 30
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "An apple a day - keeps the doctor away",
         "locales": {
@@ -8831,7 +8831,7 @@
                 }
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Hunter",
         "locales": {
@@ -8867,7 +8867,7 @@
                 ]
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "No offence",
         "locales": {
@@ -8906,7 +8906,7 @@
                 ]
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Trust regain",
         "locales": {
@@ -8966,7 +8966,7 @@
                 ]
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Loyalty buyout",
         "locales": {
@@ -9003,7 +9003,7 @@
                 27
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Hippocratic Vow",
         "locales": {
@@ -9046,7 +9046,7 @@
                 23
             ]
         },
-        "giver": "Therapist",
+        "giver": 1,
         "turnin": "Therapist",
         "title": "Disease history",
         "locales": {
@@ -9104,7 +9104,7 @@
                 111
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "A fuel matter",
         "locales": {
@@ -9149,7 +9149,7 @@
                 102
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Surplus Goods",
         "locales": {
@@ -9192,7 +9192,7 @@
                 205
             ]
         },
-        "giver": "Mechanic",
+        "giver": 4,
         "turnin": "Mechanic",
         "title": "Back door",
         "locales": {
@@ -9228,7 +9228,7 @@
                 60
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Revision",
         "locales": {
@@ -9317,7 +9317,7 @@
                 207
             ]
         },
-        "giver": "Peacekeeper",
+        "giver": 3,
         "turnin": "Peacekeeper",
         "title": "Experience exchange",
         "locales": {
@@ -9352,7 +9352,7 @@
                 204
             ]
         },
-        "giver": "Ragman",
+        "giver": 5,
         "turnin": "Ragman",
         "title": "Inventory check",
         "locales": {
@@ -9436,7 +9436,7 @@
                 192
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "No place for renegades",
         "locales": {
@@ -9471,7 +9471,7 @@
                 210
             ]
         },
-        "giver": "Prapor",
+        "giver": 0,
         "turnin": "Prapor",
         "title": "Documents",
         "locales": {
@@ -9520,7 +9520,7 @@
                 192
             ]
         },
-        "giver": "Skier",
+        "giver": 2,
         "turnin": "Skier",
         "title": "Safe corridor",
         "locales": {
@@ -9558,7 +9558,7 @@
                 165
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Huntsman Path - Factory Chief",
         "locales": {
@@ -9600,7 +9600,7 @@
                 165
             ]
         },
-        "giver": "Jaeger",
+        "giver": 6,
         "turnin": "Jaeger",
         "title": "Pest control",
         "locales": {

--- a/quests.json
+++ b/quests.json
@@ -6,7 +6,6 @@
             "quests": []
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Debut",
         "locales": {
             "en": "Debut",
@@ -50,7 +49,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Checking",
         "locales": {
             "en": "Checking",
@@ -92,7 +90,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Shootout picnic",
         "locales": {
             "en": "Shootout picnic",
@@ -127,7 +124,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Delivery from the past",
         "locales": {
             "en": "Delivery from the past",
@@ -178,7 +174,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "BP depot",
         "locales": {
             "en": "BP depot",
@@ -246,7 +241,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Bad rep evidence",
         "locales": {
             "en": "Bad rep evidence",
@@ -290,7 +284,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Ice cream cones",
         "locales": {
             "en": "Ice cream cones",
@@ -328,7 +321,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Therapist",
         "title": "Postman Pat",
         "locales": {
             "en": "Postman Pat",
@@ -371,7 +363,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Shaking up teller",
         "locales": {
             "en": "Shaking up teller",
@@ -420,7 +411,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Perfect mediator",
         "locales": {
             "en": "Perfect mediator",
@@ -490,7 +480,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Grenadier",
         "locales": {
             "en": "Grenadier",
@@ -526,7 +515,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Insomnia",
         "locales": {
             "en": "Insomnia",
@@ -564,7 +552,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Test drive. Pt. 1",
         "locales": {
             "en": "Test drive. Pt. 1",
@@ -604,7 +591,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 1",
         "locales": {
             "en": "The Punisher - Part 1",
@@ -644,7 +630,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 2",
         "locales": {
             "en": "The Punisher - Part 2",
@@ -689,7 +674,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 3",
         "locales": {
             "en": "The Punisher - Part 3",
@@ -733,7 +717,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 4",
         "locales": {
             "en": "The Punisher - Part 4",
@@ -795,7 +778,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 5",
         "locales": {
             "en": "The Punisher - Part 5",
@@ -857,7 +839,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The Punisher - Part 6",
         "locales": {
             "en": "The Punisher - Part 6",
@@ -915,7 +896,6 @@
             "quests": []
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Shortage",
         "locales": {
             "en": "Shortage",
@@ -950,7 +930,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Sanitary Standards - Part 1",
         "locales": {
             "en": "Sanitary Standards - Part 1",
@@ -987,7 +966,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Sanitary Standards - Part 2",
         "locales": {
             "en": "Sanitary Standards - Part 2",
@@ -1022,7 +1000,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Painkiller",
         "locales": {
             "en": "Painkiller",
@@ -1058,7 +1035,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Pharmacist",
         "locales": {
             "en": "Pharmacist",
@@ -1102,7 +1078,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Supply plans",
         "locales": {
             "en": "Supply plans",
@@ -1146,7 +1121,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Kind of sabotage",
         "locales": {
             "en": "Kind of sabotage",
@@ -1190,7 +1164,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "General wares",
         "locales": {
             "en": "General wares",
@@ -1225,7 +1198,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Car repair",
         "locales": {
             "en": "Car repair",
@@ -1269,7 +1241,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Health Care Privacy - Part 1",
         "locales": {
             "en": "Health Care Privacy - Part 1",
@@ -1326,7 +1297,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Health Care Privacy - Part 2",
         "locales": {
             "en": "Health Care Privacy - Part 2",
@@ -1368,7 +1338,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Health Care Privacy - Part 3",
         "locales": {
             "en": "Health Care Privacy - Part 3",
@@ -1405,7 +1374,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Health Care Privacy - Part 4",
         "locales": {
             "en": "Health Care Privacy - Part 4",
@@ -1440,7 +1408,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Health Care Privacy - Part 5",
         "locales": {
             "en": "Health Care Privacy - Part 5",
@@ -1476,7 +1443,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Decontamination Service",
         "locales": {
             "en": "Decontamination Service",
@@ -1515,7 +1481,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Private clinic",
         "locales": {
             "en": "Private clinic",
@@ -1557,7 +1522,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Athlete",
         "locales": {
             "en": "Athlete",
@@ -1592,7 +1556,6 @@
             "quests": []
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Supplier",
         "locales": {
             "en": "Supplier",
@@ -1636,7 +1599,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "The Extortionist",
         "locales": {
             "en": "The Extortionist",
@@ -1678,7 +1640,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "What's on the flash drive?",
         "locales": {
             "en": "What's on the flash drive?",
@@ -1717,7 +1678,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Golden swag",
         "locales": {
             "en": "Golden swag",
@@ -1775,7 +1735,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Chemical - Part 1",
         "locales": {
             "en": "Chemical - Part 1",
@@ -1817,7 +1776,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Chemical - Part 2",
         "locales": {
             "en": "Chemical - Part 2",
@@ -1868,7 +1826,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Chemical - Part 3",
         "locales": {
             "en": "Chemical - Part 3",
@@ -1907,7 +1864,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Chemical - Part 4",
         "locales": {
             "en": "Chemical - Part 4",
@@ -1959,7 +1915,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Vitamins - Part 1",
         "locales": {
             "en": "Vitamins - Part 1",
@@ -2028,7 +1983,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Vitamins - Part 2",
         "locales": {
             "en": "Vitamins - Part 2",
@@ -2072,7 +2026,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Friend from the West - Part 1",
         "locales": {
             "en": "Friend from the West - Part 1",
@@ -2117,7 +2070,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Friend from the West - Part 2",
         "locales": {
             "en": "Friend from the West - Part 2",
@@ -2152,7 +2104,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Lend lease - Part 1",
         "locales": {
             "en": "Lend lease - Part 1",
@@ -2239,7 +2190,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Lend lease - Part 2",
         "locales": {
             "en": "Lend lease - Part 2",
@@ -2281,7 +2231,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Peacekeeping mission",
         "locales": {
             "en": "Peacekeeping mission",
@@ -2360,7 +2309,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Informed means armed",
         "locales": {
             "en": "Informed means armed",
@@ -2414,7 +2362,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Chumming",
         "locales": {
             "en": "Chumming",
@@ -2473,7 +2420,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Silent caliber",
         "locales": {
             "en": "Silent caliber",
@@ -2521,7 +2467,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Flint",
         "locales": {
             "en": "Flint",
@@ -2558,7 +2503,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Bullshit",
         "locales": {
             "en": "Bullshit",
@@ -2623,7 +2567,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Setup",
         "locales": {
             "en": "Setup",
@@ -2665,7 +2608,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Fishing Gear",
         "locales": {
             "en": "Fishing Gear",
@@ -2709,7 +2651,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Tigr Safari",
         "locales": {
             "en": "Tigr Safari",
@@ -2768,7 +2709,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Scrap Metal",
         "locales": {
             "en": "Scrap Metal",
@@ -2829,7 +2769,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Eagle Eye",
         "locales": {
             "en": "Eagle Eye",
@@ -2873,7 +2812,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Humanitarian Supplies",
         "locales": {
             "en": "Humanitarian Supplies",
@@ -2937,7 +2875,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "The Cult - Part 1",
         "locales": {
             "en": "The Cult - Part 1",
@@ -2974,7 +2911,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "The Cult - Part 2",
         "locales": {
             "en": "The Cult - Part 2",
@@ -3043,7 +2979,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 1",
         "locales": {
             "en": "Spa Tour - Part 1",
@@ -3081,7 +3016,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 2",
         "locales": {
             "en": "Spa Tour - Part 2",
@@ -3127,7 +3061,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 3",
         "locales": {
             "en": "Spa Tour - Part 3",
@@ -3183,7 +3116,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 4",
         "locales": {
             "en": "Spa Tour - Part 4",
@@ -3235,7 +3167,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 5",
         "locales": {
             "en": "Spa Tour - Part 5",
@@ -3270,7 +3201,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 6",
         "wiki": "https://escapefromtarkov.gamepedia.com/Spa_Tour_-_Part_5",
         "locales": {
@@ -3307,7 +3237,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Spa Tour - Part 7",
         "locales": {
             "en": "Spa Tour - Part 7",
@@ -3367,7 +3296,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Cargo X - Part 1",
         "locales": {
             "en": "Cargo X - Part 1",
@@ -3412,7 +3340,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Cargo X - Part 2",
         "locales": {
             "en": "Cargo X - Part 2",
@@ -3450,7 +3377,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Cargo X - Part 3",
         "locales": {
             "en": "Cargo X - Part 3",
@@ -3485,7 +3411,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 1",
         "locales": {
             "en": "Wet Job - Part 1",
@@ -3527,7 +3452,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 2",
         "locales": {
             "en": "Wet Job - Part 2",
@@ -3565,7 +3489,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 3",
         "locales": {
             "en": "Wet Job - Part 3",
@@ -3600,7 +3523,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 4",
         "locales": {
             "en": "Wet Job - Part 4",
@@ -3635,7 +3557,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 5",
         "locales": {
             "en": "Wet Job - Part 5",
@@ -3682,7 +3603,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Wet Job - Part 6",
         "locales": {
             "en": "Wet Job - Part 6",
@@ -3723,7 +3643,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Psycho Sniper",
         "locales": {
             "en": "Psycho Sniper",
@@ -3753,7 +3672,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "The guide",
         "locales": {
             "en": "The guide",
@@ -3782,7 +3700,6 @@
             "quests": []
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 1",
         "locales": {
             "en": "Gunsmith - Part 1",
@@ -3809,7 +3726,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 2",
         "locales": {
             "en": "Gunsmith - Part 2",
@@ -3836,7 +3752,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 3",
         "locales": {
             "en": "Gunsmith - Part 3",
@@ -3863,7 +3778,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 4",
         "locales": {
             "en": "Gunsmith - Part 4",
@@ -3890,7 +3804,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 5",
         "locales": {
             "en": "Gunsmith - Part 5",
@@ -3917,7 +3830,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 6",
         "locales": {
             "en": "Gunsmith - Part 6",
@@ -3944,7 +3856,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 7",
         "locales": {
             "en": "Gunsmith - Part 7",
@@ -3971,7 +3882,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 8",
         "locales": {
             "en": "Gunsmith - Part 8",
@@ -3998,7 +3908,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 9",
         "locales": {
             "en": "Gunsmith - Part 9",
@@ -4025,7 +3934,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 10",
         "locales": {
             "en": "Gunsmith - Part 10",
@@ -4054,7 +3962,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 11",
         "locales": {
             "en": "Gunsmith - Part 11",
@@ -4081,7 +3988,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 12",
         "locales": {
             "en": "Gunsmith - Part 12",
@@ -4111,7 +4017,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 13",
         "locales": {
             "en": "Gunsmith - Part 13",
@@ -4140,7 +4045,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 14",
         "locales": {
             "en": "Gunsmith - Part 14",
@@ -4169,7 +4073,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 15",
         "locales": {
             "en": "Gunsmith - Part 15",
@@ -4196,7 +4099,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Gunsmith - Part 16",
         "locales": {
             "en": "Gunsmith - Part 16",
@@ -4223,7 +4125,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Signal - Part 1",
         "locales": {
             "en": "Signal - Part 1",
@@ -4265,7 +4166,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Signal - Part 2",
         "locales": {
             "en": "Signal - Part 2",
@@ -4321,7 +4221,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Signal - Part 3",
         "locales": {
             "en": "Signal - Part 3",
@@ -4378,7 +4277,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Signal - Part 4",
         "locales": {
             "en": "Signal - Part 4",
@@ -4413,7 +4311,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Scout",
         "locales": {
             "en": "Scout",
@@ -4466,7 +4363,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Insider",
         "locales": {
             "en": "Insider",
@@ -4501,7 +4397,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Farming - Part 1",
         "locales": {
             "en": "Farming - Part 1",
@@ -4545,7 +4440,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Farming - Part 2",
         "locales": {
             "en": "Farming - Part 2",
@@ -4594,7 +4488,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Farming - Part 3",
         "locales": {
             "en": "Farming - Part 3",
@@ -4636,7 +4529,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Farming - Part 4",
         "locales": {
             "en": "Farming - Part 4",
@@ -4678,7 +4570,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Import",
         "locales": {
             "en": "Import",
@@ -4725,7 +4616,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Fertilizers",
         "locales": {
             "en": "Fertilizers",
@@ -4767,7 +4657,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "A Shooter Born in Heaven",
         "locales": {
             "en": "A Shooter Born in Heaven",
@@ -4835,7 +4724,6 @@
             "quests": []
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Only business",
         "locales": {
             "en": "Only business",
@@ -4870,7 +4758,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Big sale",
         "locales": {
             "en": "Big sale",
@@ -4933,7 +4820,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "The Blood of War - Part 1",
         "locales": {
             "en": "The Blood of War - Part 1",
@@ -4988,7 +4874,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Dressed to kill",
         "locales": {
             "en": "Dressed to kill",
@@ -5030,7 +4915,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Database - Part 1",
         "locales": {
             "en": "Database - Part 1",
@@ -5079,7 +4963,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Database - Part 2",
         "locales": {
             "en": "Database - Part 2",
@@ -5121,7 +5004,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Gratitude",
         "locales": {
             "en": "Gratitude",
@@ -5177,7 +5059,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Sales Night",
         "locales": {
             "en": "Sales Night",
@@ -5214,7 +5095,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Supervisor",
         "locales": {
             "en": "Supervisor",
@@ -5251,7 +5131,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Hot Delivery",
         "locales": {
             "en": "Hot Delivery",
@@ -5305,7 +5184,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Scavenger",
         "locales": {
             "en": "Scavenger",
@@ -5342,7 +5220,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Make ULTRA Great Again",
         "locales": {
             "en": "Make ULTRA Great Again",
@@ -5377,7 +5254,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Minibus",
         "locales": {
             "en": "Minibus",
@@ -5432,7 +5308,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Sew it good - Part 1",
         "locales": {
             "en": "Sew it good - Part 1",
@@ -5474,7 +5349,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Sew it good - Part 2",
         "locales": {
             "en": "Sew it good - Part 2",
@@ -5518,7 +5392,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Sew it good - Part 3",
         "locales": {
             "en": "Sew it good - Part 3",
@@ -5562,7 +5435,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Sew it good - Part 4",
         "locales": {
             "en": "Sew it good - Part 4",
@@ -5604,7 +5476,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Charisma brings success",
         "locales": {
             "en": "Charisma brings success",
@@ -5640,7 +5511,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "No fuss needed",
         "locales": {
             "en": "No fuss needed",
@@ -5677,7 +5547,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "The Blood of War - Part 2",
         "locales": {
             "en": "The Blood of War - Part 2",
@@ -5712,7 +5581,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "The Blood of War - Part 3",
         "locales": {
             "en": "The Blood of War - Part 3",
@@ -5769,7 +5637,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Living high is not a crime - Part 1",
         "locales": {
             "en": "Living high is not a crime - Part 1",
@@ -5826,7 +5693,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Living high is not a crime - Part 2",
         "locales": {
             "en": "Living high is not a crime - Part 2",
@@ -5868,7 +5734,6 @@
             "quests": []
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Introduction",
         "locales": {
             "en": "Introduction",
@@ -5903,7 +5768,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Acquaintance",
         "locales": {
             "en": "Acquaintance",
@@ -5952,7 +5816,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Unprotected, but dangerous",
         "locales": {
             "en": "The survivalist path - Unprotected, but dangerous",
@@ -5990,7 +5853,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Thrifty",
         "locales": {
             "en": "The survivalist path - Thrifty",
@@ -6050,7 +5912,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Zhivchik",
         "locales": {
             "en": "The survivalist path - Zhivchik",
@@ -6085,7 +5946,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Wounded beast",
         "locales": {
             "en": "The survivalist path - Wounded beast",
@@ -6123,7 +5983,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Tough guy",
         "locales": {
             "en": "The survivalist path - Tough guy",
@@ -6162,7 +6021,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Courtesy visit",
         "locales": {
             "en": "Courtesy visit",
@@ -6211,7 +6069,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Nostalgia",
         "locales": {
             "en": "Nostalgia",
@@ -6246,7 +6103,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 1",
         "locales": {
             "en": "The Tarkov shooter - Part 1",
@@ -6285,7 +6141,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 2",
         "locales": {
             "en": "The Tarkov shooter - Part 2",
@@ -6339,7 +6194,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 3",
         "locales": {
             "en": "The Tarkov shooter - Part 3",
@@ -6381,7 +6235,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 4",
         "locales": {
             "en": "The Tarkov shooter - Part 4",
@@ -6419,7 +6272,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 5",
         "locales": {
             "en": "The Tarkov shooter - Part 5",
@@ -6460,7 +6312,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 6",
         "locales": {
             "en": "The Tarkov shooter - Part 6",
@@ -6501,7 +6352,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 7",
         "locales": {
             "en": "The Tarkov shooter - Part 7",
@@ -6542,7 +6392,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The Tarkov shooter - Part 8",
         "locales": {
             "en": "The Tarkov shooter - Part 8",
@@ -6584,7 +6433,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Cold blooded",
         "locales": {
             "en": "The survivalist path - Cold blooded",
@@ -6623,7 +6471,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Colleagues - Part 2",
         "locales": {
             "en": "Colleagues - Part 2",
@@ -6675,7 +6522,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Colleagues - Part 3",
         "locales": {
             "en": "Colleagues - Part 3",
@@ -6746,7 +6592,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Combat medic",
         "locales": {
             "en": "The survivalist path - Combat medic",
@@ -6781,7 +6626,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Ambulance",
         "locales": {
             "en": "Ambulance",
@@ -6825,7 +6669,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Secured perimeter",
         "locales": {
             "en": "Huntsman path - Secured perimeter",
@@ -6863,7 +6706,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Reserve",
         "locales": {
             "en": "Reserve",
@@ -6898,7 +6740,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Woods cleaning",
         "locales": {
             "en": "Huntsman path - Woods cleaning",
@@ -6933,7 +6774,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Controller",
         "locales": {
             "en": "Huntsman path - Controller",
@@ -6972,7 +6812,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Evil watchman",
         "locales": {
             "en": "Huntsman path - Evil watchman",
@@ -7011,7 +6850,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Fishing place",
         "locales": {
             "en": "Fishing place",
@@ -7046,7 +6884,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - The trophy",
         "locales": {
             "en": "Huntsman path - The trophy",
@@ -7088,7 +6925,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Justice",
         "locales": {
             "en": "Huntsman path - Justice",
@@ -7127,7 +6963,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Sellout",
         "locales": {
             "en": "Huntsman path - Sellout",
@@ -7169,7 +7004,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Woods keeper",
         "locales": {
             "en": "Huntsman path - Woods keeper",
@@ -7211,7 +7045,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Eraser - Part 1",
         "locales": {
             "en": "Huntsman path - Eraser - Part 1",
@@ -7246,7 +7079,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Eraser - Part 2",
         "locales": {
             "en": "Huntsman path - Eraser - Part 2",
@@ -7281,7 +7113,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Hunting trip",
         "locales": {
             "en": "Hunting trip",
@@ -7326,7 +7157,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Operation Aquarius - Part 1",
         "locales": {
             "en": "Operation Aquarius - Part 1",
@@ -7372,7 +7202,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Operation Aquarius - Part 2",
         "locales": {
             "en": "Operation Aquarius - Part 2",
@@ -7413,7 +7242,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Polikhim hobo",
         "locales": {
             "en": "Polikhim hobo",
@@ -7448,7 +7276,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Regulated materials",
         "locales": {
             "en": "Regulated materials",
@@ -7493,7 +7320,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Stirrup",
         "locales": {
             "en": "Stirrup",
@@ -7541,7 +7367,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Mentor",
         "locales": {
             "en": "Mentor",
@@ -7572,7 +7397,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Bad habit",
         "locales": {
             "en": "Bad habit",
@@ -7621,7 +7445,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "The key to success",
         "locales": {
             "en": "The key to success",
@@ -7667,7 +7490,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Shady Business",
         "locales": {
             "en": "Shady Business",
@@ -7702,7 +7524,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Postman Pat - Part 2",
         "locales": {
             "en": "Postman Pat - Part 2",
@@ -7737,7 +7558,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Out of curiosity",
         "locales": {
             "en": "Out of curiosity",
@@ -7783,7 +7603,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Big customer",
         "locales": {
             "en": "Big customer",
@@ -7832,7 +7651,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Junkie",
         "locales": {
             "en": "The survivalist path - Junkie",
@@ -7870,7 +7688,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Textile - Part 1",
         "locales": {
             "en": "Textile - Part 1",
@@ -7915,7 +7732,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Textile - Part 2",
         "locales": {
             "en": "Textile - Part 2",
@@ -7960,7 +7776,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Anesthesia",
         "locales": {
             "en": "Anesthesia",
@@ -8016,7 +7831,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Colleagues - Part 1",
         "locales": {
             "en": "Colleagues - Part 1",
@@ -8066,7 +7880,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Rigged game",
         "locales": {
             "en": "Rigged game",
@@ -8120,7 +7933,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Chemistry closet",
         "locales": {
             "en": "Chemistry closet",
@@ -8163,7 +7975,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Samples",
         "locales": {
             "en": "Samples",
@@ -8245,7 +8056,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "TerraGroup employee",
         "locales": {
             "en": "TerraGroup employee",
@@ -8297,7 +8107,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman path - Sadist",
         "locales": {
             "en": "Huntsman path - Sadist",
@@ -8340,7 +8149,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The bunker - Part 1",
         "locales": {
             "en": "The bunker - Part 1",
@@ -8383,7 +8191,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "The bunker - Part 2",
         "locales": {
             "en": "The bunker - Part 2",
@@ -8447,7 +8254,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Search mission",
         "locales": {
             "en": "Search mission",
@@ -8489,7 +8295,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "The stylish one",
         "locales": {
             "en": "The stylish one",
@@ -8519,7 +8324,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "The survivalist path - Eagle-owl",
         "locales": {
             "en": "The survivalist path - Eagle-owl",
@@ -8612,7 +8416,6 @@
             ]
         },
         "giver": 7,
-        "turnin": "Fence",
         "title": "Collector",
         "locales": {
             "en": "Collector",
@@ -8795,7 +8598,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "An apple a day - keeps the doctor away",
         "locales": {
             "en": "An apple a day - keeps the doctor away",
@@ -8832,7 +8634,7 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
+
         "title": "Hunter",
         "locales": {
             "en": "Hunter",
@@ -8868,7 +8670,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "No offence",
         "locales": {
             "en": "No offence",
@@ -8907,7 +8708,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Trust regain",
         "locales": {
             "en": "Trust regain",
@@ -8967,7 +8767,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Loyalty buyout",
         "locales": {
             "en": "Loyalty buyout",
@@ -9004,7 +8803,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Hippocratic Vow",
         "locales": {
             "en": "Hippocratic Vow",
@@ -9047,7 +8845,6 @@
             ]
         },
         "giver": 1,
-        "turnin": "Therapist",
         "title": "Disease history",
         "locales": {
             "en": "Disease history",
@@ -9105,7 +8902,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "A fuel matter",
         "locales": {
             "en": "A fuel matter",
@@ -9150,7 +8946,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Surplus Goods",
         "locales": {
             "en": "Surplus Goods",
@@ -9193,7 +8988,6 @@
             ]
         },
         "giver": 4,
-        "turnin": "Mechanic",
         "title": "Back door",
         "locales": {
             "en": "Back door",
@@ -9229,7 +9023,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Revision",
         "locales": {
             "en": "Revision",
@@ -9318,7 +9111,6 @@
             ]
         },
         "giver": 3,
-        "turnin": "Peacekeeper",
         "title": "Experience exchange",
         "locales": {
             "en": "Experience exchange",
@@ -9353,7 +9145,6 @@
             ]
         },
         "giver": 5,
-        "turnin": "Ragman",
         "title": "Inventory check",
         "locales": {
             "en": "Inventory check",
@@ -9437,7 +9228,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "No place for renegades",
         "locales": {
             "en": "No place for renegades",
@@ -9472,7 +9262,6 @@
             ]
         },
         "giver": 0,
-        "turnin": "Prapor",
         "title": "Documents",
         "locales": {
             "en": "Documents",
@@ -9521,7 +9310,6 @@
             ]
         },
         "giver": 2,
-        "turnin": "Skier",
         "title": "Safe corridor",
         "locales": {
             "en": "Safe corridor",
@@ -9559,7 +9347,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Huntsman Path - Factory Chief",
         "locales": {
             "en": "Huntsman Path - Factory Chief",
@@ -9601,7 +9388,6 @@
             ]
         },
         "giver": 6,
-        "turnin": "Jaeger",
         "title": "Pest control",
         "locales": {
             "en": "Pest control",

--- a/quests.json
+++ b/quests.json
@@ -365,7 +365,7 @@
             ],
             "loyalty": [
                 {
-                    "trader": "Prapor",
+                    "trader": 0,
                     "stage": 2
                 }
             ]
@@ -8826,7 +8826,7 @@
             ],
             "loyalty": [
                 {
-                    "trader": "Jaeger",
+                    "trader": 6,
                     "stage": 4
                 }
             ]

--- a/quests.json
+++ b/quests.json
@@ -438,42 +438,42 @@
         "objectives": [
             {
                 "type": "reputation",
-                "target": "Prapor",
+                "target": 0,
                 "number": 4,
                 "location": "Any",
                 "id": 16
             },
             {
                 "type": "reputation",
-                "target": "Therapist",
+                "target": 1,
                 "number": 4,
                 "location": "Any",
                 "id": 17
             },
             {
                 "type": "reputation",
-                "target": "Skier",
+                "target": 2,
                 "number": 4,
                 "location": "Any",
                 "id": 18
             },
             {
                 "type": "reputation",
-                "target": "Peacekeeper",
+                "target": 3,
                 "number": 4,
                 "location": "Any",
                 "id": 19
             },
             {
                 "type": "reputation",
-                "target": "Mechanic",
+                "target": 4,
                 "number": 4,
                 "location": "Any",
                 "id": 20
             },
             {
                 "type": "reputation",
-                "target": "Ragman",
+                "target": 5,
                 "number": 4,
                 "location": "Any",
                 "id": 21
@@ -4484,7 +4484,7 @@
         "objectives": [
             {
                 "type": "reputation",
-                "target": "Prapor",
+                "target": 0,
                 "number": 3,
                 "location": "Any",
                 "id": 176
@@ -4853,7 +4853,7 @@
         "objectives": [
             {
                 "type": "reputation",
-                "target": "Ragman",
+                "target": 5,
                 "number": 2,
                 "location": "Any",
                 "id": 194
@@ -5660,7 +5660,7 @@
         "objectives": [
             {
                 "type": "reputation",
-                "target": "Therapist",
+                "target": 1,
                 "number": 3,
                 "location": "Any",
                 "id": 232


### PR DESCRIPTION
But at first, we need to update tarkovtracker for using id instead of name.