### PR TITLE
Quest: gunsmith part 1 - updated recoil

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -4278,7 +4278,7 @@
                     {
                         "type": "stat",
                         "name": "recoil",
-                        "value": "<=950"
+                        "value": "<=850"
                     },
                     {
                         "type": "cells",


### PR DESCRIPTION
[Discord Post: #bugs-data](https://discord.com/channels/668387296973684737/668387739808563221/920152248787562516)

![image](https://user-images.githubusercontent.com/46737902/145928729-94accf38-9ad1-4fd1-8acd-26993e7a174a.png)

They lowered the recoil for Gunsmith part 1 to 850 (from 950).