### PR TITLE
Update location for The Huntsman path - Outcasts

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -11608,7 +11608,7 @@
         "type": "kill",
         "target": "Rogues",
         "number": 10,
-        "location": -1,
+        "location": 7,
         "id": 487
       }
     ],


### PR DESCRIPTION
The only location for Rogues is Lighthouse, so the location for the quest should be lighthouse.