### PR TITLE
Updated level requirement for No Place for Renegades

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -10560,7 +10560,7 @@
   {
     "id": 210,
     "require": {
-      "level": 10,
+      "level": 12,
       "quests": [6, 192]
     },
     "giver": 0,

--- a/quests.json
+++ b/quests.json
@@ -10565,13 +10565,15 @@
     },
     "giver": 0,
     "turnin": 0,
-    "title": "No place for renegades",
+    "title": "No Place for Renegades",
     "locales": {
-      "en": "No place for renegades",
+      "en": "No Place for Renegades",
       "ru": "Ренегатам тут не место",
-      "cs": "Pro odpadlíky tu není místo"
+      "cs": "Pro odpadlíky tu není místo",
+      "fr": "Pas de place pour les renégats",
+      "de": "Kein Platz für Deserteure"
     },
-    "wiki": "https://escapefromtarkov.fandom.com/wiki/No_place_for_renegades",
+    "wiki": "https://escapefromtarkov.fandom.com/wiki/No_Place_for_Renegades",
     "exp": 8500,
     "unlocks": [],
     "reputation": [


### PR DESCRIPTION
As described in https://github.com/TarkovTracker/TarkovTracker/issues/290 filed in the wrong project. Confirmed by wiki.

The quest requirement was already covered by #276 

Also updated some capitalization, and brought some more locales along. Are those still used or worth updating? Can't see these languages in use anywhere else in the quests.json yet.