### PR TITLE
Hideout: Solar Power L1 - added working lcd

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -1800,6 +1800,12 @@
                     "id": 207
                 },
                 {
+                    "type": "item",
+                    "name": "5d1b304286f774253763a528",
+                    "quantity": 3,
+                    "id": 312
+                },
+                {
                     "type": "trader",
                     "name": 3,
                     "quantity": 4,


### PR DESCRIPTION
Submitted by `MrDeeTee` in discord:
[Discord Post: #bugs-data](https://discord.com/channels/668387296973684737/668387739808563221/920695707508293662)

![image](https://user-images.githubusercontent.com/46737902/146510275-071a5631-c37b-4e09-aaab-0d4786d986f7.png)
![image](https://user-images.githubusercontent.com/46737902/146510283-9c5c565a-d9ea-4ff0-8bbf-e60a5585f3df.png)

They added requirement for three working lcds from Solar Power L1.