### PR TITLE
Update "Living High is Not a Crime" wiki URLs

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -7184,7 +7184,7 @@
             "ru": "Красиво жить не запретишь",
             "cs": "Žít blaze, není zločin - Část 1"
         },
-        "wiki": "https://escapefromtarkov.fandom.com/wiki/Living_high_is_not_a_crime_-_Part_1",
+        "wiki": "https://escapefromtarkov.fandom.com/wiki/Living_High_is_Not_a_Crime_-_Part_1",
         "exp": 19900,
         "nokappa": true,
         "unlocks": [],
@@ -7242,7 +7242,7 @@
             "ru": "Красиво жить не запретишь. Часть 2",
             "cs": "Žít blaze, není zločin - Část 2"
         },
-        "wiki": "https://escapefromtarkov.fandom.com/wiki/Living_high_is_not_a_crime_-_Part_2",
+        "wiki": "https://escapefromtarkov.fandom.com/wiki/Living_High_is_Not_a_Crime_-_Part_2",
         "exp": 25900,
         "unlocks": [
             "5d5d87f786f77427997cfaef"


### PR DESCRIPTION
Some casing changed and they didn't create a redirect page

Old:
* https://escapefromtarkov.fandom.com/wiki/Living_high_is_not_a_crime_-_Part_1
* https://escapefromtarkov.fandom.com/wiki/Living_high_is_not_a_crime_-_Part_2

New:
* https://escapefromtarkov.fandom.com/wiki/Living_High_is_Not_a_Crime_-_Part_1
* https://escapefromtarkov.fandom.com/wiki/Living_High_is_Not_a_Crime_-_Part_2