### PR TITLE
Update "Lost Contact" and "Energy Crisis"

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -11739,8 +11739,8 @@
       "level": null,
       "quests": [29]
     },
-    "giver": 0,
-    "turnin": 0,
+    "giver": 1,
+    "turnin": 1,
     "title": "Lost Contact",
     "locales": {
       "en": "Lost Contact"
@@ -11768,7 +11768,7 @@
   {
     "id": 242,
     "require": {
-      "level": null,
+      "level": 25,
       "quests": []
     },
     "giver": 4,


### PR DESCRIPTION
Lost Contact is a Therapist quest, was added as a Prapor.
Added level requirement to "Energy Crisis".