### PR TITLE
fix: Update tarkov shooter - part 1 dependent quest.

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -7213,7 +7213,7 @@
     "id": 143,
     "require": {
       "level": 17,
-      "quests": [86]
+      "quests": [136]
     },
     "giver": 6,
     "turnin": 6,


### PR DESCRIPTION
Updates the dependent quest based on wiki changes. 

Relevant wiki diff: https://escapefromtarkov.fandom.com/wiki/The_Tarkov_Shooter_-_Part_1?diff=cur&oldid=197464