### PR TITLE
Add appendname attribute

### DIFF
--- a/item_presets.json
+++ b/item_presets.json
@@ -2,6 +2,7 @@
     "59411abb86f77478f702b5d2": {
         "id": "59411abb86f77478f702b5d2",
         "name": "MP5 SD",
+        "appendName": "SD",
         "default": false,
         "baseId": "5926bb2186f7744b1c6c6e60",
         "parts": [
@@ -46,6 +47,7 @@
     "5841482e2459775a050cdda9": {
         "id": "5841482e2459775a050cdda9",
         "name": "AS VAL",
+        "appendName": "",
         "default": true,
         "baseId": "57c44b372459772d2b39b8ce",
         "parts": [
@@ -81,7 +83,8 @@
     },
     "59e8d2b386f77445830dd299": {
         "id": "59e8d2b386f77445830dd299",
-        "name": "DVL-10 Urbana",
+        "name": "DVL-10 Saboteur",
+        "appendName": "Saboteur",
         "default": false,
         "baseId": "588892092459774ac91d4b11",
         "parts": [
@@ -118,6 +121,7 @@
     "5a43a86d86f7746c9d7395e8": {
         "id": "5a43a86d86f7746c9d7395e8",
         "name": "P226R Tactical",
+        "appendName": "Tactical",
         "default": false,
         "baseId": "56d59856d2720bd8418b456a",
         "parts": [
@@ -170,6 +174,7 @@
     "5ac4ad3686f774181345c3da": {
         "id": "5ac4ad3686f774181345c3da",
         "name": "M1A",
+        "appendName": "",
         "default": true,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
@@ -210,6 +215,7 @@
     "5b439b1f86f7744fd8059cbe": {
         "id": "5b439b1f86f7744fd8059cbe",
         "name": "Glock 18C",
+        "appendName": "",
         "default": true,
         "baseId": "5b1fa9b25acfc40018633c01",
         "parts": [
@@ -242,6 +248,7 @@
     "5841499024597759f825ff3e": {
         "id": "5841499024597759f825ff3e",
         "name": "PM (t)",
+        "appendName": "",
         "default": true,
         "baseId": "579204f224597773d619e051",
         "parts": [
@@ -258,6 +265,7 @@
     "5c0e93cb86f77432297fdfc8": {
         "id": "5c0e93cb86f77432297fdfc8",
         "name": "TT Brunner",
+        "appendName": "Brunner",
         "default": false,
         "baseId": "571a12c42459771f627b58a0",
         "parts": [
@@ -290,6 +298,7 @@
     "59b81f7386f77421ac688a0a": {
         "id": "59b81f7386f77421ac688a0a",
         "name": "PP-19-01",
+        "appendName": "",
         "default": true,
         "baseId": "59984ab886f7743e98271174",
         "parts": [
@@ -334,6 +343,7 @@
     "59ef247086f77439967a900a": {
         "id": "59ef247086f77439967a900a",
         "name": "VPO-209",
+        "appendName": "",
         "default": true,
         "baseId": "59e6687d86f77411d949b251",
         "parts": [
@@ -378,6 +388,7 @@
     "59430b9b86f77403c27945fd": {
         "id": "59430b9b86f77403c27945fd",
         "name": "AK-74N Magpul",
+        "appendName": "Magpul",
         "default": false,
         "baseId": "5644bd2b4bdc2d3b4c8b4572",
         "parts": [
@@ -442,6 +453,7 @@
     "58dffd4586f77408a27629b2": {
         "id": "58dffd4586f77408a27629b2",
         "name": "MPX Silenced",
+        "appendName": "Silenced",
         "default": false,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
@@ -506,6 +518,7 @@
     "5ac4ac9486f774181345c3d2": {
         "id": "5ac4ac9486f774181345c3d2",
         "name": "APB",
+        "appendName": "",
         "default": true,
         "baseId": "5abccb7dd8ce87001773e277",
         "parts": [
@@ -542,6 +555,7 @@
     "5a8ae21486f774377b73cf5d": {
         "id": "5a8ae21486f774377b73cf5d",
         "name": "AKM T-OPS",
+        "appendName": "T-OPS",
         "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
@@ -626,6 +640,7 @@
     "5a8ae65f86f774377a23ed55": {
         "id": "5a8ae65f86f774377a23ed55",
         "name": "PP-19-01 Zenit",
+        "appendName": "Zenit",
         "default": false,
         "baseId": "59984ab886f7743e98271174",
         "parts": [
@@ -690,6 +705,7 @@
     "5a88ae4a86f77457fd2c0dae": {
         "id": "5a88ae4a86f77457fd2c0dae",
         "name": "GLOCK17 Viper",
+        "appendName": "Viper",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -730,6 +746,7 @@
     "5a8ae36686f774377d6ce226": {
         "id": "5a8ae36686f774377d6ce226",
         "name": "M4A1 Space Trooper",
+        "appendName": "Space Trooper",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -814,6 +831,7 @@
     "5a327f4a86f774766866140b": {
         "id": "5a327f4a86f774766866140b",
         "name": "AKMS",
+        "appendName": "",
         "default": true,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
@@ -858,6 +876,7 @@
     "5a3b898486f77467720a2f29": {
         "id": "5a3b898486f77467720a2f29",
         "name": "SLock PVS-14",
+        "appendName": "PVS-14",
         "default": false,
         "baseId": "5a16bb52fcdbcb001a3b00dc",
         "parts": [
@@ -882,6 +901,7 @@
     "584149ad2459775a7726350e": {
         "id": "584149ad2459775a7726350e",
         "name": "PP-9 Klin",
+        "appendName": "",
         "default": true,
         "baseId": "57f4c844245977379d5c14d1",
         "parts": [
@@ -901,7 +921,8 @@
     },
     "58dffc5d86f77407c744a847": {
         "id": "58dffc5d86f77407c744a847",
-        "name": "DVL-10",
+        "name": "DVL-10 Urbana",
+        "appendName": "Urbana",
         "default": true,
         "baseId": "588892092459774ac91d4b11",
         "parts": [
@@ -938,6 +959,7 @@
     "5a8ae43686f774377b73cfb3": {
         "id": "5a8ae43686f774377b73cfb3",
         "name": "MPX MQB",
+        "appendName": "MQB",
         "default": false,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
@@ -1014,6 +1036,7 @@
     "59ef24b986f77439987b8762": {
         "id": "59ef24b986f77439987b8762",
         "name": "VPO-136",
+        "appendName": "",
         "default": true,
         "baseId": "59e6152586f77473dc057aa1",
         "parts": [
@@ -1058,6 +1081,7 @@
     "5af08bfd86f774223d4528e2": {
         "id": "5af08bfd86f774223d4528e2",
         "name": "M1A EBR",
+        "appendName": "EBR",
         "default": false,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
@@ -1102,6 +1126,7 @@
     "5a327f6386f77479010da870": {
         "id": "5a327f6386f77479010da870",
         "name": "SR-1MP",
+        "appendName": "",
         "default": true,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
@@ -1118,6 +1143,7 @@
     "5c0c1dba86f7743e667da897": {
         "id": "5c0c1dba86f7743e667da897",
         "name": "M700 AAC SD",
+        "appendName": "AAC SD",
         "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -1158,6 +1184,7 @@
     "58414967245977598f1ad391": {
         "id": "58414967245977598f1ad391",
         "name": "PM",
+        "appendName": "",
         "default": true,
         "baseId": "5448bd6b4bdc2dfc2f8b4569",
         "parts": [
@@ -1174,6 +1201,7 @@
     "5ac4abf986f7747d117c67aa": {
         "id": "5ac4abf986f7747d117c67aa",
         "name": "AKS-74N",
+        "appendName": "",
         "default": true,
         "baseId": "5ab8e9fcd8ce870019439434",
         "parts": [
@@ -1218,6 +1246,7 @@
     "59dcdbb386f77417b03f350d": {
         "id": "59dcdbb386f77417b03f350d",
         "name": "OP-SKS",
+        "appendName": "",
         "default": true,
         "baseId": "587e02ff24597743df3deaeb",
         "parts": [
@@ -1246,6 +1275,7 @@
     "5a88aed086f77476cd391963": {
         "id": "5a88aed086f77476cd391963",
         "name": "GLOCK17 Fischer",
+        "appendName": "Fischer",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -1290,6 +1320,7 @@
     "5c0c202e86f77448687e0368": {
         "id": "5c0c202e86f77448687e0368",
         "name": "Mosin Obrez",
+        "appendName": "Obrez",
         "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
@@ -1318,6 +1349,7 @@
     "584149ea2459775a6c55e940": {
         "id": "584149ea2459775a6c55e940",
         "name": "PP-91-01 Kedr-B",
+        "appendName": "",
         "default": true,
         "baseId": "57f3c6bd24597738e730fa2f",
         "parts": [
@@ -1346,6 +1378,7 @@
     "5c0c1fc586f77455912eaf08": {
         "id": "5c0c1fc586f77455912eaf08",
         "name": "Mosin Inf. Obrez",
+        "appendName": "Obrez",
         "default": false,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
@@ -1370,6 +1403,7 @@
     "5ba3a3dfd4351e0032020190": {
         "id": "5ba3a3dfd4351e0032020190",
         "name": "AKM (AKMP)",
+        "appendName": "(AKMP)",
         "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
@@ -1422,6 +1456,7 @@
     "5ba3a4d1d4351e4502010622": {
         "id": "5ba3a4d1d4351e4502010622",
         "name": "AKMN (AKMN2 6P1N2)",
+        "appendName": "(AKMN2 6P1N2)",
         "default": false,
         "baseId": "5a0ec13bfcdbcb00165aa685",
         "parts": [
@@ -1474,6 +1509,7 @@
     "584148f2245977598f1ad387": {
         "id": "584148f2245977598f1ad387",
         "name": "MP-133",
+        "appendName": "",
         "default": true,
         "baseId": "54491c4f4bdc2db1078b4568",
         "parts": [
@@ -1502,6 +1538,7 @@
     "58dffca786f774083a256ab1": {
         "id": "58dffca786f774083a256ab1",
         "name": "MPX",
+        "appendName": "",
         "default": true,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
@@ -1562,6 +1599,7 @@
     "5c0c208886f7743e5335d279": {
         "id": "5c0c208886f7743e5335d279",
         "name": "Mosin Obrez M",
+        "appendName": "Obrez M",
         "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
@@ -1590,6 +1628,7 @@
     "5bdb3ac186f77405f232ad22": {
         "id": "5bdb3ac186f77405f232ad22",
         "name": "MP7A2",
+        "appendName": "",
         "default": true,
         "baseId": "5bd70322209c4d00d7167b8f",
         "parts": [
@@ -1622,6 +1661,7 @@
     "5a8ae54786f7743b5e013ba0": {
         "id": "5a8ae54786f7743b5e013ba0",
         "name": "MP-133 Tactical",
+        "appendName": "Tactical",
         "default": false,
         "baseId": "54491c4f4bdc2db1078b4568",
         "parts": [
@@ -1678,6 +1718,7 @@
     "5a8ae73886f7747b2e6e1416": {
         "id": "5a8ae73886f7747b2e6e1416",
         "name": "M4A1 SOPMOD II",
+        "appendName": "SOPMOD II",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -1762,6 +1803,7 @@
     "58414a052459775a2b6d9f1e": {
         "id": "58414a052459775a2b6d9f1e",
         "name": "Saiga 12ga v.10",
+        "appendName": "",
         "default": true,
         "baseId": "576165642459773c7a400233",
         "parts": [
@@ -1802,6 +1844,7 @@
     "5af08cf886f774223c269184": {
         "id": "5af08cf886f774223c269184",
         "name": "M4A1",
+        "appendName": "",
         "default": true,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -1858,6 +1901,7 @@
     "5a43a85186f7746c914b947a": {
         "id": "5a43a85186f7746c914b947a",
         "name": "AKS-74UN Zenit",
+        "appendName": "Zenit",
         "default": false,
         "baseId": "583990e32459771419544dd2",
         "parts": [
@@ -1930,6 +1974,7 @@
     "58dffce486f77409f40f8162": {
         "id": "58dffce486f77409f40f8162",
         "name": "SKS",
+        "appendName": "",
         "default": true,
         "baseId": "574d967124597745970e7c94",
         "parts": [
@@ -1954,6 +1999,7 @@
     "5b44abe986f774283e2e3512": {
         "id": "5b44abe986f774283e2e3512",
         "name": "TT Gold",
+        "appendName": "",
         "default": true,
         "baseId": "5b3b713c5acfc4330140bd8d",
         "parts": [
@@ -1978,6 +2024,7 @@
     "584149242459775a7726350a": {
         "id": "584149242459775a7726350a",
         "name": "P226R",
+        "appendName": "",
         "default": true,
         "baseId": "56d59856d2720bd8418b456a",
         "parts": [
@@ -2014,6 +2061,7 @@
     "5a88b0f686f77416370eca3e": {
         "id": "5a88b0f686f77416370eca3e",
         "name": "GLOCK17 Hex",
+        "appendName": "Hex",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -2050,6 +2098,7 @@
     "5a3a85af86f774745637d46c": {
         "id": "5a3a85af86f774745637d46c",
         "name": "RSASS",
+        "appendName": "",
         "default": true,
         "baseId": "5a367e5dc4a282000e49738f",
         "parts": [
@@ -2098,6 +2147,7 @@
     "5c0d1ec986f77439512a1a72": {
         "id": "5c0d1ec986f77439512a1a72",
         "name": "RPK-16",
+        "appendName": "",
         "default": true,
         "baseId": "5beed0f50db834001c062b12",
         "parts": [
@@ -2150,6 +2200,7 @@
     "5ba3a449d4351e0034778243": {
         "id": "5ba3a449d4351e0034778243",
         "name": "AKMS (AKMSP)",
+        "appendName": "(AKMSP)",
         "default": false,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
@@ -2202,6 +2253,7 @@
     "5bd05f1186f774572f181678": {
         "id": "5bd05f1186f774572f181678",
         "name": "MP7A1 SEALS",
+        "appendName": "SEALS",
         "default": false,
         "baseId": "5ba26383d4351e00334c93d9",
         "parts": [
@@ -2254,6 +2306,7 @@
     "584149c42459775a77263510": {
         "id": "584149c42459775a77263510",
         "name": "PP-91 Kedr",
+        "appendName": "",
         "default": true,
         "baseId": "57d14d2524597714373db789",
         "parts": [
@@ -2274,6 +2327,7 @@
     "5c0d1e9386f77440120288b7": {
         "id": "5c0d1e9386f77440120288b7",
         "name": "HK 416A5",
+        "appendName": "",
         "default": true,
         "baseId": "5bb2475ed4351e00853264e3",
         "parts": [
@@ -2330,6 +2384,7 @@
     "58414a16245977599247970a": {
         "id": "58414a16245977599247970a",
         "name": "SV-98",
+        "appendName": "",
         "default": true,
         "baseId": "55801eed4bdc2d89578b4588",
         "parts": [
@@ -2362,6 +2417,7 @@
     "584147732459775a2b6d9f12": {
         "id": "584147732459775a2b6d9f12",
         "name": "AKS-74U",
+        "appendName": "",
         "default": true,
         "baseId": "57dc2fa62459775949412633",
         "parts": [
@@ -2405,7 +2461,8 @@
     },
     "5a8c436686f7740f394d10b5": {
         "id": "5a8c436686f7740f394d10b5",
-        "name": "GLOCK17 Tac HC",
+        "name": "GLOCK17",
+        "appendName": "Tac HC",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -2450,6 +2507,7 @@
     "5acf7e4c86f774499a3f3bdd": {
         "id": "5acf7e4c86f774499a3f3bdd",
         "name": "AK-104",
+        "appendName": "",
         "default": true,
         "baseId": "5ac66d725acfc43b321d4b60",
         "parts": [
@@ -2494,6 +2552,7 @@
     "5b439b5686f77428bd137424": {
         "id": "5b439b5686f77428bd137424",
         "name": "SA-58",
+        "appendName": "",
         "default": true,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
@@ -2550,6 +2609,7 @@
     "59e8d2ab86f77407f03fc9c2": {
         "id": "59e8d2ab86f77407f03fc9c2",
         "name": "AKM",
+        "appendName": "",
         "default": true,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
@@ -2594,6 +2654,7 @@
     "5b83f23a86f7746d3d190a73": {
         "id": "5b83f23a86f7746d3d190a73",
         "name": "SA-58 BEL",
+        "appendName": "BEL",
         "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
@@ -2638,6 +2699,7 @@
     "5bbf1c5a88a45017bb03d7aa": {
         "id": "5bbf1c5a88a45017bb03d7aa",
         "name": "M4A1 LVOA",
+        "appendName": "LVOA",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -2698,6 +2760,7 @@
     "5a88ad7b86f77479aa7226af": {
         "id": "5a88ad7b86f77479aa7226af",
         "name": "GLOCK17 Tac 3",
+        "appendName": "Tac 3",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -2742,6 +2805,7 @@
     "5acf7e7986f774401e19c3a0": {
         "id": "5acf7e7986f774401e19c3a0",
         "name": "AK-105",
+        "appendName": "",
         "default": true,
         "baseId": "5ac66d9b5acfc4001633997a",
         "parts": [
@@ -2786,6 +2850,7 @@
     "5c0c1e7486f7744dba7a289b": {
         "id": "5c0c1e7486f7744dba7a289b",
         "name": "Mosin Infantry",
+        "appendName": "",
         "default": true,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
@@ -2818,6 +2883,7 @@
     "584147ed2459775a77263501": {
         "id": "584147ed2459775a77263501",
         "name": "AKS-74UN",
+        "appendName": "",
         "default": true,
         "baseId": "583990e32459771419544dd2",
         "parts": [
@@ -2862,6 +2928,7 @@
     "5af08cc686f77424a61595f2": {
         "id": "5af08cc686f77424a61595f2",
         "name": "M4A1 SOPMOD I",
+        "appendName": "SOPMOD I",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -2918,6 +2985,7 @@
     "5c0c1f2b86f77455912eaefc": {
         "id": "5c0c1f2b86f77455912eaefc",
         "name": "Mosin Carbine",
+        "appendName": "Carbine",
         "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
@@ -2962,6 +3030,7 @@
     "584148a524597759eb357a44": {
         "id": "584148a524597759eb357a44",
         "name": "MP-443 \"Grach\"",
+        "appendName": "",
         "default": true,
         "baseId": "576a581d2459771e7b1bc4f1",
         "parts": [
@@ -2982,6 +3051,7 @@
     "5a13df5286f774032f5454a0": {
         "id": "5a13df5286f774032f5454a0",
         "name": "Saiga-9",
+        "appendName": "",
         "default": true,
         "baseId": "59f9cabd86f7743a10721f46",
         "parts": [
@@ -3026,6 +3096,7 @@
     "5a3a859786f7747e2305e8bf": {
         "id": "5a3a859786f7747e2305e8bf",
         "name": "TOZ-106",
+        "appendName": "",
         "default": true,
         "baseId": "5a38e6bac4a2826c6e06d79b",
         "parts": [
@@ -3050,6 +3121,7 @@
     "5a88acfb86f77457fd2c0d8f": {
         "id": "5a88acfb86f77457fd2c0d8f",
         "name": "Glock 17",
+        "appendName": "",
         "default": true,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -3082,6 +3154,7 @@
     "5a325c3686f7744273716c5b": {
         "id": "5a325c3686f7744273716c5b",
         "name": "AKMN",
+        "appendName": "",
         "default": true,
         "baseId": "5a0ec13bfcdbcb00165aa685",
         "parts": [
@@ -3126,6 +3199,7 @@
     "584149452459775992479702": {
         "id": "584149452459775992479702",
         "name": "PB",
+        "appendName": "",
         "default": true,
         "baseId": "56e0598dd2720bb5668b45a6",
         "parts": [
@@ -3150,6 +3224,7 @@
     "5ba3a53dd4351e3bac12056e": {
         "id": "5ba3a53dd4351e3bac12056e",
         "name": "AKMSN (AKMSN2 6P4N2)",
+        "appendName": "(AKMSN2 6P4N2)",
         "default": false,
         "baseId": "5abcbc27d8ce8700182eceeb",
         "parts": [
@@ -3202,6 +3277,7 @@
     "5a88afdc86f7746de12fcc20": {
         "id": "5a88afdc86f7746de12fcc20",
         "name": "GLOCK17 Alpha Wolf",
+        "appendName": "Alpha Wolf",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -3230,6 +3306,7 @@
     "5b8683a486f77467f2423114": {
         "id": "5b8683a486f77467f2423114",
         "name": "Mosin",
+        "appendName": "",
         "default": true,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
@@ -3262,6 +3339,7 @@
     "5c0c1d6586f7743e5335d264": {
         "id": "5c0c1d6586f7743e5335d264",
         "name": "M700",
+        "appendName": "",
         "default": true,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -3286,6 +3364,7 @@
     "5ba3a078d4351e00334c96ca": {
         "id": "5ba3a078d4351e00334c96ca",
         "name": "AKM (AKMB)",
+        "appendName": "(AKMB)",
         "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
@@ -3330,6 +3409,7 @@
     "58414a2724597759b344da4d": {
         "id": "58414a2724597759b344da4d",
         "name": "TT",
+        "appendName": "",
         "default": true,
         "baseId": "571a12c42459771f627b58a0",
         "parts": [
@@ -3354,6 +3434,7 @@
     "5a88af5086f77411a871682c": {
         "id": "5a88af5086f77411a871682c",
         "name": "GLOCK17 Tac 2",
+        "appendName": "Tac 2",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -3394,6 +3475,7 @@
     "5c0c1ce886f77401c119d014": {
         "id": "5c0c1ce886f77401c119d014",
         "name": "AK-74",
+        "appendName": "",
         "default": true,
         "baseId": "5bf3e03b0db834001d2c4a9c",
         "parts": [
@@ -3438,6 +3520,7 @@
     "5a327f7286f7747668661419": {
         "id": "5a327f7286f7747668661419",
         "name": "SR-1MP Tactical 1",
+        "appendName": "Tactical 1",
         "default": false,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
@@ -3466,6 +3549,7 @@
     "5ac4ad7586f7747d14551da3": {
         "id": "5ac4ad7586f7747d14551da3",
         "name": "M870 12ga",
+        "appendName": "",
         "default": true,
         "baseId": "5a7828548dc32e5a9c28b516",
         "parts": [
@@ -3494,6 +3578,7 @@
     "5af08d1c86f774223a7aa1b4": {
         "id": "5af08d1c86f774223a7aa1b4",
         "name": "M870 Breacher",
+        "appendName": "Breacher",
         "default": false,
         "baseId": "5a7828548dc32e5a9c28b516",
         "parts": [
@@ -3546,6 +3631,7 @@
     "5b83f22086f77464e15a1d5f": {
         "id": "5b83f22086f77464e15a1d5f",
         "name": "SA-58 AUS",
+        "appendName": "AUS",
         "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
@@ -3590,6 +3676,7 @@
     "5c10fcb186f774533e5529ab": {
         "id": "5c10fcb186f774533e5529ab",
         "name": "ADAR 2-15",
+        "appendName": "",
         "default": true,
         "baseId": "5c07c60e0db834002330051f",
         "parts": [
@@ -3638,6 +3725,7 @@
     "5a88b1f686f774159949926e": {
         "id": "5a88b1f686f774159949926e",
         "name": "GLOCK17 Spartan",
+        "appendName": "Spartan",
         "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
@@ -3678,6 +3766,7 @@
     "59411aa786f7747aeb37f9a5": {
         "id": "59411aa786f7747aeb37f9a5",
         "name": "MP5",
+        "appendName": "",
         "default": true,
         "baseId": "5926bb2186f7744b1c6c6e60",
         "parts": [
@@ -3722,6 +3811,7 @@
     "5acf7db286f7743a9c7092e3": {
         "id": "5acf7db286f7743a9c7092e3",
         "name": "AK-74M",
+        "appendName": "",
         "default": true,
         "baseId": "5ac4cd105acfc40016339859",
         "parts": [
@@ -3766,6 +3856,7 @@
     "5acf7e2b86f7740874790e20": {
         "id": "5acf7e2b86f7740874790e20",
         "name": "AK-103",
+        "appendName": "",
         "default": true,
         "baseId": "5ac66d2e5acfc43b321d4b53",
         "parts": [
@@ -3810,6 +3901,7 @@
     "5af08c4486f774223b094223": {
         "id": "5af08c4486f774223b094223",
         "name": "M1A SASS",
+        "appendName": "SASS",
         "default": false,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
@@ -3850,6 +3942,7 @@
     "5a327f7c86f77475187e509a": {
         "id": "5a327f7c86f77475187e509a",
         "name": "SR-1MP Tactical 2",
+        "appendName": "Tactical 2",
         "default": false,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
@@ -3878,6 +3971,7 @@
     "5841474424597759ba49be91": {
         "id": "5841474424597759ba49be91",
         "name": "AK-74N",
+        "appendName": "",
         "default": true,
         "baseId": "5644bd2b4bdc2d3b4c8b4572",
         "parts": [
@@ -3926,6 +4020,7 @@
     "58414a3f2459775a77263531": {
         "id": "58414a3f2459775a77263531",
         "name": "VSS Vintorez",
+        "appendName": "",
         "default": true,
         "baseId": "57838ad32459774a17445cd2",
         "parts": [
@@ -3958,6 +4053,7 @@
     "5acf7dfc86f774401e19c390": {
         "id": "5acf7dfc86f774401e19c390",
         "name": "AK-102",
+        "appendName": "",
         "default": true,
         "baseId": "5ac66d015acfc400180ae6e4",
         "parts": [
@@ -4002,6 +4098,7 @@
     "5acf7dd986f774486e1281bf": {
         "id": "5acf7dd986f774486e1281bf",
         "name": "AK-101",
+        "appendName": "",
         "default": true,
         "baseId": "5ac66cb05acfc40198510a10",
         "parts": [
@@ -4046,6 +4143,7 @@
     "584147982459775a6c55e931": {
         "id": "584147982459775a6c55e931",
         "name": "AKS-74UB",
+        "appendName": "",
         "default": true,
         "baseId": "5839a40f24597726f856b511",
         "parts": [
@@ -4090,6 +4188,7 @@
     "5bd056fa86f7743aba7658cd": {
         "id": "5bd056fa86f7743aba7658cd",
         "name": "MP7A1",
+        "appendName": "",
         "default": true,
         "baseId": "5ba26383d4351e00334c93d9",
         "parts": [
@@ -4122,6 +4221,7 @@
     "5c0c1d2b86f77401c119d01f": {
         "id": "5c0c1d2b86f77401c119d01f",
         "name": "AKS-74",
+        "appendName": "",
         "default": true,
         "baseId": "5bf3e0490db83400196199af",
         "parts": [
@@ -4166,6 +4266,7 @@
     "5ac4ab8886f7747d0f66429a": {
         "id": "5ac4ab8886f7747d0f66429a",
         "name": "AKMSN",
+        "appendName": "",
         "default": true,
         "baseId": "5abcbc27d8ce8700182eceeb",
         "parts": [
@@ -4210,6 +4311,7 @@
     "58414907245977598f1ad38d": {
         "id": "58414907245977598f1ad38d",
         "name": "MP-153",
+        "appendName": "",
         "default": true,
         "baseId": "56dee2bdd2720bc8328b4567",
         "parts": [
@@ -4238,6 +4340,7 @@
     "5ac4accf86f774181345c3d7": {
         "id": "5ac4accf86f774181345c3d7",
         "name": "APS",
+        "appendName": "",
         "default": true,
         "baseId": "5a17f98cfcdbcb0980087290",
         "parts": [
@@ -4266,6 +4369,7 @@
     "5bbf1c1c88a45017144d28c5": {
         "id": "5bbf1c1c88a45017144d28c5",
         "name": "AK-74M Zenitco",
+        "appendName": "Zenitco",
         "default": false,
         "baseId": "5ac4cd105acfc40016339859",
         "parts": [
@@ -4314,6 +4418,7 @@
     "5b83f29886f7746d956305a1": {
         "id": "5b83f29886f7746d956305a1",
         "name": "SA-58 PBR",
+        "appendName": "PBR",
         "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
@@ -4374,6 +4479,7 @@
     "5ba3a14cd4351e003202017f": {
         "id": "5ba3a14cd4351e003202017f",
         "name": "AKMS (AKMSB 6P4M)",
+        "appendName": "(AKMSB 6P4M)",
         "default": false,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
@@ -4418,6 +4524,7 @@
     "5c98be1e86f7741cc96ffd79": {
         "id": "5c98be1e86f7741cc96ffd79",
         "name": "SVDS",
+        "appendName": "",
         "default": true,
         "baseId": "5c46fbd72e2216398b5a8c9c",
         "parts": [
@@ -4474,6 +4581,7 @@
     "5c0c1dff86f7744dba7a2892": {
         "id": "5c0c1dff86f7744dba7a2892",
         "name": "Mosin Inf. Carbine",
+        "appendName": "Carbine",
         "default": false,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
@@ -4506,6 +4614,7 @@
     "5c98bd7386f7740cfb15654e": {
         "id": "5c98bd7386f7740cfb15654e",
         "name": "MDR",
+        "appendName": "",
         "default": true,
         "baseId": "5c488a752e221602b412af63",
         "parts": [
@@ -4538,6 +4647,7 @@
     "5d3f0bc986f7743cb332abdc": {
         "id": "5d3f0bc986f7743cb332abdc",
         "name": "M9A3",
+        "appendName": "",
         "default": true,
         "baseId": "5cadc190ae921500103bb3b6",
         "parts": [
@@ -4578,6 +4688,7 @@
     "5d23467086f77443f37fc602": {
         "id": "5d23467086f77443f37fc602",
         "name": "ASh-12",
+        "appendName": "",
         "default": true,
         "baseId": "5cadfbf7ae92152ac412eeef",
         "parts": [
@@ -4614,6 +4725,7 @@
     "5c98bf9186f7740cf708c509": {
         "id": "5c98bf9186f7740cf708c509",
         "name": "Vepr Hunter",
+        "appendName": "",
         "default": true,
         "baseId": "5c501a4d2e221602b412b540",
         "parts": [
@@ -4646,6 +4758,7 @@
     "5d2340e986f77461496241bc": {
         "id": "5d2340e986f77461496241bc",
         "name": "P90 CWDG",
+        "appendName": "CWDG",
         "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
@@ -4702,6 +4815,7 @@
     "5d23404b86f7740d62079098": {
         "id": "5d23404b86f7740d62079098",
         "name": "P90 SBR",
+        "appendName": "SBR",
         "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
@@ -4746,6 +4860,7 @@
     "5d3f06c886f7743bb5318c6a": {
         "id": "5d3f06c886f7743bb5318c6a",
         "name": "MP5K-N",
+        "appendName": "",
         "default": true,
         "baseId": "5d2f0d8048f0356c925bc3b0",
         "parts": [
@@ -4782,6 +4897,7 @@
     "5d51290186f77419093e7c24": {
         "id": "5d51290186f77419093e7c24",
         "name": "FN 5-7",
+        "appendName": "",
         "default": true,
         "baseId": "5d3eb3b0a4b93615055e84d2",
         "parts": [
@@ -4814,6 +4930,7 @@
     "5d38517786f7742a1468cf6a": {
         "id": "5d38517786f7742a1468cf6a",
         "name": "M700 MRS",
+        "appendName": "MRS",
         "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -4870,6 +4987,7 @@
     "5d383e1a86f7742a1468ce63": {
         "id": "5d383e1a86f7742a1468ce63",
         "name": "M700 AICS",
+        "appendName": "AICS",
         "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -4902,6 +5020,7 @@
     "5d23424c86f7740d5e50ce65": {
         "id": "5d23424c86f7740d5e50ce65",
         "name": "P90 SBRT",
+        "appendName": "SBRT",
         "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
@@ -4938,6 +5057,7 @@
     "5d7b845786f7743c1e531da7": {
         "id": "5d7b845786f7743c1e531da7",
         "name": "FN 5-7 FDE",
+        "appendName": "",
         "default": true,
         "baseId": "5d67abc1a4b93614ec50137f",
         "parts": [
@@ -4970,6 +5090,7 @@
     "5d4d617f86f77449c463d107": {
         "id": "5d4d617f86f77449c463d107",
         "name": "TX-15 DML",
+        "appendName": "",
         "default": true,
         "baseId": "5d43021ca4b9362eab4b5e25",
         "parts": [
@@ -5034,6 +5155,7 @@
     "5e03511086f7744ccb1fb6cf": {
         "id": "5e03511086f7744ccb1fb6cf",
         "name": "SR-25",
+        "appendName": "",
         "default": true,
         "baseId": "5df8ce05b11454561e39243b",
         "parts": [
@@ -5094,6 +5216,7 @@
     "5e0340ab86f7745bb7339235": {
         "id": "5e0340ab86f7745bb7339235",
         "name": "MP9",
+        "appendName": "",
         "default": true,
         "baseId": "5e00903ae9dc277128008b87",
         "parts": [
@@ -5130,6 +5253,7 @@
     "5d23376786f77459bb77d838": {
         "id": "5d23376786f77459bb77d838",
         "name": "P90",
+        "appendName": "",
         "default": true,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
@@ -5178,6 +5302,7 @@
     "5d383f5d86f7742a15793872": {
         "id": "5d383f5d86f7742a15793872",
         "name": "M700 PRO",
+        "appendName": "PRO",
         "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -5222,6 +5347,7 @@
     "5d383ee786f7742a15793860": {
         "id": "5d383ee786f7742a15793860",
         "name": "M700 ARCH",
+        "appendName": "ARCH",
         "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
@@ -5250,6 +5376,7 @@
     "5dd800bde492226366631317": {
         "id": "5dd800bde492226366631317",
         "name": "AK-104 T-SAW",
+        "appendName": "T-SAW",
         "default": false,
         "baseId": "5ac66d725acfc43b321d4b60",
         "parts": [
@@ -5322,6 +5449,7 @@
     "5e03410186f77469041348ea": {
         "id": "5e03410186f77469041348ea",
         "name": "MP9-N",
+        "appendName": "",
         "default": true,
         "baseId": "5de7bd7bfd6b4e6e2276dc25",
         "parts": [
@@ -5362,6 +5490,7 @@
     "5e0354f786f77425b53eb6c5": {
         "id": "5e0354f786f77425b53eb6c5",
         "name": "T-5000M",
+        "appendName": "",
         "default": true,
         "baseId": "5df24cf80dee1b22f862e9bc",
         "parts": [
@@ -5418,6 +5547,7 @@
     "5e035eb586f774756048ec12": {
         "id": "5e035eb586f774756048ec12",
         "name": "MDR",
+        "appendName": "",
         "default": true,
         "baseId": "5dcbd56fdbd3d91b3e5468d5",
         "parts": [
@@ -5450,6 +5580,7 @@
     "5dd800eae49222636663133b": {
         "id": "5dd800eae49222636663133b",
         "name": "M4A1 SAI",
+        "appendName": "SAI",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -5530,6 +5661,7 @@
     "5e0359bd86f7746b243db876": {
         "id": "5e0359bd86f7746b243db876",
         "name": "VPO-215",
+        "appendName": "",
         "default": true,
         "baseId": "5de652c31b7e3716273428be",
         "parts": [
@@ -5562,6 +5694,7 @@
     "5dd8013ff4c3af18c507b10a": {
         "id": "5dd8013ff4c3af18c507b10a",
         "name": "TX-15 DML D-WARRIOR",
+        "appendName": "D-WARRIOR",
         "default": false,
         "baseId": "5d43021ca4b9362eab4b5e25",
         "parts": [
@@ -5630,6 +5763,7 @@
     "5ddbbeac582ed30a6134e577": {
         "id": "5ddbbeac582ed30a6134e577",
         "name": "Saiga 12ga v.10 NERFGUN",
+        "appendName": "NERFGUN",
         "default": false,
         "baseId": "576165642459773c7a400233",
         "parts": [
@@ -5706,6 +5840,7 @@
     "5dd7f8c524e5d7504a4e3077": {
         "id": "5dd7f8c524e5d7504a4e3077",
         "name": "AK-74 Plum",
+        "appendName": "Plum",
         "default": false,
         "baseId": "5bf3e03b0db834001d2c4a9c",
         "parts": [
@@ -5750,6 +5885,7 @@
     "5eb2968186f7746d1f1a4fd5": {
         "id": "5eb2968186f7746d1f1a4fd5",
         "name": "M1911A1",
+        "appendName": "",
         "default": true,
         "baseId": "5e81c3cbac2bb513793cdc75",
         "parts": [
@@ -5798,6 +5934,7 @@
     "5eb2963686f7742d3f5ab0f8": {
         "id": "5eb2963686f7742d3f5ab0f8",
         "name": "PPSh-41",
+        "appendName": "",
         "default": true,
         "baseId": "5ea03f7400685063ec28bfa8",
         "parts": [
@@ -5826,6 +5963,7 @@
     "5ebbfe23ba87a5065a00a563": {
         "id": "5ebbfe23ba87a5065a00a563",
         "name": "M4A1 USASOC-I",
+        "appendName": "USASOC-I",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -5906,6 +6044,7 @@
     "5ebbff0841a637322117a5fb": {
         "id": "5ebbff0841a637322117a5fb",
         "name": "M4A1 USASOC-II",
+        "appendName": "USASOC-II",
         "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
@@ -5978,6 +6117,7 @@
     "5f676b779ab5ec19f028eaf3": {
         "id": "5f676b779ab5ec19f028eaf3",
         "name": "RFB",
+        "appendName": "",
         "default": true,
         "baseId": "5f2a9575926fd9352339381f",
         "parts": [
@@ -6014,6 +6154,7 @@
     "5f6771214ef1ca4f4e1b8a06": {
         "id": "5f6771214ef1ca4f4e1b8a06",
         "name": "KS-23M",
+        "appendName": "",
         "default": true,
         "baseId": "5e848cc2988a8701445df1e8",
         "parts": [
@@ -6042,6 +6183,7 @@
     "5f6770f839a13e712a1dff54": {
         "id": "5f6770f839a13e712a1dff54",
         "name": "KS-23M Drozd",
+        "appendName": "Drozd",
         "default": false,
         "baseId": "5e848cc2988a8701445df1e8",
         "parts": [
@@ -6074,6 +6216,7 @@
     "5f06d6e1475d472556679d16": {
         "id": "5f06d6e1475d472556679d16",
         "name": "FN40GL",
+        "appendName": "",
         "default": true,
         "baseId": "5e81ebcd8e146c7080625e15",
         "parts": [
@@ -6090,6 +6233,7 @@
     "5f06d6bb4010601e3232cd22": {
         "id": "5f06d6bb4010601e3232cd22",
         "name": "590A1",
+        "appendName": "",
         "default": true,
         "baseId": "5e870397991fd70db46995c8",
         "parts": [
@@ -6126,6 +6270,7 @@
     "5f6762e964af6a2aa319deeb": {
         "id": "5f6762e964af6a2aa319deeb",
         "name": "M45A1",
+        "appendName": "",
         "default": true,
         "baseId": "5f36a0e5fbf956000b716b65",
         "parts": [
@@ -6174,6 +6319,7 @@
     "5fd25119dd870108a754a163": {
         "id": "5fd25119dd870108a754a163",
         "name": "Mk-18",
+        "appendName": "",
         "default": true,
         "baseId": "5fc22d7c187fea44d52eda44",
         "parts": [
@@ -6222,6 +6368,7 @@
     "5fd251a31189a17bcc172662": {
         "id": "5fd251a31189a17bcc172662",
         "name": "SIG MCX .300 BLK",
+        "appendName": "",
         "default": true,
         "baseId": "5fbcc1d9016cce60e8341ab3",
         "parts": [
@@ -6282,6 +6429,7 @@
     "5fd251c90d9c95034825edb5": {
         "id": "5fd251c90d9c95034825edb5",
         "name": "Vector 9x19",
+        "appendName": "",
         "default": true,
         "baseId": "5fc3f2d5900b1d5091531e57",
         "parts": [
@@ -6326,6 +6474,7 @@
     "5fd2517dbdd50d684f73a474": {
         "id": "5fd2517dbdd50d684f73a474",
         "name": "UMP 45",
+        "appendName": "",
         "default": true,
         "baseId": "5fc3e272f8b6a877a729eac5",
         "parts": [
@@ -6358,6 +6507,7 @@
     "5fd251ee16cac650092f5d02": {
         "id": "5fd251ee16cac650092f5d02",
         "name": "Vector .45ACP",
+        "appendName": "",
         "default": true,
         "baseId": "5fb64bc92b1b027b1f50bcf2",
         "parts": [
@@ -6402,6 +6552,7 @@
     "60479c3f420fac5ebc199f86": {
         "id": "60479c3f420fac5ebc199f86",
         "name": "STM-9",
+        "appendName": "",
         "default": true,
         "baseId": "60339954d62c9b14ed777c06",
         "parts": [
@@ -6454,6 +6605,7 @@
     "60479fb29c15b12b9a480fb0": {
         "id": "60479fb29c15b12b9a480fb0",
         "name": "PL-15",
+        "appendName": "",
         "default": true,
         "baseId": "602a9740da11d6478d5a06dc",
         "parts": [
@@ -6486,6 +6638,7 @@
     "60b7c28ee53e4c5c8945dd73": {
         "id": "60b7c28ee53e4c5c8945dd73",
         "name": "MP-155",
+        "appendName": "",
         "default": true,
         "baseId": "606dae0ab0e443224b421bb7",
         "parts": [
@@ -6514,6 +6667,7 @@
     "60b7c2bd95047637182d90a4": {
         "id": "60b7c2bd95047637182d90a4",
         "name": "MP-155 Ultima",
+        "appendName": "Ultima",
         "default": false,
         "baseId": "606dae0ab0e443224b421bb7",
         "parts": [
@@ -6558,6 +6712,7 @@
     "60b7d76e2a3c79100f1979de": {
         "id": "60b7d76e2a3c79100f1979de",
         "name": "Mk47",
+        "appendName": "",
         "default": true,
         "baseId": "606587252535c57a13424cfd",
         "parts": [
@@ -6618,6 +6773,7 @@
     "6197d1f3585c515a052ad88f": {
         "id": "6197d1f3585c515a052ad88f",
         "name": "MP-43",
+        "appendName": "",
         "default": true,
         "baseId": "5580223e4bdc2d1c128b457f",
         "parts": [
@@ -6638,6 +6794,7 @@
     "6193e4fae693542ea37d11c6": {
         "id": "6193e4fae693542ea37d11c6",
         "name": "Mk 17 (FDE)",
+        "appendName": "",
         "default": true,
         "baseId": "6165ac306ef05c2ce828ef74",
         "parts": [
@@ -6702,6 +6859,7 @@
     "6193e590069d61205d490dd8": {
         "id": "6193e590069d61205d490dd8",
         "name": "G28",
+        "appendName": "",
         "default": true,
         "baseId": "6176aca650224f204c1da3fb",
         "parts": [
@@ -6786,6 +6944,7 @@
     "6193e4a46bb904059c382295": {
         "id": "6193e4a46bb904059c382295",
         "name": "Mk 17",
+        "appendName": "",
         "default": true,
         "baseId": "6183afd850224f204c1da514",
         "parts": [
@@ -6854,6 +7013,7 @@
     "6193e18de693542ea37d11b3": {
         "id": "6193e18de693542ea37d11b3",
         "name": "Mk 16",
+        "appendName": "",
         "default": true,
         "baseId": "6184055050224f204c1da540",
         "parts": [
@@ -6922,6 +7082,7 @@
     "6193e226449ec003d9127fa6": {
         "id": "6193e226449ec003d9127fa6",
         "name": "Mk 16 (FDE)",
+        "appendName": "",
         "default": true,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
@@ -6990,6 +7151,7 @@
     "6193e108c1982475fa2a7f16": {
         "id": "6193e108c1982475fa2a7f16",
         "name": "Mk 16 (FDE) CQC",
+        "appendName": "CQC",
         "default": false,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
@@ -7058,6 +7220,7 @@
     "619e61e70459e93c12392ba7": {
         "id": "619e61e70459e93c12392ba7",
         "name": "Mk 16 (FDE) CW",
+        "appendName": "Contract Wars",
         "default": false,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
@@ -7142,6 +7305,7 @@
     "619d267f36b5be1f3236f9ba": {
         "id": "619d267f36b5be1f3236f9ba",
         "name": "USP .45",
+        "appendName": "",
         "default": true,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
@@ -7186,6 +7350,7 @@
     "619d26ccc7791e3af27ae3cd": {
         "id": "619d26ccc7791e3af27ae3cd",
         "name": "USP .45 Match",
+        "appendName": "Match",
         "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
@@ -7234,6 +7399,7 @@
     "619d270836b5be1f3236f9c5": {
         "id": "619d270836b5be1f3236f9c5",
         "name": "USP .45 Tactical",
+        "appendName": "Tactical",
         "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
@@ -7294,6 +7460,7 @@
     "619d272b0f9e4513744e7699": {
         "id": "619d272b0f9e4513744e7699",
         "name": "USP .45 Elite",
+        "appendName": "Elite",
         "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
@@ -7342,6 +7509,7 @@
     "619d276ca4712949ff3159b9": {
         "id": "619d276ca4712949ff3159b9",
         "name": "USP .45 Expert",
+        "appendName": "Expert",
         "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
@@ -7386,6 +7554,7 @@
     "6198e2ddef80673cae5d1c87": {
         "id": "6198e2ddef80673cae5d1c87",
         "name": "MTs-255-12",
+        "appendName": "",
         "default": true,
         "baseId": "60db29ce99594040e04c4a27",
         "parts": [

--- a/item_presets.json
+++ b/item_presets.json
@@ -2,6 +2,7 @@
     "59411abb86f77478f702b5d2": {
         "id": "59411abb86f77478f702b5d2",
         "name": "MP5 SD",
+        "default": false,
         "baseId": "5926bb2186f7744b1c6c6e60",
         "parts": [
             {
@@ -40,12 +41,12 @@
                 "id": "5926c32286f774616e42de99",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5841482e2459775a050cdda9": {
         "id": "5841482e2459775a050cdda9",
         "name": "AS VAL",
+        "default": true,
         "baseId": "57c44b372459772d2b39b8ce",
         "parts": [
             {
@@ -76,12 +77,12 @@
                 "id": "57c450252459772d28133253",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "59e8d2b386f77445830dd299": {
         "id": "59e8d2b386f77445830dd299",
         "name": "DVL-10 Urbana",
+        "default": false,
         "baseId": "588892092459774ac91d4b11",
         "parts": [
             {
@@ -112,12 +113,12 @@
                 "id": "58889d0c2459775bc215d981",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a43a86d86f7746c9d7395e8": {
         "id": "5a43a86d86f7746c9d7395e8",
         "name": "P226R Tactical",
+        "default": false,
         "baseId": "56d59856d2720bd8418b456a",
         "parts": [
             {
@@ -164,12 +165,12 @@
                 "id": "56d59d3ad2720bdb418b4577",
                 "quantity": 15
             }
-        ],
-        "default": false
+        ]        
     },
     "5ac4ad3686f774181345c3da": {
         "id": "5ac4ad3686f774181345c3da",
         "name": "M1A",
+        "default": true,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
             {
@@ -204,12 +205,12 @@
                 "id": "5abcbb20d8ce87001773e258",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5b439b1f86f7744fd8059cbe": {
         "id": "5b439b1f86f7744fd8059cbe",
         "name": "Glock 18C",
+        "default": true,
         "baseId": "5b1fa9b25acfc40018633c01",
         "parts": [
             {
@@ -236,12 +237,12 @@
                 "id": "5a718b548dc32e000d46d262",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5841499024597759f825ff3e": {
         "id": "5841499024597759f825ff3e",
         "name": "PM (t)",
+        "default": true,
         "baseId": "579204f224597773d619e051",
         "parts": [
             {
@@ -252,12 +253,12 @@
                 "id": "5448c12b4bdc2d02308b456f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0e93cb86f77432297fdfc8": {
         "id": "5c0e93cb86f77432297fdfc8",
         "name": "TT Brunner",
+        "default": false,
         "baseId": "571a12c42459771f627b58a0",
         "parts": [
             {
@@ -284,12 +285,12 @@
                 "id": "5c079ed60db834001a66b372",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "59b81f7386f77421ac688a0a": {
         "id": "59b81f7386f77421ac688a0a",
         "name": "PP-19-01",
+        "default": true,
         "baseId": "59984ab886f7743e98271174",
         "parts": [
             {
@@ -328,12 +329,12 @@
                 "id": "5648b1504bdc2d9d488b4584",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "59ef247086f77439967a900a": {
         "id": "59ef247086f77439967a900a",
         "name": "VPO-209",
+        "default": true,
         "baseId": "59e6687d86f77411d949b251",
         "parts": [
             {
@@ -372,12 +373,12 @@
                 "id": "59d625f086f774661516605d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "59430b9b86f77403c27945fd": {
         "id": "59430b9b86f77403c27945fd",
         "name": "AK-74N Magpul",
+        "default": false,
         "baseId": "5644bd2b4bdc2d3b4c8b4572",
         "parts": [
             {
@@ -436,12 +437,12 @@
                 "id": "55d482194bdc2d1d4e8b456b",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "58dffd4586f77408a27629b2": {
         "id": "58dffd4586f77408a27629b2",
         "name": "MPX Silenced",
+        "default": false,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
             {
@@ -500,12 +501,12 @@
                 "id": "58949fac86f77409483e16aa",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ac4ac9486f774181345c3d2": {
         "id": "5ac4ac9486f774181345c3d2",
         "name": "APB",
+        "default": true,
         "baseId": "5abccb7dd8ce87001773e277",
         "parts": [
             {
@@ -536,12 +537,12 @@
                 "id": "5abcc328d8ce8700194394f3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a8ae21486f774377b73cf5d": {
         "id": "5a8ae21486f774377b73cf5d",
         "name": "AKM T-OPS",
+        "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
             {
@@ -620,12 +621,12 @@
                 "id": "5648ac824bdc2ded0b8b457d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a8ae65f86f774377a23ed55": {
         "id": "5a8ae65f86f774377a23ed55",
         "name": "PP-19-01 Zenit",
+        "default": false,
         "baseId": "59984ab886f7743e98271174",
         "parts": [
             {
@@ -684,12 +685,12 @@
                 "id": "560d657b4bdc2da74d8b4572",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a88ae4a86f77457fd2c0dae": {
         "id": "5a88ae4a86f77457fd2c0dae",
         "name": "GLOCK17 Viper",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -724,12 +725,12 @@
                 "id": "58d268fc86f774111273f8c2",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a8ae36686f774377d6ce226": {
         "id": "5a8ae36686f774377d6ce226",
         "name": "M4A1 Space Trooper",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -808,12 +809,12 @@
                 "id": "56ea7165d2720b6e518b4583",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a327f4a86f774766866140b": {
         "id": "5a327f4a86f774766866140b",
         "name": "AKMS",
+        "default": true,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
             {
@@ -852,12 +853,12 @@
                 "id": "5a0060fc86f7745793204432",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a3b898486f77467720a2f29": {
         "id": "5a3b898486f77467720a2f29",
         "name": "SLock PVS-14",
+        "default": false,
         "baseId": "5a16bb52fcdbcb001a3b00dc",
         "parts": [
             {
@@ -876,12 +877,12 @@
                 "id": "57235b6f24597759bf5a30f1",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "584149ad2459775a7726350e": {
         "id": "584149ad2459775a7726350e",
         "name": "PP-9 Klin",
+        "default": true,
         "baseId": "57f4c844245977379d5c14d1",
         "parts": [
             {
@@ -896,12 +897,12 @@
                 "id": "57d1519e24597714373db79d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "58dffc5d86f77407c744a847": {
         "id": "58dffc5d86f77407c744a847",
         "name": "DVL-10",
+        "default": true,
         "baseId": "588892092459774ac91d4b11",
         "parts": [
             {
@@ -932,12 +933,12 @@
                 "id": "58889d0c2459775bc215d981",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a8ae43686f774377b73cfb3": {
         "id": "5a8ae43686f774377b73cfb3",
         "name": "MPX MQB",
+        "default": false,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
             {
@@ -1008,12 +1009,12 @@
                 "id": "58949edd86f77409483e16a9",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "59ef24b986f77439987b8762": {
         "id": "59ef24b986f77439987b8762",
         "name": "VPO-136",
+        "default": true,
         "baseId": "59e6152586f77473dc057aa1",
         "parts": [
             {
@@ -1052,12 +1053,12 @@
                 "id": "59d625f086f774661516605d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5af08bfd86f774223d4528e2": {
         "id": "5af08bfd86f774223d4528e2",
         "name": "M1A EBR",
+        "default": false,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
             {
@@ -1096,12 +1097,12 @@
                 "id": "5abcbb20d8ce87001773e258",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a327f6386f77479010da870": {
         "id": "5a327f6386f77479010da870",
         "name": "SR-1MP",
+        "default": true,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
             {
@@ -1112,12 +1113,12 @@
                 "id": "59f99a7d86f7745b134aa97b",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1dba86f7743e667da897": {
         "id": "5c0c1dba86f7743e667da897",
         "name": "M700 AAC SD",
+        "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -1152,12 +1153,12 @@
                 "id": "5a37cb10c4a282329a73b4e7",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "58414967245977598f1ad391": {
         "id": "58414967245977598f1ad391",
         "name": "PM",
+        "default": true,
         "baseId": "5448bd6b4bdc2dfc2f8b4569",
         "parts": [
             {
@@ -1168,12 +1169,12 @@
                 "id": "5448c12b4bdc2d02308b456f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ac4abf986f7747d117c67aa": {
         "id": "5ac4abf986f7747d117c67aa",
         "name": "AKS-74N",
+        "default": true,
         "baseId": "5ab8e9fcd8ce870019439434",
         "parts": [
             {
@@ -1212,12 +1213,12 @@
                 "id": "564ca99c4bdc2d16268b4589",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "59dcdbb386f77417b03f350d": {
         "id": "59dcdbb386f77417b03f350d",
         "name": "OP-SKS",
+        "default": true,
         "baseId": "587e02ff24597743df3deaeb",
         "parts": [
             {
@@ -1240,12 +1241,12 @@
                 "id": "587e08ee245977446b4410cf",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a88aed086f77476cd391963": {
         "id": "5a88aed086f77476cd391963",
         "name": "GLOCK17 Fischer",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -1284,12 +1285,12 @@
                 "id": "5a7b483fe899ef0016170d15",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c0c202e86f77448687e0368": {
         "id": "5c0c202e86f77448687e0368",
         "name": "Mosin Obrez",
+        "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
             {
@@ -1312,12 +1313,12 @@
                 "id": "5bfd4c980db834001b73449d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "584149ea2459775a6c55e940": {
         "id": "584149ea2459775a6c55e940",
         "name": "PP-91-01 Kedr-B",
+        "default": true,
         "baseId": "57f3c6bd24597738e730fa2f",
         "parts": [
             {
@@ -1340,12 +1341,12 @@
                 "id": "57d1519e24597714373db79d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1fc586f77455912eaf08": {
         "id": "5c0c1fc586f77455912eaf08",
         "name": "Mosin Inf. Obrez",
+        "default": false,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
             {
@@ -1364,12 +1365,12 @@
                 "id": "5bfd4cc90db834001d23e846",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ba3a3dfd4351e0032020190": {
         "id": "5ba3a3dfd4351e0032020190",
         "name": "AKM (AKMP)",
+        "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
             {
@@ -1416,12 +1417,12 @@
                 "id": "5a0f096dfcdbcb0176308b15",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ba3a4d1d4351e4502010622": {
         "id": "5ba3a4d1d4351e4502010622",
         "name": "AKMN (AKMN2 6P1N2)",
+        "default": false,
         "baseId": "5a0ec13bfcdbcb00165aa685",
         "parts": [
             {
@@ -1468,12 +1469,12 @@
                 "id": "5ba36f85d4351e0085325c81",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "584148f2245977598f1ad387": {
         "id": "584148f2245977598f1ad387",
         "name": "MP-133",
+        "default": true,
         "baseId": "54491c4f4bdc2db1078b4568",
         "parts": [
             {
@@ -1496,12 +1497,12 @@
                 "id": "56083cba4bdc2de22e8b456f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "58dffca786f774083a256ab1": {
         "id": "58dffca786f774083a256ab1",
         "name": "MPX",
+        "default": true,
         "baseId": "58948c8e86f77409493f7266",
         "parts": [
             {
@@ -1556,12 +1557,12 @@
                 "id": "58949edd86f77409483e16a9",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c208886f7743e5335d279": {
         "id": "5c0c208886f7743e5335d279",
         "name": "Mosin Obrez M",
+        "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
             {
@@ -1584,12 +1585,12 @@
                 "id": "5bbdb811d4351e45020113c7",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5bdb3ac186f77405f232ad22": {
         "id": "5bdb3ac186f77405f232ad22",
         "name": "MP7A2",
+        "default": true,
         "baseId": "5bd70322209c4d00d7167b8f",
         "parts": [
             {
@@ -1616,12 +1617,12 @@
                 "id": "5bd704e7209c4d00d7167c31",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a8ae54786f7743b5e013ba0": {
         "id": "5a8ae54786f7743b5e013ba0",
         "name": "MP-133 Tactical",
+        "default": false,
         "baseId": "54491c4f4bdc2db1078b4568",
         "parts": [
             {
@@ -1672,12 +1673,12 @@
                 "id": "5a32aa8bc4a2826c6e06d737",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a8ae73886f7747b2e6e1416": {
         "id": "5a8ae73886f7747b2e6e1416",
         "name": "M4A1 SOPMOD II",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -1756,12 +1757,12 @@
                 "id": "55d44fd14bdc2d962f8b456e",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "58414a052459775a2b6d9f1e": {
         "id": "58414a052459775a2b6d9f1e",
         "name": "Saiga 12ga v.10",
+        "default": true,
         "baseId": "576165642459773c7a400233",
         "parts": [
             {
@@ -1796,12 +1797,12 @@
                 "id": "57616a9e2459773c7a400234",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5af08cf886f774223c269184": {
         "id": "5af08cf886f774223c269184",
         "name": "M4A1",
+        "default": true,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -1852,12 +1853,12 @@
                 "id": "55d44fd14bdc2d962f8b456e",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a43a85186f7746c914b947a": {
         "id": "5a43a85186f7746c914b947a",
         "name": "AKS-74UN Zenit",
+        "default": false,
         "baseId": "583990e32459771419544dd2",
         "parts": [
             {
@@ -1924,12 +1925,12 @@
                 "id": "57fd23e32459772d0805bcf1",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "58dffce486f77409f40f8162": {
         "id": "58dffce486f77409f40f8162",
         "name": "SKS",
+        "default": true,
         "baseId": "574d967124597745970e7c94",
         "parts": [
             {
@@ -1948,12 +1949,12 @@
                 "id": "587df3a12459772c28142567",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5b44abe986f774283e2e3512": {
         "id": "5b44abe986f774283e2e3512",
         "name": "TT Gold",
+        "default": true,
         "baseId": "5b3b713c5acfc4330140bd8d",
         "parts": [
             {
@@ -1972,12 +1973,12 @@
                 "id": "571a29dc2459771fb2755a6a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "584149242459775a7726350a": {
         "id": "584149242459775a7726350a",
         "name": "P226R",
+        "default": true,
         "baseId": "56d59856d2720bd8418b456a",
         "parts": [
             {
@@ -2008,12 +2009,12 @@
                 "id": "56d59948d2720bb7418b4582",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a88b0f686f77416370eca3e": {
         "id": "5a88b0f686f77416370eca3e",
         "name": "GLOCK17 Hex",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -2044,12 +2045,12 @@
                 "id": "56def37dd2720bec348b456a",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a3a85af86f774745637d46c": {
         "id": "5a3a85af86f774745637d46c",
         "name": "RSASS",
+        "default": true,
         "baseId": "5a367e5dc4a282000e49738f",
         "parts": [
             {
@@ -2092,12 +2093,12 @@
                 "id": "5a34fbadc4a28200741e230a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0d1ec986f77439512a1a72": {
         "id": "5c0d1ec986f77439512a1a72",
         "name": "RPK-16",
+        "default": true,
         "baseId": "5beed0f50db834001c062b12",
         "parts": [
             {
@@ -2144,12 +2145,12 @@
                 "id": "5beec3420db834001b095429",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ba3a449d4351e0034778243": {
         "id": "5ba3a449d4351e0034778243",
         "name": "AKMS (AKMSP)",
+        "default": false,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
             {
@@ -2196,12 +2197,12 @@
                 "id": "5a0f096dfcdbcb0176308b15",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5bd05f1186f774572f181678": {
         "id": "5bd05f1186f774572f181678",
         "name": "MP7A1 SEALS",
+        "default": false,
         "baseId": "5ba26383d4351e00334c93d9",
         "parts": [
             {
@@ -2248,12 +2249,12 @@
                 "id": "5bcf0213d4351e0085327c17",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "584149c42459775a77263510": {
         "id": "584149c42459775a77263510",
         "name": "PP-91 Kedr",
+        "default": true,
         "baseId": "57d14d2524597714373db789",
         "parts": [
             {
@@ -2268,12 +2269,12 @@
                 "id": "57d1519e24597714373db79d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0d1e9386f77440120288b7": {
         "id": "5c0d1e9386f77440120288b7",
         "name": "HK 416A5",
+        "default": true,
         "baseId": "5bb2475ed4351e00853264e3",
         "parts": [
             {
@@ -2324,12 +2325,12 @@
                 "id": "5bb20dbcd4351e44f824c04e",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "58414a16245977599247970a": {
         "id": "58414a16245977599247970a",
         "name": "SV-98",
+        "default": true,
         "baseId": "55801eed4bdc2d89578b4588",
         "parts": [
             {
@@ -2356,12 +2357,12 @@
                 "id": "56ea8222d2720b69698b4567",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "584147732459775a2b6d9f12": {
         "id": "584147732459775a2b6d9f12",
         "name": "AKS-74U",
+        "default": true,
         "baseId": "57dc2fa62459775949412633",
         "parts": [
             {
@@ -2400,12 +2401,12 @@
                 "id": "57dc32dc245977596d4ef3d3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a8c436686f7740f394d10b5": {
         "id": "5a8c436686f7740f394d10b5",
         "name": "GLOCK17 Tac HC",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -2444,12 +2445,12 @@
                 "id": "5a7b483fe899ef0016170d15",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5acf7e4c86f774499a3f3bdd": {
         "id": "5acf7e4c86f774499a3f3bdd",
         "name": "AK-104",
+        "default": true,
         "baseId": "5ac66d725acfc43b321d4b60",
         "parts": [
             {
@@ -2488,12 +2489,12 @@
                 "id": "5ac66bea5acfc43b321d4aec",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5b439b5686f77428bd137424": {
         "id": "5b439b5686f77428bd137424",
         "name": "SA-58",
+        "default": true,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
             {
@@ -2544,12 +2545,12 @@
                 "id": "58d2912286f7744e27117493",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "59e8d2ab86f77407f03fc9c2": {
         "id": "59e8d2ab86f77407f03fc9c2",
         "name": "AKM",
+        "default": true,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
             {
@@ -2588,12 +2589,12 @@
                 "id": "59d625f086f774661516605d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5b83f23a86f7746d3d190a73": {
         "id": "5b83f23a86f7746d3d190a73",
         "name": "SA-58 BEL",
+        "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
             {
@@ -2632,12 +2633,12 @@
                 "id": "5b7d63cf5acfc4001876c8df",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5bbf1c5a88a45017bb03d7aa": {
         "id": "5bbf1c5a88a45017bb03d7aa",
         "name": "M4A1 LVOA",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -2692,12 +2693,12 @@
                 "id": "5b2240bf5acfc40dc528af69",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a88ad7b86f77479aa7226af": {
         "id": "5a88ad7b86f77479aa7226af",
         "name": "GLOCK17 Tac 3",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -2736,12 +2737,12 @@
                 "id": "5a7b483fe899ef0016170d15",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5acf7e7986f774401e19c3a0": {
         "id": "5acf7e7986f774401e19c3a0",
         "name": "AK-105",
+        "default": true,
         "baseId": "5ac66d9b5acfc4001633997a",
         "parts": [
             {
@@ -2780,12 +2781,12 @@
                 "id": "55d480c04bdc2d1d4e8b456a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1e7486f7744dba7a289b": {
         "id": "5c0c1e7486f7744dba7a289b",
         "name": "Mosin Infantry",
+        "default": true,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
             {
@@ -2812,12 +2813,12 @@
                 "id": "5ae099925acfc4001a5fc7b3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "584147ed2459775a77263501": {
         "id": "584147ed2459775a77263501",
         "name": "AKS-74UN",
+        "default": true,
         "baseId": "583990e32459771419544dd2",
         "parts": [
             {
@@ -2856,12 +2857,12 @@
                 "id": "57dc32dc245977596d4ef3d3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5af08cc686f77424a61595f2": {
         "id": "5af08cc686f77424a61595f2",
         "name": "M4A1 SOPMOD I",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -2912,12 +2913,12 @@
                 "id": "55d44fd14bdc2d962f8b456e",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c0c1f2b86f77455912eaefc": {
         "id": "5c0c1f2b86f77455912eaefc",
         "name": "Mosin Carbine",
+        "default": false,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
             {
@@ -2956,12 +2957,12 @@
                 "id": "5b3f7c1c5acfc40dc5296b1d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "584148a524597759eb357a44": {
         "id": "584148a524597759eb357a44",
         "name": "MP-443 \"Grach\"",
+        "default": true,
         "baseId": "576a581d2459771e7b1bc4f1",
         "parts": [
             {
@@ -2976,12 +2977,12 @@
                 "id": "576a63cd2459771e796e0e11",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a13df5286f774032f5454a0": {
         "id": "5a13df5286f774032f5454a0",
         "name": "Saiga-9",
+        "default": true,
         "baseId": "59f9cabd86f7743a10721f46",
         "parts": [
             {
@@ -3020,12 +3021,12 @@
                 "id": "5648b1504bdc2d9d488b4584",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a3a859786f7747e2305e8bf": {
         "id": "5a3a859786f7747e2305e8bf",
         "name": "TOZ-106",
+        "default": true,
         "baseId": "5a38e6bac4a2826c6e06d79b",
         "parts": [
             {
@@ -3044,12 +3045,12 @@
                 "id": "5a38eecdc4a282329a73b512",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a88acfb86f77457fd2c0d8f": {
         "id": "5a88acfb86f77457fd2c0d8f",
         "name": "Glock 17",
+        "default": true,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -3076,12 +3077,12 @@
                 "id": "5a718b548dc32e000d46d262",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a325c3686f7744273716c5b": {
         "id": "5a325c3686f7744273716c5b",
         "name": "AKMN",
+        "default": true,
         "baseId": "5a0ec13bfcdbcb00165aa685",
         "parts": [
             {
@@ -3120,12 +3121,12 @@
                 "id": "5a01c29586f77474660c694c",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "584149452459775992479702": {
         "id": "584149452459775992479702",
         "name": "PB",
+        "default": true,
         "baseId": "56e0598dd2720bb5668b45a6",
         "parts": [
             {
@@ -3144,12 +3145,12 @@
                 "id": "56e05a6ed2720bd0748b4567",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ba3a53dd4351e3bac12056e": {
         "id": "5ba3a53dd4351e3bac12056e",
         "name": "AKMSN (AKMSN2 6P4N2)",
+        "default": false,
         "baseId": "5abcbc27d8ce8700182eceeb",
         "parts": [
             {
@@ -3196,12 +3197,12 @@
                 "id": "5ba36f85d4351e0085325c81",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a88afdc86f7746de12fcc20": {
         "id": "5a88afdc86f7746de12fcc20",
         "name": "GLOCK17 Alpha Wolf",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -3224,12 +3225,12 @@
                 "id": "5a718b548dc32e000d46d262",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5b8683a486f77467f2423114": {
         "id": "5b8683a486f77467f2423114",
         "name": "Mosin",
+        "default": true,
         "baseId": "5ae08f0a5acfc408fb1398a1",
         "parts": [
             {
@@ -3256,12 +3257,12 @@
                 "id": "5ae099925acfc4001a5fc7b3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1d6586f7743e5335d264": {
         "id": "5c0c1d6586f7743e5335d264",
         "name": "M700",
+        "default": true,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -3280,12 +3281,12 @@
                 "id": "5bfebc320db8340019668d79",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ba3a078d4351e00334c96ca": {
         "id": "5ba3a078d4351e00334c96ca",
         "name": "AKM (AKMB)",
+        "default": false,
         "baseId": "59d6088586f774275f37482f",
         "parts": [
             {
@@ -3324,12 +3325,12 @@
                 "id": "59d625f086f774661516605d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "58414a2724597759b344da4d": {
         "id": "58414a2724597759b344da4d",
         "name": "TT",
+        "default": true,
         "baseId": "571a12c42459771f627b58a0",
         "parts": [
             {
@@ -3348,12 +3349,12 @@
                 "id": "571a29dc2459771fb2755a6a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a88af5086f77411a871682c": {
         "id": "5a88af5086f77411a871682c",
         "name": "GLOCK17 Tac 2",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -3388,12 +3389,12 @@
                 "id": "577d141e24597739c5255e01",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c0c1ce886f77401c119d014": {
         "id": "5c0c1ce886f77401c119d014",
         "name": "AK-74",
+        "default": true,
         "baseId": "5bf3e03b0db834001d2c4a9c",
         "parts": [
             {
@@ -3432,12 +3433,12 @@
                 "id": "564ca99c4bdc2d16268b4589",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a327f7286f7747668661419": {
         "id": "5a327f7286f7747668661419",
         "name": "SR-1MP Tactical 1",
+        "default": false,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
             {
@@ -3460,12 +3461,12 @@
                 "id": "59f99a7d86f7745b134aa97b",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ac4ad7586f7747d14551da3": {
         "id": "5ac4ad7586f7747d14551da3",
         "name": "M870 12ga",
+        "default": true,
         "baseId": "5a7828548dc32e5a9c28b516",
         "parts": [
             {
@@ -3488,12 +3489,12 @@
                 "id": "5a7880d0c5856700142fdd9d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5af08d1c86f774223a7aa1b4": {
         "id": "5af08d1c86f774223a7aa1b4",
         "name": "M870 Breacher",
+        "default": false,
         "baseId": "5a7828548dc32e5a9c28b516",
         "parts": [
             {
@@ -3540,12 +3541,12 @@
                 "id": "584924ec24597768f12ae244",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5b83f22086f77464e15a1d5f": {
         "id": "5b83f22086f77464e15a1d5f",
         "name": "SA-58 AUS",
+        "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
             {
@@ -3584,12 +3585,12 @@
                 "id": "5b7d645e5acfc400170e2f90",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c10fcb186f774533e5529ab": {
         "id": "5c10fcb186f774533e5529ab",
         "name": "ADAR 2-15",
+        "default": true,
         "baseId": "5c07c60e0db834002330051f",
         "parts": [
             {
@@ -3632,12 +3633,12 @@
                 "id": "5c0faf68d174af02a96260b8",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5a88b1f686f774159949926e": {
         "id": "5a88b1f686f774159949926e",
         "name": "GLOCK17 Spartan",
+        "default": false,
         "baseId": "5a7ae0c351dfba0017554310",
         "parts": [
             {
@@ -3672,12 +3673,12 @@
                 "id": "5a718b548dc32e000d46d262",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "59411aa786f7747aeb37f9a5": {
         "id": "59411aa786f7747aeb37f9a5",
         "name": "MP5",
+        "default": true,
         "baseId": "5926bb2186f7744b1c6c6e60",
         "parts": [
             {
@@ -3716,12 +3717,12 @@
                 "id": "5926c32286f774616e42de99",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5acf7db286f7743a9c7092e3": {
         "id": "5acf7db286f7743a9c7092e3",
         "name": "AK-74M",
+        "default": true,
         "baseId": "5ac4cd105acfc40016339859",
         "parts": [
             {
@@ -3760,12 +3761,12 @@
                 "id": "55d480c04bdc2d1d4e8b456a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5acf7e2b86f7740874790e20": {
         "id": "5acf7e2b86f7740874790e20",
         "name": "AK-103",
+        "default": true,
         "baseId": "5ac66d2e5acfc43b321d4b53",
         "parts": [
             {
@@ -3804,12 +3805,12 @@
                 "id": "5ac66bea5acfc43b321d4aec",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5af08c4486f774223b094223": {
         "id": "5af08c4486f774223b094223",
         "name": "M1A SASS",
+        "default": false,
         "baseId": "5aafa857e5b5b00018480968",
         "parts": [
             {
@@ -3844,12 +3845,12 @@
                 "id": "5addbbb25acfc40015621bd9",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5a327f7c86f77475187e509a": {
         "id": "5a327f7c86f77475187e509a",
         "name": "SR-1MP Tactical 2",
+        "default": false,
         "baseId": "59f98b4986f7746f546d2cef",
         "parts": [
             {
@@ -3872,12 +3873,12 @@
                 "id": "59f99a7d86f7745b134aa97b",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5841474424597759ba49be91": {
         "id": "5841474424597759ba49be91",
         "name": "AK-74N",
+        "default": true,
         "baseId": "5644bd2b4bdc2d3b4c8b4572",
         "parts": [
             {
@@ -3920,12 +3921,12 @@
                 "id": "56dfef82d2720bbd668b4567",
                 "quantity": 30
             }
-        ],
-        "default": true
+        ]
     },
     "58414a3f2459775a77263531": {
         "id": "58414a3f2459775a77263531",
         "name": "VSS Vintorez",
+        "default": true,
         "baseId": "57838ad32459774a17445cd2",
         "parts": [
             {
@@ -3952,12 +3953,12 @@
                 "id": "578395e82459774a0e553c7b",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5acf7dfc86f774401e19c390": {
         "id": "5acf7dfc86f774401e19c390",
         "name": "AK-102",
+        "default": true,
         "baseId": "5ac66d015acfc400180ae6e4",
         "parts": [
             {
@@ -3996,12 +3997,12 @@
                 "id": "5ac66c5d5acfc4001718d314",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5acf7dd986f774486e1281bf": {
         "id": "5acf7dd986f774486e1281bf",
         "name": "AK-101",
+        "default": true,
         "baseId": "5ac66cb05acfc40198510a10",
         "parts": [
             {
@@ -4040,12 +4041,12 @@
                 "id": "5ac66c5d5acfc4001718d314",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "584147982459775a6c55e931": {
         "id": "584147982459775a6c55e931",
         "name": "AKS-74UB",
+        "default": true,
         "baseId": "5839a40f24597726f856b511",
         "parts": [
             {
@@ -4084,12 +4085,12 @@
                 "id": "57dc32dc245977596d4ef3d3",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5bd056fa86f7743aba7658cd": {
         "id": "5bd056fa86f7743aba7658cd",
         "name": "MP7A1",
+        "default": true,
         "baseId": "5ba26383d4351e00334c93d9",
         "parts": [
             {
@@ -4116,12 +4117,12 @@
                 "id": "5bcf0213d4351e0085327c17",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1d2b86f77401c119d01f": {
         "id": "5c0c1d2b86f77401c119d01f",
         "name": "AKS-74",
+        "default": true,
         "baseId": "5bf3e0490db83400196199af",
         "parts": [
             {
@@ -4160,12 +4161,12 @@
                 "id": "564ca99c4bdc2d16268b4589",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ac4ab8886f7747d0f66429a": {
         "id": "5ac4ab8886f7747d0f66429a",
         "name": "AKMSN",
+        "default": true,
         "baseId": "5abcbc27d8ce8700182eceeb",
         "parts": [
             {
@@ -4204,12 +4205,12 @@
                 "id": "5a0060fc86f7745793204432",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "58414907245977598f1ad38d": {
         "id": "58414907245977598f1ad38d",
         "name": "MP-153",
+        "default": true,
         "baseId": "56dee2bdd2720bc8328b4567",
         "parts": [
             {
@@ -4232,12 +4233,12 @@
                 "id": "56083be64bdc2d20478b456f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ac4accf86f774181345c3d7": {
         "id": "5ac4accf86f774181345c3d7",
         "name": "APS",
+        "default": true,
         "baseId": "5a17f98cfcdbcb0980087290",
         "parts": [
             {
@@ -4260,12 +4261,12 @@
                 "id": "5aba637ad8ce87001773e17f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5bbf1c1c88a45017144d28c5": {
         "id": "5bbf1c1c88a45017144d28c5",
         "name": "AK-74M Zenitco",
+        "default": false,
         "baseId": "5ac4cd105acfc40016339859",
         "parts": [
             {
@@ -4308,12 +4309,12 @@
                 "id": "5648ac824bdc2ded0b8b457d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5b83f29886f7746d956305a1": {
         "id": "5b83f29886f7746d956305a1",
         "name": "SA-58 PBR",
+        "default": false,
         "baseId": "5b0bbe4e5acfc40dc528a72d",
         "parts": [
             {
@@ -4368,12 +4369,12 @@
                 "id": "5b7d63b75acfc400170e2f8a",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ba3a14cd4351e003202017f": {
         "id": "5ba3a14cd4351e003202017f",
         "name": "AKMS (AKMSB 6P4M)",
+        "default": false,
         "baseId": "59ff346386f77477562ff5e2",
         "parts": [
             {
@@ -4412,12 +4413,12 @@
                 "id": "5a0060fc86f7745793204432",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c98be1e86f7741cc96ffd79": {
         "id": "5c98be1e86f7741cc96ffd79",
         "name": "SVDS",
+        "default": true,
         "baseId": "5c46fbd72e2216398b5a8c9c",
         "parts": [
             {
@@ -4468,12 +4469,12 @@
                 "id": "5c471bd12e221602b4129c3a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c0c1dff86f7744dba7a2892": {
         "id": "5c0c1dff86f7744dba7a2892",
         "name": "Mosin Inf. Carbine",
+        "default": false,
         "baseId": "5bfd297f0db834001a669119",
         "parts": [
             {
@@ -4500,12 +4501,12 @@
                 "id": "5bfd4c980db834001b73449d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5c98bd7386f7740cfb15654e": {
         "id": "5c98bd7386f7740cfb15654e",
         "name": "MDR",
+        "default": true,
         "baseId": "5c488a752e221602b412af63",
         "parts": [
             {
@@ -4532,12 +4533,12 @@
                 "id": "5c48a2a42e221602b66d1e07",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d3f0bc986f7743cb332abdc": {
         "id": "5d3f0bc986f7743cb332abdc",
         "name": "M9A3",
+        "default": true,
         "baseId": "5cadc190ae921500103bb3b6",
         "parts": [
             {
@@ -4572,12 +4573,12 @@
                 "id": "5cadc2e0ae9215051e1c21e7",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d23467086f77443f37fc602": {
         "id": "5d23467086f77443f37fc602",
         "name": "ASh-12",
+        "default": true,
         "baseId": "5cadfbf7ae92152ac412eeef",
         "parts": [
             {
@@ -4608,12 +4609,12 @@
                 "id": "5caf1691ae92152ac412efb9",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5c98bf9186f7740cf708c509": {
         "id": "5c98bf9186f7740cf708c509",
         "name": "Vepr Hunter",
+        "default": true,
         "baseId": "5c501a4d2e221602b412b540",
         "parts": [
             {
@@ -4640,12 +4641,12 @@
                 "id": "5c503ac82e221602b21d6e9a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d2340e986f77461496241bc": {
         "id": "5d2340e986f77461496241bc",
         "name": "P90 CWDG",
+        "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
             {
@@ -4696,12 +4697,12 @@
                 "id": "5cc6ea78e4a949000e1ea3c1",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d23404b86f7740d62079098": {
         "id": "5d23404b86f7740d62079098",
         "name": "P90 SBR",
+        "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
             {
@@ -4740,12 +4741,12 @@
                 "id": "5cc6ea78e4a949000e1ea3c1",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d3f06c886f7743bb5318c6a": {
         "id": "5d3f06c886f7743bb5318c6a",
         "name": "MP5K-N",
+        "default": true,
         "baseId": "5d2f0d8048f0356c925bc3b0",
         "parts": [
             {
@@ -4776,12 +4777,12 @@
                 "id": "5d2f2d5748f03572ec0c0139",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d51290186f77419093e7c24": {
         "id": "5d51290186f77419093e7c24",
         "name": "FN 5-7",
+        "default": true,
         "baseId": "5d3eb3b0a4b93615055e84d2",
         "parts": [
             {
@@ -4808,12 +4809,12 @@
                 "id": "5d3eb5eca4b9363b1f22f8e4",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d38517786f7742a1468cf6a": {
         "id": "5d38517786f7742a1468cf6a",
         "name": "M700 MRS",
+        "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -4864,12 +4865,12 @@
                 "id": "5cde7b43d7f00c000d36b93e",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d383e1a86f7742a1468ce63": {
         "id": "5d383e1a86f7742a1468ce63",
         "name": "M700 AICS",
+        "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -4896,12 +4897,12 @@
                 "id": "5d270b3c8abbc3105335cfb8",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d23424c86f7740d5e50ce65": {
         "id": "5d23424c86f7740d5e50ce65",
         "name": "P90 SBRT",
+        "default": false,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
             {
@@ -4932,12 +4933,12 @@
                 "id": "5cc6ea85e4a949000e1ea3c3",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d7b845786f7743c1e531da7": {
         "id": "5d7b845786f7743c1e531da7",
         "name": "FN 5-7 FDE",
+        "default": true,
         "baseId": "5d67abc1a4b93614ec50137f",
         "parts": [
             {
@@ -4964,12 +4965,12 @@
                 "id": "5d3eb5eca4b9363b1f22f8e4",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d4d617f86f77449c463d107": {
         "id": "5d4d617f86f77449c463d107",
         "name": "TX-15 DML",
+        "default": true,
         "baseId": "5d43021ca4b9362eab4b5e25",
         "parts": [
             {
@@ -5028,12 +5029,12 @@
                 "id": "5d44334ba4b9362b346d1948",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5e03511086f7744ccb1fb6cf": {
         "id": "5e03511086f7744ccb1fb6cf",
         "name": "SR-25",
+        "default": true,
         "baseId": "5df8ce05b11454561e39243b",
         "parts": [
             {
@@ -5088,12 +5089,12 @@
                 "id": "5df8e053bb49d91fb446d6a6",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5e0340ab86f7745bb7339235": {
         "id": "5e0340ab86f7745bb7339235",
         "name": "MP9",
+        "default": true,
         "baseId": "5e00903ae9dc277128008b87",
         "parts": [
             {
@@ -5124,12 +5125,12 @@
                 "id": "5de8fbf2b74cd90030650c79",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d23376786f77459bb77d838": {
         "id": "5d23376786f77459bb77d838",
         "name": "P90",
+        "default": true,
         "baseId": "5cc82d76e24e8d00134b4b83",
         "parts": [
             {
@@ -5172,12 +5173,12 @@
                 "id": "5cc6ea78e4a949000e1ea3c1",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5d383f5d86f7742a15793872": {
         "id": "5d383f5d86f7742a15793872",
         "name": "M700 PRO",
+        "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -5216,12 +5217,12 @@
                 "id": "5d270b3c8abbc3105335cfb8",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5d383ee786f7742a15793860": {
         "id": "5d383ee786f7742a15793860",
         "name": "M700 ARCH",
+        "default": false,
         "baseId": "5bfea6e90db834001b7347f3",
         "parts": [
             {
@@ -5244,12 +5245,12 @@
                 "id": "5d270b3c8abbc3105335cfb8",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5dd800bde492226366631317": {
         "id": "5dd800bde492226366631317",
         "name": "AK-104 T-SAW",
+        "default": false,
         "baseId": "5ac66d725acfc43b321d4b60",
         "parts": [
             {
@@ -5316,12 +5317,12 @@
                 "id": "5648ac824bdc2ded0b8b457d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5e03410186f77469041348ea": {
         "id": "5e03410186f77469041348ea",
         "name": "MP9-N",
+        "default": true,
         "baseId": "5de7bd7bfd6b4e6e2276dc25",
         "parts": [
             {
@@ -5356,12 +5357,12 @@
                 "id": "5de922d4b11454561e39239f",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5e0354f786f77425b53eb6c5": {
         "id": "5e0354f786f77425b53eb6c5",
         "name": "T-5000M",
+        "default": true,
         "baseId": "5df24cf80dee1b22f862e9bc",
         "parts": [
             {
@@ -5412,12 +5413,12 @@
                 "id": "5df35e970b92095fd441e4d2",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5e035eb586f774756048ec12": {
         "id": "5e035eb586f774756048ec12",
         "name": "MDR",
+        "default": true,
         "baseId": "5dcbd56fdbd3d91b3e5468d5",
         "parts": [
             {
@@ -5444,12 +5445,12 @@
                 "id": "5dcbe965e4ed22586443a79d",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5dd800eae49222636663133b": {
         "id": "5dd800eae49222636663133b",
         "name": "M4A1 SAI",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -5524,12 +5525,12 @@
                 "id": "5d44334ba4b9362b346d1948",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5e0359bd86f7746b243db876": {
         "id": "5e0359bd86f7746b243db876",
         "name": "VPO-215",
+        "default": true,
         "baseId": "5de652c31b7e3716273428be",
         "parts": [
             {
@@ -5556,12 +5557,12 @@
                 "id": "5de6558e9f98ac2bc65950fc",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5dd8013ff4c3af18c507b10a": {
         "id": "5dd8013ff4c3af18c507b10a",
         "name": "TX-15 DML D-WARRIOR",
+        "default": false,
         "baseId": "5d43021ca4b9362eab4b5e25",
         "parts": [
             {
@@ -5624,12 +5625,12 @@
                 "id": "5bb20dbcd4351e44f824c04e",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ddbbeac582ed30a6134e577": {
         "id": "5ddbbeac582ed30a6134e577",
         "name": "Saiga 12ga v.10 NERFGUN",
+        "default": false,
         "baseId": "576165642459773c7a400233",
         "parts": [
             {
@@ -5700,12 +5701,12 @@
                 "id": "5d6e68c4a4b9361b93413f79",
                 "quantity": 10
             }
-        ],
-        "default": false
+        ]
     },
     "5dd7f8c524e5d7504a4e3077": {
         "id": "5dd7f8c524e5d7504a4e3077",
         "name": "AK-74 Plum",
+        "default": false,
         "baseId": "5bf3e03b0db834001d2c4a9c",
         "parts": [
             {
@@ -5744,12 +5745,12 @@
                 "id": "5cbdaf89ae9215000e5b9c94",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5eb2968186f7746d1f1a4fd5": {
         "id": "5eb2968186f7746d1f1a4fd5",
         "name": "M1911A1",
+        "default": true,
         "baseId": "5e81c3cbac2bb513793cdc75",
         "parts": [
             {
@@ -5792,12 +5793,12 @@
                 "id": "5e81c539cb2b95385c177553",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5eb2963686f7742d3f5ab0f8": {
         "id": "5eb2963686f7742d3f5ab0f8",
         "name": "PPSh-41",
+        "default": true,
         "baseId": "5ea03f7400685063ec28bfa8",
         "parts": [
             {
@@ -5820,12 +5821,12 @@
                 "id": "5ea02bb600685063ec28bfa1",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5ebbfe23ba87a5065a00a563": {
         "id": "5ebbfe23ba87a5065a00a563",
         "name": "M4A1 USASOC-I",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -5900,12 +5901,12 @@
                 "id": "5ea16d4d5aad6446a939753d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5ebbff0841a637322117a5fb": {
         "id": "5ebbff0841a637322117a5fb",
         "name": "M4A1 USASOC-II",
+        "default": false,
         "baseId": "5447a9cd4bdc2dbd208b4567",
         "parts": [
             {
@@ -5972,12 +5973,12 @@
                 "id": "5ea16d4d5aad6446a939753d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5f676b779ab5ec19f028eaf3": {
         "id": "5f676b779ab5ec19f028eaf3",
         "name": "RFB",
+        "default": true,
         "baseId": "5f2a9575926fd9352339381f",
         "parts": [
             {
@@ -6008,12 +6009,12 @@
                 "id": "5f2aa49f9b44de6b1b4e68d4",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5f6771214ef1ca4f4e1b8a06": {
         "id": "5f6771214ef1ca4f4e1b8a06",
         "name": "KS-23M",
+        "default": true,
         "baseId": "5e848cc2988a8701445df1e8",
         "parts": [
             {
@@ -6036,12 +6037,12 @@
                 "id": "5e848db4681bea2ada00daa9",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5f6770f839a13e712a1dff54": {
         "id": "5f6770f839a13e712a1dff54",
         "name": "KS-23M Drozd",
+        "default": false,
         "baseId": "5e848cc2988a8701445df1e8",
         "parts": [
             {
@@ -6068,12 +6069,12 @@
                 "id": "5e848dc4e4dbc5266a4ec63d",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "5f06d6e1475d472556679d16": {
         "id": "5f06d6e1475d472556679d16",
         "name": "FN40GL",
+        "default": true,
         "baseId": "5e81ebcd8e146c7080625e15",
         "parts": [
             {
@@ -6084,12 +6085,12 @@
                 "id": "571659bb2459771fb2755a12",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5f06d6bb4010601e3232cd22": {
         "id": "5f06d6bb4010601e3232cd22",
         "name": "590A1",
+        "default": true,
         "baseId": "5e870397991fd70db46995c8",
         "parts": [
             {
@@ -6120,12 +6121,12 @@
                 "id": "5e87114fe2db31558c75a120",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5f6762e964af6a2aa319deeb": {
         "id": "5f6762e964af6a2aa319deeb",
         "name": "M45A1",
+        "default": true,
         "baseId": "5f36a0e5fbf956000b716b65",
         "parts": [
             {
@@ -6168,12 +6169,12 @@
                 "id": "5f3e777688ca2d00ad199d25",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5fd25119dd870108a754a163": {
         "id": "5fd25119dd870108a754a163",
         "name": "Mk-18",
+        "default": true,
         "baseId": "5fc22d7c187fea44d52eda44",
         "parts": [
             {
@@ -6216,12 +6217,12 @@
                 "id": "5fc235db2770a0045c59c683",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5fd251a31189a17bcc172662": {
         "id": "5fd251a31189a17bcc172662",
         "name": "SIG MCX .300 BLK",
+        "default": true,
         "baseId": "5fbcc1d9016cce60e8341ab3",
         "parts": [
             {
@@ -6276,12 +6277,12 @@
                 "id": "5fbcc640016cce60e8341acc",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "5fd251c90d9c95034825edb5": {
         "id": "5fd251c90d9c95034825edb5",
         "name": "Vector 9x19",
+        "default": true,
         "baseId": "5fc3f2d5900b1d5091531e57",
         "parts": [
             {
@@ -6320,12 +6321,12 @@
                 "id": "5fce0f9b55375d18a253eff2",
                 "quantity": 2
             }
-        ],
-        "default": true
+        ]
     },
     "5fd2517dbdd50d684f73a474": {
         "id": "5fd2517dbdd50d684f73a474",
         "name": "UMP 45",
+        "default": true,
         "baseId": "5fc3e272f8b6a877a729eac5",
         "parts": [
             {
@@ -6352,12 +6353,12 @@
                 "id": "5fc5396e900b1d5091531e72",
                 "quantity": 2
             }
-        ],
-        "default": true
+        ]
     },
     "5fd251ee16cac650092f5d02": {
         "id": "5fd251ee16cac650092f5d02",
         "name": "Vector .45ACP",
+        "default": true,
         "baseId": "5fb64bc92b1b027b1f50bcf2",
         "parts": [
             {
@@ -6396,12 +6397,12 @@
                 "id": "5fce0f9b55375d18a253eff2",
                 "quantity": 2
             }
-        ],
-        "default": true
+        ]
     },
     "60479c3f420fac5ebc199f86": {
         "id": "60479c3f420fac5ebc199f86",
         "name": "STM-9",
+        "default": true,
         "baseId": "60339954d62c9b14ed777c06",
         "parts": [
             {
@@ -6448,12 +6449,12 @@
                 "id": "602e620f9b513876d4338d9a",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "60479fb29c15b12b9a480fb0": {
         "id": "60479fb29c15b12b9a480fb0",
         "name": "PL-15",
+        "default": true,
         "baseId": "602a9740da11d6478d5a06dc",
         "parts": [
             {
@@ -6480,12 +6481,12 @@
                 "id": "602286df23506e50807090c6",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "60b7c28ee53e4c5c8945dd73": {
         "id": "60b7c28ee53e4c5c8945dd73",
         "name": "MP-155",
+        "default": true,
         "baseId": "606dae0ab0e443224b421bb7",
         "parts": [
             {
@@ -6508,12 +6509,12 @@
                 "id": "607d5a891246154cad35d6aa",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "60b7c2bd95047637182d90a4": {
         "id": "60b7c2bd95047637182d90a4",
         "name": "MP-155 Ultima",
+        "default": false,
         "baseId": "606dae0ab0e443224b421bb7",
         "parts": [
             {
@@ -6552,12 +6553,12 @@
                 "id": "60785ce5132d4d12c81fd918",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "60b7d76e2a3c79100f1979de": {
         "id": "60b7d76e2a3c79100f1979de",
         "name": "Mk47",
+        "default": true,
         "baseId": "606587252535c57a13424cfd",
         "parts": [
             {
@@ -6612,12 +6613,12 @@
                 "id": "606587bd6d0bd7580617bacc",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6197d1f3585c515a052ad88f": {
         "id": "6197d1f3585c515a052ad88f",
         "name": "MP-43",
+        "default": true,
         "baseId": "5580223e4bdc2d1c128b457f",
         "parts": [
             {
@@ -6632,12 +6633,12 @@
                 "id": "611a31ce5b7ffe001b4649d1",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e4fae693542ea37d11c6": {
         "id": "6193e4fae693542ea37d11c6",
         "name": "Mk 17 (FDE)",
+        "default": true,
         "baseId": "6165ac306ef05c2ce828ef74",
         "parts": [
             {
@@ -6696,12 +6697,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e590069d61205d490dd8": {
         "id": "6193e590069d61205d490dd8",
         "name": "G28",
+        "default": true,
         "baseId": "6176aca650224f204c1da3fb",
         "parts": [
             {
@@ -6780,12 +6781,12 @@
                 "id": "61702d8a67085e45ef140b24",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e4a46bb904059c382295": {
         "id": "6193e4a46bb904059c382295",
         "name": "Mk 17",
+        "default": true,
         "baseId": "6183afd850224f204c1da514",
         "parts": [
             {
@@ -6848,12 +6849,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e18de693542ea37d11b3": {
         "id": "6193e18de693542ea37d11b3",
         "name": "Mk 16",
+        "default": true,
         "baseId": "6184055050224f204c1da540",
         "parts": [
             {
@@ -6916,12 +6917,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e226449ec003d9127fa6": {
         "id": "6193e226449ec003d9127fa6",
         "name": "Mk 16 (FDE)",
+        "default": true,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
             {
@@ -6984,12 +6985,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "6193e108c1982475fa2a7f16": {
         "id": "6193e108c1982475fa2a7f16",
         "name": "Mk 16 (FDE) CQC",
+        "default": false,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
             {
@@ -7052,12 +7053,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "619e61e70459e93c12392ba7": {
         "id": "619e61e70459e93c12392ba7",
         "name": "Mk 16 (FDE) CW",
+        "default": false,
         "baseId": "618428466ef05c2ce828f218",
         "parts": [
             {
@@ -7136,12 +7137,12 @@
                 "id": "6181688c6c780c1e710c9b04",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "619d267f36b5be1f3236f9ba": {
         "id": "619d267f36b5be1f3236f9ba",
         "name": "USP .45",
+        "default": true,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
             {
@@ -7180,12 +7181,12 @@
                 "id": "6193d5d4f8ee7e52e4210a1b",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     },
     "619d26ccc7791e3af27ae3cd": {
         "id": "619d26ccc7791e3af27ae3cd",
         "name": "USP .45 Match",
+        "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
             {
@@ -7228,12 +7229,12 @@
                 "id": "619624b26db0f2477964e6b0",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "619d270836b5be1f3236f9c5": {
         "id": "619d270836b5be1f3236f9c5",
         "name": "USP .45 Tactical",
+        "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
             {
@@ -7288,12 +7289,12 @@
                 "id": "",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "619d272b0f9e4513744e7699": {
         "id": "619d272b0f9e4513744e7699",
         "name": "USP .45 Elite",
+        "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
             {
@@ -7336,12 +7337,12 @@
                 "id": "619621a4de3cdf1d2614a7a7",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "619d276ca4712949ff3159b9": {
         "id": "619d276ca4712949ff3159b9",
         "name": "USP .45 Expert",
+        "default": false,
         "baseId": "6193a720f8ee7e52e42109ed",
         "parts": [
             {
@@ -7380,12 +7381,12 @@
                 "id": "6193d5d4f8ee7e52e4210a1b",
                 "quantity": 1
             }
-        ],
-        "default": false
+        ]
     },
     "6198e2ddef80673cae5d1c87": {
         "id": "6198e2ddef80673cae5d1c87",
         "name": "MTs-255-12",
+        "default": true,
         "baseId": "60db29ce99594040e04c4a27",
         "parts": [
             {
@@ -7412,7 +7413,6 @@
                 "id": "6123649463849f3d843da7c4",
                 "quantity": 1
             }
-        ],
-        "default": true
+        ]
     }
 }


### PR DESCRIPTION
The appendName attribute indicates if the preset changes the item name. If an appendName value is present, the item name becomes the base item's name (or short name, depending on context) plus a space and the appendName value. This allows accurately matching the item names of presets. The "name" attribute now exists mostly to make the preset recognizable in the file.

Also relocated the "default" attribute from after the parts list to before to improve readability.