### PR TITLE
Update Illumnation Level 2 requirements

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -736,7 +736,7 @@
                 {
                     "type": "item",
                     "name": "5c06779c86f77426e00dd782",
-                    "quantity": 5,
+                    "quantity": 10,
                     "id": 54
                 }
             ],


### PR DESCRIPTION
[Recreating PR, old one is closed.]

It is the case that Illumination Level 2 now needs 10 wires, instead of 5. The appropriate value has been updated.

Tarkov Dev Data
![Illumination LVL 2 on Tarkov.dev](https://user-images.githubusercontent.com/9197590/178929750-d4055889-d4ef-4316-a89d-535306c65ca6.png)

In-Game Requirement
![Illumination LVL 2 Actual Requirements](https://user-images.githubusercontent.com/9197590/178930079-1c9fadf9-3721-4d62-b4e3-15ff6fd46d8a.png)

