### PR TITLE
Hideout: Medstation L2 - added medical tools requirement

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -1198,6 +1198,12 @@
                     "id": 198
                 },
                 {
+                    "type": "item",
+                    "name": "619cc01e0a7c3a1a2731940c",
+                    "quantity": 3,
+                    "id": 314
+                },
+                {
                     "type": "trader",
                     "name": 1,
                     "quantity": 2,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46737902/146657810-33d5fe47-b831-423a-819e-5f8e40c24e0c.png)

They added requirement for three medical tools for Medstation level 2.