### PR TITLE
Update quest requirements for "No place for renegades"

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -10544,7 +10544,7 @@
     "id": 210,
     "require": {
       "level": 10,
-      "quests": [192]
+      "quests": [6, 192]
     },
     "giver": 0,
     "turnin": 0,


### PR DESCRIPTION
The quest "No place for renegades" requires "Ice cream cones" (ID 6)