### PR TITLE
Update Workbench LVL 2 requirements

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -2423,6 +2423,12 @@
                     "id": 265
                 },
                 {
+                    "type": "item",
+                    "name": "62a0a0bb621468534a797ad5",
+                    "quantity": 1,
+                    "id": 326
+                },
+                {
                     "type": "trader",
                     "name": 4,
                     "quantity": 2,


### PR DESCRIPTION
Workbench level 2 now additionally needs Set of files "Master"

In-game screenshot:
![image](https://user-images.githubusercontent.com/9197590/179353473-7fc95f1a-83e7-472c-9b9e-ce191c54bb93.png)

Current Tarkov Tracker output:
![image](https://user-images.githubusercontent.com/9197590/179353483-74962d0e-9f3a-4f8f-a9d9-3217606d3106.png)

I take it you assign IDs to items in sequential order as they are added to the file in question. Given I found no other mention of the BSG UID relevant for the Set of files "Master" item, I incremented it to 326 from the highest number available previously. 