### PR TITLE
Added missing quest requirement for "Living high is not a crime - Part 2"

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -6784,7 +6784,7 @@
     "id": 133,
     "require": {
       "level": 27,
-      "quests": [131]
+      "quests": [131, 132]
     },
     "giver": 5,
     "turnin": 5,


### PR DESCRIPTION
Part 1 of the quest check must be completed for Part 2 to start

![image](https://user-images.githubusercontent.com/21007593/180039589-7d009a34-40fd-4a85-9eb7-c36ff7b4f83c.png)
