### PR TITLE
Update sewing kit amount for Lavatory level 2

### DIFF
--- a/hideout.json
+++ b/hideout.json
@@ -1054,7 +1054,7 @@
                 {
                     "type": "item",
                     "name": "61bf83814088ec1a363d7097",
-                    "quantity": 1,
+                    "quantity": 2,
                     "id": 318
                 }
             ],


### PR DESCRIPTION
Update sewing kits required for upgrading Lavatory from 1 to 2, from 1 to 2.
<details><summary>Screenshots</summary>

![chrome_IdHv28qITA](https://user-images.githubusercontent.com/31581159/180663974-13e9d70c-848d-469b-bce5-c31e49ebfb51.png)
![EscapeFromTarkov_BtEs3iuBOl](https://user-images.githubusercontent.com/31581159/180663975-96fd7d0f-1574-40cb-a1f6-7b4a6b834cc2.png)
</details>