### PR TITLE
Fix: Add 'Missing Cargo' quest requirement

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -12380,7 +12380,9 @@
         "id": 237,
         "require": {
             "level": null,
-            "quests": []
+            "quests": [
+                229
+            ]
         },
         "giver": 2,
         "turnin": 2,


### PR DESCRIPTION
Currently the 'Missing Cargo' quest does not have any requirements. The quest does have a requirement; finishing the 'Long Road' quest (see Wiki).

I can confirm this as I have not unlocked the quest ingame, but do have it showing on the  TarkovTracker website.

See https://escapefromtarkov.fandom.com/wiki/Missing_Cargo

![image](https://user-images.githubusercontent.com/14212955/149938289-975264db-b850-4daf-824e-6398a60aab3d.png)


