### PR TITLE
Re-Adding the double Brackets on quest.json

### DIFF
--- a/quests.json
+++ b/quests.json
@@ -9915,7 +9915,7 @@
     "id": 199,
     "require": {
       "level": 11,
-      "quests": [43, 179]
+      "quests": [[43, 179]]
     },
     "giver": 0,
     "turnin": 0,
@@ -9950,7 +9950,7 @@
     "id": 200,
     "require": {
       "level": 11,
-      "quests": [43, 180]
+      "quests": [[43, 180]]
     },
     "giver": 1,
     "turnin": 1,
@@ -10006,7 +10006,7 @@
     "id": 201,
     "require": {
       "level": 11,
-      "quests": [179, 180]
+      "quests": [[179, 180]]
     },
     "giver": 2,
     "turnin": 2,


### PR DESCRIPTION
Re-Adding the double Brackets which got removed on commiting Pull Request #294 (commit: d2545cd9a703322f3ed25c0aa99d7b4c269c83a6). Looks like these double brackets were in place for the tracker to recognize those quest as "either or". At the moment two quests for example out of curiosity (quest id 179) and Big Customer (quest id 180) which are exclusive to each other needs to be done at the same time resulting in a dead end. The tracker doesn't show you Loyality Buyout (quest id 201) which should come available after completing 179 OR 180 not both.