### PR TITLE
Fix "Wounded beast" locked behind wrong quest

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -7074,7 +7074,7 @@
     "id": 139,
     "require": {
       "level": 10,
-      "quests": [138]
+      "quests": [137]
     },
     "giver": 6,
     "turnin": 6,


### PR DESCRIPTION
The Survivalist Path - Wounded Beast is actually unlocked by completing The Survivalist Path - Thrifty.
Updated quest ID to match the correct quest