### PR TITLE
Hideout: illumination 2 - removed crickent

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -702,12 +702,6 @@
                     "name": "5c06779c86f77426e00dd782",
                     "quantity": 5,
                     "id": 54
-                },
-                {
-                    "type": "item",
-                    "name": "56742c284bdc2d98058b456d",
-                    "quantity": 1,
-                    "id": 311
                 }
             ],
             "id": 13,


### PR DESCRIPTION
[Discord Post: #bugs-data](https://discord.com/channels/668387296973684737/668387739808563221/920097791278202880)

![image](https://user-images.githubusercontent.com/46737902/145936728-ca2919da-9908-44bf-8b6a-9d0842d7a6a1.png)
![image](https://user-images.githubusercontent.com/46737902/145936739-22a633b8-e327-4de5-bcf2-5cf3413e1171.png)

They removed the crickent requirement from Illumination L2.